### PR TITLE
fix: format code samples with existing prettier rules, minor markdown fixes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "endOfLine": "auto",
-  "proseWrap": "always"
+  "proseWrap": "preserve"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "endOfLine": "auto",
-  "proseWrap": "preserve"
+  "proseWrap": "always"
 }

--- a/developers/courses/solana-course/content/anchor-cpi.md
+++ b/developers/courses/solana-course/content/anchor-cpi.md
@@ -2,42 +2,61 @@
 title: Anchor CPIs and Errors
 objectives:
   - Make Cross Program Invocations (CPIs) from an Anchor program
-  - Use the `cpi` feature to generate helper functions for invoking instructions on existing Anchor programs
-  - Use `invoke` and `invoke_signed` to make CPIs where CPI helper functions are unavailable
+  - Use the `cpi` feature to generate helper functions for invoking instructions
+    on existing Anchor programs
+  - Use `invoke` and `invoke_signed` to make CPIs where CPI helper functions are
+    unavailable
   - Create and return custom Anchor errors
 ---
 
 # TL;DR
 
 - Anchor provides a simplified way to create CPIs using a **`CpiContext`**
-- Anchor's **`cpi`** feature generates CPI helper functions for invoking instructions on existing Anchor programs
-- If you do not have access to CPI helper functions, you can still use `invoke` and `invoke_signed` directly
+- Anchor's **`cpi`** feature generates CPI helper functions for invoking
+  instructions on existing Anchor programs
+- If you do not have access to CPI helper functions, you can still use `invoke`
+  and `invoke_signed` directly
 - The **`error_code`** attribute macro is used to create custom Anchor Errors
 
 # Overview
 
-If you think back to the [first CPI lesson](cpi.md), you'll remember that constructing CPIs can get tricky with vanilla Rust. Anchor makes it a bit simpler though, especially if the program you're invoking is also an Anchor program whose crate you can access.
+If you think back to the [first CPI lesson](cpi.md), you'll remember that
+constructing CPIs can get tricky with vanilla Rust. Anchor makes it a bit
+simpler though, especially if the program you're invoking is also an Anchor
+program whose crate you can access.
 
-In this lesson, you'll learn how to construct an Anchor CPI. You'll also learn how to throw custom errors from an Anchor program so that you can start to write more sophisticated Anchor programs.
+In this lesson, you'll learn how to construct an Anchor CPI. You'll also learn
+how to throw custom errors from an Anchor program so that you can start to write
+more sophisticated Anchor programs.
 
 ## Cross Program Invocations (CPIs) with Anchor
 
-As a refresher, CPIs allow programs to invoke instructions on other programs using the `invoke` or `invoke_signed` functions. This allows new programs to build on top of existing programs (we call that composability).
+As a refresher, CPIs allow programs to invoke instructions on other programs
+using the `invoke` or `invoke_signed` functions. This allows new programs to
+build on top of existing programs (we call that composability).
 
-While making CPIs directly using `invoke` or `invoke_signed` is still an option, Anchor also provides a simplified way to make CPIs by using a `CpiContext`.
+While making CPIs directly using `invoke` or `invoke_signed` is still an option,
+Anchor also provides a simplified way to make CPIs by using a `CpiContext`.
 
-In this lesson, you'll use the `anchor_spl` crate to make CPIs to the SPL Token Program. You can explore what's available in the `anchor_spl` crate [here](https://docs.rs/anchor-spl/latest/anchor_spl/#).
+In this lesson, you'll use the `anchor_spl` crate to make CPIs to the SPL Token
+Program. You can explore what's available in the `anchor_spl` crate
+[here](https://docs.rs/anchor-spl/latest/anchor_spl/#).
 
 ### `CpiContext`
 
-The first step in making a CPI is to create an instance of `CpiContext`. `CpiContext` is very similar to `Context`, the first argument type required by Anchor instruction functions. They are both declared in the same module and share similar functionality.
+The first step in making a CPI is to create an instance of `CpiContext`.
+`CpiContext` is very similar to `Context`, the first argument type required by
+Anchor instruction functions. They are both declared in the same module and
+share similar functionality.
 
-The `CpiContext` type specifies non-argument inputs for cross program invocations:
+The `CpiContext` type specifies non-argument inputs for cross program
+invocations:
 
 - `accounts` - the list of accounts required for the instruction being invoked
 - `remaining_accounts` - any remaining accounts
 - `program` - the program ID of the program being invoked
-- `signer_seeds` - if a PDA is signing, include the seeds required to derived the PDA
+- `signer_seeds` - if a PDA is signing, include the seeds required to derived
+  the PDA
 
 ```rust
 pub struct CpiContext<'a, 'b, 'c, 'info, T>
@@ -51,7 +70,8 @@ where
 }
 ```
 
-You use `CpiContext::new` to construct a new instance when passing along the original transaction signature.
+You use `CpiContext::new` to construct a new instance when passing along the
+original transaction signature.
 
 ```rust
 CpiContext::new(cpi_program, cpi_accounts)
@@ -71,7 +91,8 @@ pub fn new(
 }
 ```
 
-You use `CpiContext::new_with_signer` to construct a new instance when signing on behalf of a PDA for the CPI.
+You use `CpiContext::new_with_signer` to construct a new instance when signing
+on behalf of a PDA for the CPI.
 
 ```rust
 CpiContext::new_with_signer(cpi_program, cpi_accounts, seeds)
@@ -94,28 +115,42 @@ pub fn new_with_signer(
 
 ### CPI accounts
 
-One of the main things about `CpiContext` that simplifies cross-program invocations is that the `accounts` argument is a generic type that lets you pass in any object that adopts the `ToAccountMetas` and `ToAccountInfos<'info>` traits.
+One of the main things about `CpiContext` that simplifies cross-program
+invocations is that the `accounts` argument is a generic type that lets you pass
+in any object that adopts the `ToAccountMetas` and `ToAccountInfos<'info>`
+traits.
 
-These traits are added by the `#[derive(Accounts)]` attribute macro that you've used before when creating structs to represent instruction accounts. That means you can use similar structs with `CpiContext`.
+These traits are added by the `#[derive(Accounts)]` attribute macro that you've
+used before when creating structs to represent instruction accounts. That means
+you can use similar structs with `CpiContext`.
 
 This helps with code organization and type safety.
 
 ### Invoke an instruction on another Anchor program
 
-When the program you're calling is an Anchor program with a published crate, Anchor can generate instruction builders and CPI helper functions for you.
+When the program you're calling is an Anchor program with a published crate,
+Anchor can generate instruction builders and CPI helper functions for you.
 
-Simply declare your program's dependency on the program you're calling in your program's `Cargo.toml` file as follows:
+Simply declare your program's dependency on the program you're calling in your
+program's `Cargo.toml` file as follows:
 
 ```
 [dependencies]
 callee = { path = "../callee", features = ["cpi"]}
 ```
 
-By adding `features = ["cpi"]`, you enable the `cpi` feature and your program gains access to the `callee::cpi` module.
+By adding `features = ["cpi"]`, you enable the `cpi` feature and your program
+gains access to the `callee::cpi` module.
 
-The `cpi` module exposes `callee`'s instructions as a Rust function that takes as arguments a `CpiContext` and any additional instruction data. These functions use the same format as the instruction functions in your Anchor programs, only with `CpiContext` instead of `Context`. The `cpi` module also exposes the accounts structs required for calling the instructions.
+The `cpi` module exposes `callee`'s instructions as a Rust function that takes
+as arguments a `CpiContext` and any additional instruction data. These functions
+use the same format as the instruction functions in your Anchor programs, only
+with `CpiContext` instead of `Context`. The `cpi` module also exposes the
+accounts structs required for calling the instructions.
 
-For example, if `callee` has the instruction `do_something` that requires the accounts defined in the `DoSomething` struct, you could invoke `do_something` as follows:
+For example, if `callee` has the instruction `do_something` that requires the
+accounts defined in the `DoSomething` struct, you could invoke `do_something` as
+follows:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -143,9 +178,17 @@ pub mod lootbox_program {
 
 ### Invoke an instruction on a non-Anchor program
 
-When the program you're calling is _not_ an Anchor program, there are two possible options:
+When the program you're calling is _not_ an Anchor program, there are two
+possible options:
 
-1. It's possible that the program maintainers have published a crate with their own helper functions for calling into their program. For example, the `anchor_spl` crate provides helper functions that are virtually identical from a call-site perspective to what you would get with the `cpi` module of an Anchor program. E.g. you can mint using the [`mint_to` helper function](https://docs.rs/anchor-spl/latest/src/anchor_spl/token.rs.html#36-58) and use the [`MintTo` accounts struct](https://docs.rs/anchor-spl/latest/anchor_spl/token/struct.MintTo.html).
+1. It's possible that the program maintainers have published a crate with their
+   own helper functions for calling into their program. For example, the
+   `anchor_spl` crate provides helper functions that are virtually identical
+   from a call-site perspective to what you would get with the `cpi` module of
+   an Anchor program. E.g. you can mint using the
+   [`mint_to` helper function](https://docs.rs/anchor-spl/latest/src/anchor_spl/token.rs.html#36-58)
+   and use the
+   [`MintTo` accounts struct](https://docs.rs/anchor-spl/latest/anchor_spl/token/struct.MintTo.html).
    ```rust
    token::mint_to(
        CpiContext::new_with_signer(
@@ -163,7 +206,12 @@ When the program you're calling is _not_ an Anchor program, there are two possib
        amount,
    )?;
    ```
-2. If there is no helper module for the program whose instruction(s) you need to invoke, you can fall back to using `invoke` and `invoke_signed`. In fact, the source code of the `mint_to` helper function referenced above shows an example us using `invoke_signed` when given a `CpiContext`. You can follow a similar pattern if you decide to use an accounts struct and `CpiContext` to organize and prepare your CPI.
+2. If there is no helper module for the program whose instruction(s) you need to
+   invoke, you can fall back to using `invoke` and `invoke_signed`. In fact, the
+   source code of the `mint_to` helper function referenced above shows an
+   example us using `invoke_signed` when given a `CpiContext`. You can follow a
+   similar pattern if you decide to use an accounts struct and `CpiContext` to
+   organize and prepare your CPI.
    ```rust
    pub fn mint_to<'a, 'b, 'c, 'info>(
        ctx: CpiContext<'a, 'b, 'c, 'info, MintTo<'info>>,
@@ -192,9 +240,14 @@ When the program you're calling is _not_ an Anchor program, there are two possib
 
 ## Throw errors in Anchor
 
-We're deep enough into Anchor at this point that it's important to know how to create custom errors.
+We're deep enough into Anchor at this point that it's important to know how to
+create custom errors.
 
-Ultimately, all programs return the same error type: [`ProgramError`](https://docs.rs/solana-program/latest/solana_program/program_error/enum.ProgramError.html). However, when writing a program using Anchor you can use `AnchorError` as an abstraction on top of `ProgramError`. This abstraction provides additional information when a program fails, including:
+Ultimately, all programs return the same error
+type: [`ProgramError`](https://docs.rs/solana-program/latest/solana_program/program_error/enum.ProgramError.html).
+However, when writing a program using Anchor you can use `AnchorError` as an
+abstraction on top of `ProgramError`. This abstraction provides additional
+information when a program fails, including:
 
 - The error name and number
 - Location in the code where the error was thrown
@@ -215,7 +268,11 @@ Anchor Errors can be divided into:
 - Anchor Internal Errors that the framework returns from inside its own code
 - Custom errors that you the developer can create
 
-You can add errors unique to your program by using the `error_code` attribute. Simply add this attribute to a custom `enum` type. You can then use the variants of the `enum` as errors in your program. Additionally, you can add an error message to each variant using the `msg` attribute. Clients can then display this error message if the error occurs.
+You can add errors unique to your program by using the `error_code` attribute.
+Simply add this attribute to a custom `enum` type. You can then use the variants
+of the `enum` as errors in your program. Additionally, you can add an error
+message to each variant using the `msg` attribute. Clients can then display this
+error message if the error occurs.
 
 ```rust
 #[error_code]
@@ -225,7 +282,11 @@ pub enum MyError {
 }
 ```
 
-To return a custom error you can use the [err](https://docs.rs/anchor-lang/latest/anchor_lang/macro.err.html) or the [error](https://docs.rs/anchor-lang/latest/anchor_lang/prelude/macro.error.html) macro from an instruction function. These add file and line information to the error that is then logged by Anchor to help you with debugging.
+To return a custom error you can use
+the [err](https://docs.rs/anchor-lang/latest/anchor_lang/macro.err.html) or
+the [error](https://docs.rs/anchor-lang/latest/anchor_lang/prelude/macro.error.html)
+macro from an instruction function. These add file and line information to the
+error that is then logged by Anchor to help you with debugging.
 
 ```rust
 #[program]
@@ -247,7 +308,9 @@ pub enum MyError {
 }
 ```
 
-Alternatively, you can use the [require](https://docs.rs/anchor-lang/latest/anchor_lang/macro.require.html) macro to simplify returning errors. The code above can be refactored to the following:
+Alternatively, you can use
+the [require](https://docs.rs/anchor-lang/latest/anchor_lang/macro.require.html) macro
+to simplify returning errors. The code above can be refactored to the following:
 
 ```rust
 #[program]
@@ -269,17 +332,27 @@ pub enum MyError {
 
 # Demo
 
-Let’s practice the concepts we’ve gone over in this lesson by building on top of the Movie Review program from previous lessons.
+Let’s practice the concepts we’ve gone over in this lesson by building on top of
+the Movie Review program from previous lessons.
 
-In this demo we’ll update the program to mint tokens to users when they submit a new movie review.
+In this demo we’ll update the program to mint tokens to users when they submit a
+new movie review.
 
 ### 1. Starter
 
-To get started, we will be using the final state of the Anchor Movie Review program from the previous lesson. So, if you just completed that lesson then you’re all set and ready to go. If you are just jumping in here, no worries, you can download the starter code [here](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-pdas). We'll be using the `solution-pdas` branch as our starting point.
+To get started, we will be using the final state of the Anchor Movie Review
+program from the previous lesson. So, if you just completed that lesson then
+you’re all set and ready to go. If you are just jumping in here, no worries, you
+can download the starter code
+[here](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-pdas).
+We'll be using the `solution-pdas` branch as our starting point.
 
 ### 2. Add dependencies to `Cargo.toml`
 
-Before we get started we need enable the `init-if-needed` feature and add the `anchor-spl` crate to the dependencies in `Cargo.toml`. If you need to brush up on the `init-if-needed` feature take a look at the [Anchor PDAs and Accounts lesson](anchor-pdas.md).
+Before we get started we need enable the `init-if-needed` feature and add the
+`anchor-spl` crate to the dependencies in `Cargo.toml`. If you need to brush up
+on the `init-if-needed` feature take a look at the
+[Anchor PDAs and Accounts lesson](anchor-pdas.md).
 
 ```rust
 [dependencies]
@@ -289,7 +362,10 @@ anchor-spl = "0.25.0"
 
 ### 3. Initialize reward token
 
-Next, navigate to `lib.rs` and create an instruction to initialize a new token mint. This will be the token that is minted each time a user leaves a review. Note that we don't need to include any custom instruction logic since the initialization can be handled entirely through Anchor constraints.
+Next, navigate to `lib.rs` and create an instruction to initialize a new token
+mint. This will be the token that is minted each time a user leaves a review.
+Note that we don't need to include any custom instruction logic since the
+initialization can be handled entirely through Anchor constraints.
 
 ```rust
 pub fn initialize_token_mint(_ctx: Context<InitializeMint>) -> Result<()> {
@@ -298,9 +374,14 @@ pub fn initialize_token_mint(_ctx: Context<InitializeMint>) -> Result<()> {
 }
 ```
 
-Now, implement the `InitializeMint` context type and list the accounts and constraints the instruction requires. Here we initialize a new `Mint` account using a PDA with the string "mint" as a seed. Note that we can use the same PDA for both the address of the `Mint` account and the mint authority. Using a PDA as the mint authority enables our program to sign for the minting of the tokens.
+Now, implement the `InitializeMint` context type and list the accounts and
+constraints the instruction requires. Here we initialize a new `Mint` account
+using a PDA with the string "mint" as a seed. Note that we can use the same PDA
+for both the address of the `Mint` account and the mint authority. Using a PDA
+as the mint authority enables our program to sign for the minting of the tokens.
 
-In order to initialize the `Mint` account, we'll need to include the `token_program`, `rent`, and `system_program` in the list of accounts.
+In order to initialize the `Mint` account, we'll need to include the
+`token_program`, `rent`, and `system_program` in the list of accounts.
 
 ```rust
 #[derive(Accounts)]
@@ -322,11 +403,15 @@ pub struct InitializeMint<'info> {
 }
 ```
 
-There may be some constraints above that you haven't seen yet. Adding `mint::decimals` and `mint::authority` along with `init` ensures that the account is initialized as a new token mint with the appropriate decimals and mint authority set.
+There may be some constraints above that you haven't seen yet. Adding
+`mint::decimals` and `mint::authority` along with `init` ensures that the
+account is initialized as a new token mint with the appropriate decimals and
+mint authority set.
 
 ### 4. Anchor Error
 
-Next, let’s create an Anchor Error that we’ll use when validating the `rating` passed to either the `add_movie_review` or `update_movie_review` instruction.
+Next, let’s create an Anchor Error that we’ll use when validating the `rating`
+passed to either the `add_movie_review` or `update_movie_review` instruction.
 
 ```rust
 #[error_code]
@@ -338,15 +423,20 @@ enum MovieReviewError {
 
 ### 5. Update `add_movie_review` instruction
 
-Now that we've done some setup, let’s update the `add_movie_review` instruction and `AddMovieReview` context type to mint tokens to the reviewer.
+Now that we've done some setup, let’s update the `add_movie_review` instruction
+and `AddMovieReview` context type to mint tokens to the reviewer.
 
 Next, update the `AddMovieReview` context type to add the following accounts:
 
 - `token_program` - we'll be using the Token Program to mint tokens
-- `mint` - the mint account for the tokens that we'll mint to users when they add a movie review
-- `token_account` - the associated token account for the afforementioned `mint` and reviewer
-- `associated_token_program` - required because we'll be using the `associated_token` constraint on the `token_account`
-- `rent` - required because we are using the `init-if-needed` constraint on the `token_account`
+- `mint` - the mint account for the tokens that we'll mint to users when they
+  add a movie review
+- `token_account` - the associated token account for the afforementioned `mint`
+  and reviewer
+- `associated_token_program` - required because we'll be using the
+  `associated_token` constraint on the `token_account`
+- `rent` - required because we are using the `init-if-needed` constraint on the
+  `token_account`
 
 ```rust
 #[derive(Accounts)]
@@ -383,14 +473,25 @@ pub struct AddMovieReview<'info> {
 }
 ```
 
-Again, some of the above constraints may be unfamiliar to you. The `associated_token::mint` and `associated_token::authority` constraints along with the `init_if_needed` constraint ensures that if the account has not already been initialized, it will be initialized as an associated token account for the specified mint and authority.
+Again, some of the above constraints may be unfamiliar to you. The
+`associated_token::mint` and `associated_token::authority` constraints along
+with the `init_if_needed` constraint ensures that if the account has not already
+been initialized, it will be initialized as an associated token account for the
+specified mint and authority.
 
 Next, let’s update the `add_movie_review` instruction to do the following:
 
-- Check that `rating` is valid. If it is not a valid rating, return the `InvalidRating` error.
-- Make a CPI to the token program’s `mint_to` instruction using the mint authority PDA as a signer. Note that we'll mint 10 tokens to the user but need to adjust for the mint decimals by making it `10*10^6`.
+- Check that `rating` is valid. If it is not a valid rating, return the
+  `InvalidRating` error.
+- Make a CPI to the token program’s `mint_to` instruction using the mint
+  authority PDA as a signer. Note that we'll mint 10 tokens to the user but need
+  to adjust for the mint decimals by making it `10*10^6`.
 
-Fortunately, we can use the `anchor_spl` crate to access helper functions and types like `mint_to` and `MintTo` for constructing our CPI to the Token Program. `mint_to` takes a `CpiContext` and integer as arguments, where the integer represents the number of tokens to mint. `MintTo` can be used for the list of accounts that the mint instruction needs.
+Fortunately, we can use the `anchor_spl` crate to access helper functions and
+types like `mint_to` and `MintTo` for constructing our CPI to the Token Program.
+`mint_to` takes a `CpiContext` and integer as arguments, where the integer
+represents the number of tokens to mint. `MintTo` can be used for the list of
+accounts that the mint instruction needs.
 
 ```rust
 pub fn add_movie_review(ctx: Context<AddMovieReview>, title: String, description: String, rating: u8) -> Result<()> {
@@ -452,7 +553,8 @@ pub fn update_movie_review(ctx: Context<UpdateMovieReview>, title: String, descr
 
 ### 7. Test
 
-Those are all of the changes we need to make to the program! Now, let’s update our tests.
+Those are all of the changes we need to make to the program! Now, let’s update
+our tests.
 
 Start by making sure your imports nad `describe` function look like this:
 
@@ -498,11 +600,14 @@ it("Initializes the reward token", async () => {
 });
 ```
 
-Notice that we didn't have to add `.accounts` because they call be inferred, including the `mint` account (assuming you have seed inference enabled).
+Notice that we didn't have to add `.accounts` because they call be inferred,
+including the `mint` account (assuming you have seed inference enabled).
 
-Next, update the test for the `addMovieReview` instruction. The primary additions are:
+Next, update the test for the `addMovieReview` instruction. The primary
+additions are:
 
-1. To get the associated token address that needs to be passed into the instruction as an account that cannot be inferred
+1. To get the associated token address that needs to be passed into the
+   instruction as an account that cannot be inferred
 2. Check at the end of the test that the associated token account has 10 tokens
 
 ```ts
@@ -530,7 +635,8 @@ it("Movie review is added`", async () => {
 });
 ```
 
-After that, neither the test for `updateMovieReview` nor the test for `deleteMovieReview` need any changes.
+After that, neither the test for `updateMovieReview` nor the test for
+`deleteMovieReview` need any changes.
 
 At this point, run `anchor test` and you should see the following output
 
@@ -544,10 +650,20 @@ anchor-movie-review-program
   5 passing (2s)
 ```
 
-If you need more time with the concepts from this lesson or got stuck along the way, feel free to take a look at the [solution code](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-add-tokens). Note that the solution to this demo is on the `solution-add-tokens` branch.
+If you need more time with the concepts from this lesson or got stuck along the
+way, feel free to take a look at the
+[solution code](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-add-tokens).
+Note that the solution to this demo is on the `solution-add-tokens` branch.
 
 # Challenge
 
-To apply what you've learned about CPIs in this lesson, think about how you could incorporate them into the Student Intro program. You could do something similar to what we did in the demo here and add some functionality to mint tokens to users when they introduce themselves.
+To apply what you've learned about CPIs in this lesson, think about how you
+could incorporate them into the Student Intro program. You could do something
+similar to what we did in the demo here and add some functionality to mint
+tokens to users when they introduce themselves.
 
-Try to do this independently if you can! But if you get stuck, feel free to reference this [solution code](https://github.com/Unboxed-Software/anchor-student-intro-program/tree/cpi-challenge). Note that your code may look slightly different than the solution code depending on your implementation.
+Try to do this independently if you can! But if you get stuck, feel free to
+reference
+this [solution code](https://github.com/Unboxed-Software/anchor-student-intro-program/tree/cpi-challenge).
+Note that your code may look slightly different than the solution code depending
+on your implementation.

--- a/developers/courses/solana-course/content/anchor-pdas.md
+++ b/developers/courses/solana-course/content/anchor-pdas.md
@@ -1,10 +1,10 @@
 ---
 title: Anchor PDAs and Accounts
 objectives:
-- Use the `seeds` and `bump` constraints to work with PDA accounts in Anchor
-- Enable and use the `init_if_needed` constraint
-- Use the `realloc` constraint to reallocate space on an existing account
-- Use the `close` constraint to close an existing account
+  - Use the `seeds` and `bump` constraints to work with PDA accounts in Anchor
+  - Enable and use the `init_if_needed` constraint
+  - Use the `realloc` constraint to reallocate space on an existing account
+  - Use the `close` constraint to close an existing account
 ---
 
 # TL;DR
@@ -93,7 +93,7 @@ pub struct AccountType {
 
 When using `init` for non-PDA accounts, Anchor defaults to setting the owner of the initialized account to be the program currently executing the instruction.
 
-However, when using `init` in combination with `seeds` and `bump`, the owner *must* be the executing program. This is because initializing an account for the PDA requires a signature that only the executing program can provide. In other words, the signature verification for the initialization of the PDA account would fail if the program ID used to derive the PDA did not match the program ID of the executing program.
+However, when using `init` in combination with `seeds` and `bump`, the owner _must_ be the executing program. This is because initializing an account for the PDA requires a signature that only the executing program can provide. In other words, the signature verification for the initialization of the PDA account would fail if the program ID used to derive the PDA did not match the program ID of the executing program.
 
 When determining the value of `space` for an account initialized and owned by the executing Anchor program, remember that the first 8 bytes are reserved for the account discriminator. This is an 8-byte value that Anchor calculates and uses to identify the program account types. You can use this [reference](https://www.anchor-lang.com/docs/space) to calculate how much space you should allocate for an account.
 
@@ -234,6 +234,7 @@ pub struct AccountType {
 ```
 
 Notice that `realloc` is set to `8 + 4 + instruction_data.len()`. This breaks down as follows:
+
 - `8` is for the account discriminator
 - `4` is for the 4 bytes of space that BORSH uses to store the length of the string
 - `instruction_data.len()` is the length of the string itself
@@ -541,36 +542,36 @@ Here we:
 - Create placeholders for tests
 
 ```ts
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
-import { assert, expect } from "chai"
-import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { assert, expect } from "chai";
+import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program";
 
 describe("anchor-movie-review-program", () => {
   // Configure the client to use the local cluster.
-  const provider = anchor.AnchorProvider.env()
-  anchor.setProvider(provider)
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
 
   const program = anchor.workspace
-    .AnchorMovieReviewProgram as Program<AnchorMovieReviewProgram>
+    .AnchorMovieReviewProgram as Program<AnchorMovieReviewProgram>;
 
   const movie = {
     title: "Just a test movie",
     description: "Wow what a good movie it was real great",
     rating: 5,
-  }
+  };
 
   const [moviePda] = anchor.web3.PublicKey.findProgramAddressSync(
     [Buffer.from(movie.title), provider.wallet.publicKey.toBuffer()],
-    program.programId
-  )
+    program.programId,
+  );
 
-  it("Movie review is added`", async () => {})
+  it("Movie review is added`", async () => {});
 
-  it("Movie review is updated`", async () => {})
+  it("Movie review is updated`", async () => {});
 
-  it("Deletes a movie review", async () => {})
-})
+  it("Deletes a movie review", async () => {});
+});
 ```
 
 Next, let's create the first test for the `addMovieReview` instruction. Note that we don't explicitly add `.accounts`. This is because the `Wallet` from `AnchorProvider` is automatically included as a signer, Anchor can infer certain accounts like `SystemProgram`, and Anchor can also infer the `movieReview` PDA from the `title` instruction argument and the signer's public key.
@@ -582,43 +583,41 @@ it("Movie review is added`", async () => {
   // Add your test here.
   const tx = await program.methods
     .addMovieReview(movie.title, movie.description, movie.rating)
-    .rpc()
+    .rpc();
 
-  const account = await program.account.movieAccountState.fetch(moviePda)
-  expect(movie.title === account.title)
-  expect(movie.rating === account.rating)
-  expect(movie.description === account.description)
-  expect(account.reviewer === provider.wallet.publicKey)
-})
+  const account = await program.account.movieAccountState.fetch(moviePda);
+  expect(movie.title === account.title);
+  expect(movie.rating === account.rating);
+  expect(movie.description === account.description);
+  expect(account.reviewer === provider.wallet.publicKey);
+});
 ```
 
 Next, let's create the test for the `updateMovieReview` instruction following the same process as before.
 
 ```ts
 it("Movie review is updated`", async () => {
-  const newDescription = "Wow this is new"
-  const newRating = 4
+  const newDescription = "Wow this is new";
+  const newRating = 4;
 
   const tx = await program.methods
     .updateMovieReview(movie.title, newDescription, newRating)
-    .rpc()
+    .rpc();
 
-  const account = await program.account.movieAccountState.fetch(moviePda)
-  expect(movie.title === account.title)
-  expect(newRating === account.rating)
-  expect(newDescription === account.description)
-  expect(account.reviewer === provider.wallet.publicKey)
-})
+  const account = await program.account.movieAccountState.fetch(moviePda);
+  expect(movie.title === account.title);
+  expect(newRating === account.rating);
+  expect(newDescription === account.description);
+  expect(account.reviewer === provider.wallet.publicKey);
+});
 ```
 
 Next, create the test for the `deleteMovieReview` instruction
 
 ```ts
 it("Deletes a movie review", async () => {
-  const tx = await program.methods
-    .deleteMovieReview(movie.title)
-    .rpc()
-})
+  const tx = await program.methods.deleteMovieReview(movie.title).rpc();
+});
 ```
 
 Lastly, run `anchor test` and you should see the following output in the console.

--- a/developers/courses/solana-course/content/anchor-pdas.md
+++ b/developers/courses/solana-course/content/anchor-pdas.md
@@ -9,22 +9,37 @@ objectives:
 
 # TL;DR
 
-- The `seeds` and `bump` constraints are used to initialize and validate PDA accounts in Anchor
-- The `init_if_needed` constraint is used to conditionally initialize a new account
+- The `seeds` and `bump` constraints are used to initialize and validate PDA
+  accounts in Anchor
+- The `init_if_needed` constraint is used to conditionally initialize a new
+  account
 - The `realloc` constraint is used to reallocate space on an existing account
 - The `close` constraint is used to close an account and refund its rent
 
 # Overview
 
-In this lesson you'll learn how to work with PDAs, reallocate accounts, and close accounts in Anchor.
+In this lesson you'll learn how to work with PDAs, reallocate accounts, and
+close accounts in Anchor.
 
-Recall that Anchor programs separate instruction logic from account validation. Account validation primarily happens within structs that represent the list of accounts needed for a given instruction. Each field of the struct represents a different account, and you can customize the validation performed on the account using the `#[account(...)]` attribute macro.
+Recall that Anchor programs separate instruction logic from account validation.
+Account validation primarily happens within structs that represent the list of
+accounts needed for a given instruction. Each field of the struct represents a
+different account, and you can customize the validation performed on the account
+using the `#[account(...)]` attribute macro.
 
-In addition to using constraints for account validation, some constraints can handle repeatable tasks that would otherwise require a lot of boilerplate inside our instruction logic. This lesson will introduce the `seeds`, `bump`, `realloc`, and `close` constraints to help you initialize and validate PDAs, reallocate accounts, and close accounts.
+In addition to using constraints for account validation, some constraints can
+handle repeatable tasks that would otherwise require a lot of boilerplate inside
+our instruction logic. This lesson will introduce the `seeds`, `bump`,
+`realloc`, and `close` constraints to help you initialize and validate PDAs,
+reallocate accounts, and close accounts.
 
 ## PDAs with Anchor
 
-Recall that [PDAs](https://github.com/Unboxed-Software/solana-course/blob/main/content/pda.md) are derived using a list of optional seeds, a bump seed, and a program ID. Anchor provides a convenient way to validate a PDA with the `seeds` and `bump` constraints.
+Recall that
+[PDAs](https://github.com/Unboxed-Software/solana-course/blob/main/content/pda.md)
+are derived using a list of optional seeds, a bump seed, and a program ID.
+Anchor provides a convenient way to validate a PDA with the `seeds` and `bump`
+constraints.
 
 ```rust
 #[derive(Accounts)]
@@ -37,15 +52,24 @@ struct ExampleAccounts {
 }
 ```
 
-During account validation, Anchor will derive a PDA using the seeds specified in the `seeds` constraint and verify that the account passed into the instruction matches the PDA found using the specified `seeds`.
+During account validation, Anchor will derive a PDA using the seeds specified in
+the `seeds` constraint and verify that the account passed into the instruction
+matches the PDA found using the specified `seeds`.
 
-When the `bump` constraint is included without specifying a specific bump, Anchor will default to using the canonical bump (the first bump that results in a valid PDA). In most cases you should use the canonical bump.
+When the `bump` constraint is included without specifying a specific bump,
+Anchor will default to using the canonical bump (the first bump that results in
+a valid PDA). In most cases you should use the canonical bump.
 
-You can access other fields from within the struct from constraints, so you can specify seeds that are dependent on other accounts like the signer's public key.
+You can access other fields from within the struct from constraints, so you can
+specify seeds that are dependent on other accounts like the signer's public key.
 
-You can also reference the deserialized instruction data if you add the `#[instruction(...)]` attribute macro to the struct.
+You can also reference the deserialized instruction data if you add the
+`#[instruction(...)]` attribute macro to the struct.
 
-For example, the following example shows a list of accounts that include `pda_account` and `user`. The `pda_account` is constrained such that the seeds must be the string "example_seed," the public key of `user`, and the string passed into the instruction as `instruction_data`.
+For example, the following example shows a list of accounts that include
+`pda_account` and `user`. The `pda_account` is constrained such that the seeds
+must be the string "example_seed," the public key of `user`, and the string
+passed into the instruction as `instruction_data`.
 
 ```rust
 #[derive(Accounts)]
@@ -61,13 +85,20 @@ pub struct Example<'info> {
 }
 ```
 
-If the `pda_account` address provided by the client doesn't match the PDA derived using the specified seeds and the canonical bump, then the account validation will fail.
+If the `pda_account` address provided by the client doesn't match the PDA
+derived using the specified seeds and the canonical bump, then the account
+validation will fail.
 
 ### Use PDAs with the `init` constraint
 
-You can combine the `seeds` and `bump` constraints with the `init` constraint to initialize an account using a PDA.
+You can combine the `seeds` and `bump` constraints with the `init` constraint to
+initialize an account using a PDA.
 
-Recall that the `init` constraint must be used in combination with the `payer` and `space` constraints to specify the account that will pay for account initialization and the space to allocate on the new account. Additionally, you must include `system_program` as one of the fields of the account validation struct.
+Recall that the `init` constraint must be used in combination with the `payer`
+and `space` constraints to specify the account that will pay for account
+initialization and the space to allocate on the new account. Additionally, you
+must include `system_program` as one of the fields of the account validation
+struct.
 
 ```rust
 #[derive(Accounts)]
@@ -91,21 +122,41 @@ pub struct AccountType {
 }
 ```
 
-When using `init` for non-PDA accounts, Anchor defaults to setting the owner of the initialized account to be the program currently executing the instruction.
+When using `init` for non-PDA accounts, Anchor defaults to setting the owner of
+the initialized account to be the program currently executing the instruction.
 
-However, when using `init` in combination with `seeds` and `bump`, the owner _must_ be the executing program. This is because initializing an account for the PDA requires a signature that only the executing program can provide. In other words, the signature verification for the initialization of the PDA account would fail if the program ID used to derive the PDA did not match the program ID of the executing program.
+However, when using `init` in combination with `seeds` and `bump`, the owner
+_must_ be the executing program. This is because initializing an account for the
+PDA requires a signature that only the executing program can provide. In other
+words, the signature verification for the initialization of the PDA account
+would fail if the program ID used to derive the PDA did not match the program ID
+of the executing program.
 
-When determining the value of `space` for an account initialized and owned by the executing Anchor program, remember that the first 8 bytes are reserved for the account discriminator. This is an 8-byte value that Anchor calculates and uses to identify the program account types. You can use this [reference](https://www.anchor-lang.com/docs/space) to calculate how much space you should allocate for an account.
+When determining the value of `space` for an account initialized and owned by
+the executing Anchor program, remember that the first 8 bytes are reserved for
+the account discriminator. This is an 8-byte value that Anchor calculates and
+uses to identify the program account types. You can use this
+[reference](https://www.anchor-lang.com/docs/space) to calculate how much space
+you should allocate for an account.
 
 ### Seed inference
 
-The account list for an instruction can get really long for some programs. To simplify the client-side experience when invoking an Anchor program instruction, we can turn on seed inference.
+The account list for an instruction can get really long for some programs. To
+simplify the client-side experience when invoking an Anchor program instruction,
+we can turn on seed inference.
 
-Seed inference adds information about PDA seeds to the IDL so that Anchor can infer PDA seeds from existing call-site information. In the previous example, the seeds are `b"example_seed"` and `user.key()`. The first is static and therefore known, and the second is known because `user` is the transaction signer.
+Seed inference adds information about PDA seeds to the IDL so that Anchor can
+infer PDA seeds from existing call-site information. In the previous example,
+the seeds are `b"example_seed"` and `user.key()`. The first is static and
+therefore known, and the second is known because `user` is the transaction
+signer.
 
-If you use seed inference when building your program, then as long as you're calling the program using Anchor, you don't need to explicitly derive and pass in the PDA. Instead, the Anchor library will do it for you.
+If you use seed inference when building your program, then as long as you're
+calling the program using Anchor, you don't need to explicitly derive and pass
+in the PDA. Instead, the Anchor library will do it for you.
 
-You can turn on seed inference in the `Anchor.toml` file with `seeds = true` under `[features]`.
+You can turn on seed inference in the `Anchor.toml` file with `seeds = true`
+under `[features]`.
 
 ```
 [features]
@@ -114,11 +165,19 @@ seeds = true
 
 ### Use the `#[instruction(...)]` attribute macro
 
-Let's briefly look at the `#[instruction(...)]` attribute macro before moving on. When using `#[instruction(...)]`, the instruction data you provide in the list of arguments must match and be in the same order as the instruction arguments. You can omit unused arguments at the end of the list, but you must include all arguments up until the last one you will be using.
+Let's briefly look at the `#[instruction(...)]` attribute macro before moving
+on. When using `#[instruction(...)]`, the instruction data you provide in the
+list of arguments must match and be in the same order as the instruction
+arguments. You can omit unused arguments at the end of the list, but you must
+include all arguments up until the last one you will be using.
 
-For example, imagine an instruction has arguments `input_one`, `input_two`, and `input_three`. If your account constraints need to reference `input_one` and `input_three`, you need to list all three arguments in the `#[instruction(...)]` attribute macro.
+For example, imagine an instruction has arguments `input_one`, `input_two`, and
+`input_three`. If your account constraints need to reference `input_one` and
+`input_three`, you need to list all three arguments in the `#[instruction(...)]`
+attribute macro.
 
-However, if your constraints only reference `input_one` and `input_two`, you can omit `input_three`.
+However, if your constraints only reference `input_one` and `input_two`, you can
+omit `input_three`.
 
 ```rust
 pub fn example_instruction(
@@ -138,7 +197,8 @@ pub struct Example<'info> {
 }
 ```
 
-Additionally, you will get an error if you list the inputs in the incorrect order:
+Additionally, you will get an error if you list the inputs in the incorrect
+order:
 
 ```rust
 #[derive(Accounts)]
@@ -150,11 +210,19 @@ pub struct Example<'info> {
 
 ## Init-if-needed
 
-Anchor provides an `init_if_needed` constraint that can be used to initialize an account if the account has not already been initialized.
+Anchor provides an `init_if_needed` constraint that can be used to initialize an
+account if the account has not already been initialized.
 
-This feature is gated behind a feature flag to make sure you are intentional about using it. For security reasons, it's smart to avoid having one instruction branch into multiple logic paths. And as the name suggests, `init_if_needed` executes one of two possible code paths depending on the state of the account in question.
+This feature is gated behind a feature flag to make sure you are intentional
+about using it. For security reasons, it's smart to avoid having one instruction
+branch into multiple logic paths. And as the name suggests, `init_if_needed`
+executes one of two possible code paths depending on the state of the account in
+question.
 
-When using `init_if_needed`, you need to make sure to properly protect your program against re-initialization attacks. You need to include checks in your code that check that the initialized account cannot be reset to its initial settings after the first time it was initialized.
+When using `init_if_needed`, you need to make sure to properly protect your
+program against re-initialization attacks. You need to include checks in your
+code that check that the initialized account cannot be reset to its initial
+settings after the first time it was initialized.
 
 To use `init_if_needed`, you must first enable the feature in `Cargo.toml`.
 
@@ -163,7 +231,10 @@ To use `init_if_needed`, you must first enable the feature in `Cargo.toml`.
 anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
 ```
 
-Once you’ve enabled the feature, you can include the constraint in the `#[account(…)]` attribute macro. The example below demonstrates using the `init_if_needed` constraint to initialize a new associated token account if one does not already exist.
+Once you’ve enabled the feature, you can include the constraint in the
+`#[account(…)]` attribute macro. The example below demonstrates using the
+`init_if_needed` constraint to initialize a new associated token account if one
+does not already exist.
 
 ```rust
 #[program]
@@ -193,21 +264,30 @@ pub struct Initialize<'info> {
 }
 ```
 
-When the `initialize` instruction is invoked in the previous example, Anchor will check if the `token_account` exists and initialize it if it does not. If it already exists, then the instruction will continue without initializing the account. Just as with the `init` constraint, you can use `init_if_needed` in conjunction with `seeds` and `bump` if the account is a PDA.
+When the `initialize` instruction is invoked in the previous example, Anchor
+will check if the `token_account` exists and initialize it if it does not. If it
+already exists, then the instruction will continue without initializing the
+account. Just as with the `init` constraint, you can use `init_if_needed` in
+conjunction with `seeds` and `bump` if the account is a PDA.
 
 ## Realloc
 
-The `realloc` constraint provides a simple way to reallocate space for existing accounts.
+The `realloc` constraint provides a simple way to reallocate space for existing
+accounts.
 
-The `realloc` constraint must be used in combination with the following constraints:
+The `realloc` constraint must be used in combination with the following
+constraints:
 
 - `mut` - the account must be set as mutable
-- `realloc::payer` - the account to subtract or add lamports to depending on whether the reallocation is decreasing or increasing account space
+- `realloc::payer` - the account to subtract or add lamports to depending on
+  whether the reallocation is decreasing or increasing account space
 - `realloc::zero` - boolean to specify if new memory should be zero initialized
 
-As with `init`, you must include `system_program` as one of the accounts in the account validation struct when using `realloc`.
+As with `init`, you must include `system_program` as one of the accounts in the
+account validation struct when using `realloc`.
 
-Below is an example of reallocating space for an account that stores a `data` field of type `String`.
+Below is an example of reallocating space for an account that stores a `data`
+field of type `String`.
 
 ```rust
 #[derive(Accounts)]
@@ -233,23 +313,40 @@ pub struct AccountType {
 }
 ```
 
-Notice that `realloc` is set to `8 + 4 + instruction_data.len()`. This breaks down as follows:
+Notice that `realloc` is set to `8 + 4 + instruction_data.len()`. This breaks
+down as follows:
 
 - `8` is for the account discriminator
-- `4` is for the 4 bytes of space that BORSH uses to store the length of the string
+- `4` is for the 4 bytes of space that BORSH uses to store the length of the
+  string
 - `instruction_data.len()` is the length of the string itself
 
-If the change in account data length is additive, lamports will be transferred from the `realloc::payer` to the account in order to maintain rent exemption. Likewise, if the change is subtractive, lamports will be transferred from the account back to the `realloc::payer`.
+If the change in account data length is additive, lamports will be transferred
+from the `realloc::payer` to the account in order to maintain rent exemption.
+Likewise, if the change is subtractive, lamports will be transferred from the
+account back to the `realloc::payer`.
 
-The `realloc::zero` constraint is required in order to determine whether the new memory should be zero initialized after reallocation. This constraint should be set to true in cases where you expect the memory of an account to shrink and expand multiple times. That way you zero out space that would otherwise show as stale data.
+The `realloc::zero` constraint is required in order to determine whether the new
+memory should be zero initialized after reallocation. This constraint should be
+set to true in cases where you expect the memory of an account to shrink and
+expand multiple times. That way you zero out space that would otherwise show as
+stale data.
 
 ## Close
 
-The `close` constraint provides a simple and secure way to close an existing account.
+The `close` constraint provides a simple and secure way to close an existing
+account.
 
-The `close` constraint marks the account as closed at the end of the instruction’s execution by setting its discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR` and sends its lamports to a specified account. Setting the discriminator to a special variant makes account revival attacks (where a subsequent instruction adds the rent exemption lamports again) impossible. If someone tries to reinitialize the account, the reinitialization will fail the discriminator check and be considered invalid by the program.
+The `close` constraint marks the account as closed at the end of the
+instruction’s execution by setting its discriminator to
+the `CLOSED_ACCOUNT_DISCRIMINATOR` and sends its lamports to a specified
+account. Setting the discriminator to a special variant makes account revival
+attacks (where a subsequent instruction adds the rent exemption lamports again)
+impossible. If someone tries to reinitialize the account, the reinitialization
+will fail the discriminator check and be considered invalid by the program.
 
-The example below uses the `close` constraint to close the `data_account` and sends the lamports allocated for rent to the `receiver` account.
+The example below uses the `close` constraint to close the `data_account` and
+sends the lamports allocated for rent to the `receiver` account.
 
 ```rust
 pub fn close(ctx: Context<Close>) -> Result<()> {
@@ -267,7 +364,8 @@ pub struct Close<'info> {
 
 # Demo
 
-Let’s practice the concepts we’ve gone over in this lesson by creating a Movie Review program using the Anchor framework.
+Let’s practice the concepts we’ve gone over in this lesson by creating a Movie
+Review program using the Anchor framework.
 
 This program will allow users to:
 
@@ -283,7 +381,8 @@ To begin, let’s create a new project using `anchor init`.
 anchor init anchor-movie-review-program
 ```
 
-Next, navigate to the `lib.rs` file within the `programs` folder and you should see the following starter code.
+Next, navigate to the `lib.rs` file within the `programs` folder and you should
+see the following starter code.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -319,7 +418,12 @@ pub mod anchor_movie_review_program {
 
 ### 2. `MovieAccountState`
 
-First, let’s use the `#[account]` attribute macro to define the `MovieAccountState` that will represent the data structure of the movie review accounts. As a reminder, the `#[account]` attribute macro implements various traits that help with serialization and deserialization of the account, set the discriminator for the account, and set the owner of a new account as the program ID defined in the `declare_id!` macro.
+First, let’s use the `#[account]` attribute macro to define the
+`MovieAccountState` that will represent the data structure of the movie review
+accounts. As a reminder, the `#[account]` attribute macro implements various
+traits that help with serialization and deserialization of the account, set the
+discriminator for the account, and set the owner of a new account as the program
+ID defined in the `declare_id!` macro.
 
 Within each movie review account, we’ll store the:
 
@@ -350,15 +454,20 @@ pub struct MovieAccountState {
 
 ### 3. Add Movie Review
 
-Next, let’s implement the `add_movie_review` instruction. The `add_movie_review` instruction will require a `Context` of type `AddMovieReview` that we’ll implement shortly.
+Next, let’s implement the `add_movie_review` instruction. The `add_movie_review`
+instruction will require a `Context` of type `AddMovieReview` that we’ll
+implement shortly.
 
-The instruction will require three additional arguments as instruction data provided by a reviewer:
+The instruction will require three additional arguments as instruction data
+provided by a reviewer:
 
 - `title` - title of the movie as a `String`
 - `description` - details of the review as a `String`
 - `rating` - rating for the movie as a `u8`
 
-Within the instruction logic, we’ll populate the data of the new `movie_review` account with the instruction data. We’ll also set the `reviewer` field as the `initializer` account from the instruction context.
+Within the instruction logic, we’ll populate the data of the new `movie_review`
+account with the instruction data. We’ll also set the `reviewer` field as the
+`initializer` account from the instruction context.
 
 ```rust
 #[program]
@@ -386,17 +495,27 @@ pub mod movie_review{
 }
 ```
 
-Next, let’s create the `AddMovieReview` struct that we used as the generic in the instruction's context. This struct will list the accounts the `add_movie_review` instruction requires.
+Next, let’s create the `AddMovieReview` struct that we used as the generic in
+the instruction's context. This struct will list the accounts the
+`add_movie_review` instruction requires.
 
 Remember, you'll need the following macros:
 
-- The `#[derive(Accounts)]` macro is used to deserialize and validate the list of accounts specified within the struct
-- The `#[instruction(...)]` attribute macro is used to access the instruction data passed into the instruction
-- The `#[account(...)]` attribute macro then specifies additional constraints on the accounts
+- The `#[derive(Accounts)]` macro is used to deserialize and validate the list
+  of accounts specified within the struct
+- The `#[instruction(...)]` attribute macro is used to access the instruction
+  data passed into the instruction
+- The `#[account(...)]` attribute macro then specifies additional constraints on
+  the accounts
 
-The `movie_review` account is a PDA that needs to be initialized, so we'll add the `seeds` and `bump` constraints as well as the `init` constraint with its required `payer` and `space` constraints.
+The `movie_review` account is a PDA that needs to be initialized, so we'll add
+the `seeds` and `bump` constraints as well as the `init` constraint with its
+required `payer` and `space` constraints.
 
-For the PDA seeds, we'll use the movie title and the reviewer's public key. The payer for the initialization should be the reviewer, and the space allocated on the account should be enough for the account discriminator, the reviewer's public key, and the movie review's rating, title, and description.
+For the PDA seeds, we'll use the movie title and the reviewer's public key. The
+payer for the initialization should be the reviewer, and the space allocated on
+the account should be enough for the account discriminator, the reviewer's
+public key, and the movie review's rating, title, and description.
 
 ```rust
 #[derive(Accounts)]
@@ -418,17 +537,21 @@ pub struct AddMovieReview<'info> {
 
 ### 4. Update Movie Review
 
-Next, let’s implement the `update_movie_review` instruction with a context whose generic type is `UpdateMovieReview`.
+Next, let’s implement the `update_movie_review` instruction with a context whose
+generic type is `UpdateMovieReview`.
 
-Just as before, the instruction will require three additional arguments as instruction data provided by a reviewer:
+Just as before, the instruction will require three additional arguments as
+instruction data provided by a reviewer:
 
 - `title` - title of the movie
 - `description` - details of the review
 - `rating` - rating for the movie
 
-Within the instruction logic we’ll update the `rating` and `description` stored on the `movie_review` account.
+Within the instruction logic we’ll update the `rating` and `description` stored
+on the `movie_review` account.
 
-While the `title` doesn't get used in the instruction function itself, we'll need it for account validation of `movie_review` in the next step.
+While the `title` doesn't get used in the instruction function itself, we'll
+need it for account validation of `movie_review` in the next step.
 
 ```rust
 #[program]
@@ -458,11 +581,17 @@ pub mod anchor_movie_review_program {
 }
 ```
 
-Next, let’s create the `UpdateMovieReview` struct to define the accounts that the `update_movie_review` instruction needs.
+Next, let’s create the `UpdateMovieReview` struct to define the accounts that
+the `update_movie_review` instruction needs.
 
-Since the `movie_review` account will have already been initialized by this point, we no longer need the `init` constraint. However, since the value of `description` may now be different, we need to use the `realloc` constraint to reallocate the space on the account. Accompanying this, we need the `mut`, `realloc::payer`, and `realloc::zero` constraints.
+Since the `movie_review` account will have already been initialized by this
+point, we no longer need the `init` constraint. However, since the value of
+`description` may now be different, we need to use the `realloc` constraint to
+reallocate the space on the account. Accompanying this, we need the `mut`,
+`realloc::payer`, and `realloc::zero` constraints.
 
-We'll also still need the `seeds` and `bump` constraints as we had them in `AddMovieReview`.
+We'll also still need the `seeds` and `bump` constraints as we had them in
+`AddMovieReview`.
 
 ```rust
 #[derive(Accounts)]
@@ -483,17 +612,27 @@ pub struct UpdateMovieReview<'info> {
 }
 ```
 
-Note that the `realloc` constraint is set to the new space required by the `movie_review` account based on the updated value of `description`.
+Note that the `realloc` constraint is set to the new space required by the
+`movie_review` account based on the updated value of `description`.
 
-Additionally, the `realloc::payer` constraint specifies that any additional lamports required or refunded will come from or be send to the `initializer` account.
+Additionally, the `realloc::payer` constraint specifies that any additional
+lamports required or refunded will come from or be send to the `initializer`
+account.
 
-Finally, we set the `realloc::zero` constraint to `true` because the `movie_review` account may be updated multiple times either shrinking or expanding the space allocated to the account.
+Finally, we set the `realloc::zero` constraint to `true` because the
+`movie_review` account may be updated multiple times either shrinking or
+expanding the space allocated to the account.
 
 ### 5. Delete Movie Review
 
-Lastly, let’s implement the `delete_movie_review` instruction to close an existing `movie_review` account.
+Lastly, let’s implement the `delete_movie_review` instruction to close an
+existing `movie_review` account.
 
-We'll use a context whose generic type is `DeleteMovieReview` and won't include any additional instruction data. Since we are only closing an account, we actually don't need any instruction logic inside the body of the function. The closing itself will be handled by the Anchor constraint in the `DeleteMovieReview` type.
+We'll use a context whose generic type is `DeleteMovieReview` and won't include
+any additional instruction data. Since we are only closing an account, we
+actually don't need any instruction logic inside the body of the function. The
+closing itself will be handled by the Anchor constraint in the
+`DeleteMovieReview` type.
 
 ```rust
 #[program]
@@ -529,11 +668,17 @@ pub struct DeleteMovieReview<'info> {
 }
 ```
 
-Here we use the `close` constraint to specify we are closing the `movie_review` account and that the rent should be refunded to the `initializer` account. We also include the `seeds` and `bump` constraints for the the `movie_review` account for validation. Anchor then handles the additional logic required to securely close the account.
+Here we use the `close` constraint to specify we are closing the `movie_review`
+account and that the rent should be refunded to the `initializer` account. We
+also include the `seeds` and `bump` constraints for the the `movie_review`
+account for validation. Anchor then handles the additional logic required to
+securely close the account.
 
 ### 6. Testing
 
-The program should be good to go! Now let's test it out. Navigate to `anchor-movie-review-program.ts` and replace the default test code with the following.
+The program should be good to go! Now let's test it out. Navigate to
+`anchor-movie-review-program.ts` and replace the default test code with the
+following.
 
 Here we:
 
@@ -574,9 +719,14 @@ describe("anchor-movie-review-program", () => {
 });
 ```
 
-Next, let's create the first test for the `addMovieReview` instruction. Note that we don't explicitly add `.accounts`. This is because the `Wallet` from `AnchorProvider` is automatically included as a signer, Anchor can infer certain accounts like `SystemProgram`, and Anchor can also infer the `movieReview` PDA from the `title` instruction argument and the signer's public key.
+Next, let's create the first test for the `addMovieReview` instruction. Note
+that we don't explicitly add `.accounts`. This is because the `Wallet` from
+`AnchorProvider` is automatically included as a signer, Anchor can infer certain
+accounts like `SystemProgram`, and Anchor can also infer the `movieReview` PDA
+from the `title` instruction argument and the signer's public key.
 
-Once the instruction runs, we then fetch the `movieReview` account and check that the data stored on the account match the expected values.
+Once the instruction runs, we then fetch the `movieReview` account and check
+that the data stored on the account match the expected values.
 
 ```ts
 it("Movie review is added`", async () => {
@@ -593,7 +743,8 @@ it("Movie review is added`", async () => {
 });
 ```
 
-Next, let's create the test for the `updateMovieReview` instruction following the same process as before.
+Next, let's create the test for the `updateMovieReview` instruction following
+the same process as before.
 
 ```ts
 it("Movie review is updated`", async () => {
@@ -620,7 +771,8 @@ it("Deletes a movie review", async () => {
 });
 ```
 
-Lastly, run `anchor test` and you should see the following output in the console.
+Lastly, run `anchor test` and you should see the following output in the
+console.
 
 ```console
   anchor-movie-review-program
@@ -632,18 +784,29 @@ Lastly, run `anchor test` and you should see the following output in the console
   3 passing (950ms)
 ```
 
-If you need more time with this project to feel comfortable with these concepts, feel free to have a look at the [solution code](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-pdas) before continuing.
+If you need more time with this project to feel comfortable with these concepts,
+feel free to have a look at
+the [solution code](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-pdas) before
+continuing.
 
 # Challenge
 
-Now it’s your turn to build something independently. Equipped with the concepts introduced in this lesson, try to recreate the Student Intro program that we've used before using the Anchor framework.
+Now it’s your turn to build something independently. Equipped with the concepts
+introduced in this lesson, try to recreate the Student Intro program that we've
+used before using the Anchor framework.
 
-The Student Intro program is a Solana Program that lets students introduce themselves. The program takes a user's name and a short message as the instruction data and creates an account to store the data on-chain.
+The Student Intro program is a Solana Program that lets students introduce
+themselves. The program takes a user's name and a short message as the
+instruction data and creates an account to store the data on-chain.
 
-Using what you've learned in this lesson, build out this program. The program should include instructions to:
+Using what you've learned in this lesson, build out this program. The program
+should include instructions to:
 
-1. Initialize a PDA account for each student that stores the student's name and their short message
+1. Initialize a PDA account for each student that stores the student's name and
+   their short message
 2. Update the message on an existing account
 3. Close an existing account
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/anchor-student-intro-program).
+Try to do this independently if you can! But if you get stuck, feel free to
+reference
+the [solution code](https://github.com/Unboxed-Software/anchor-student-intro-program).

--- a/developers/courses/solana-course/content/arbitrary-cpi.md
+++ b/developers/courses/solana-course/content/arbitrary-cpi.md
@@ -1,9 +1,9 @@
 ---
 title: Arbitrary CPI
 objectives:
-- Explain the security risks associated with invoking a CPI to an unknown program
-- Showcase how Anchor’s CPI module prevents this from happening when making a CPI from one Anchor program to another
-- Safely and securely make a CPI from an Anchor program to an arbitrary non-anchor program
+  - Explain the security risks associated with invoking a CPI to an unknown program
+  - Showcase how Anchor’s CPI module prevents this from happening when making a CPI from one Anchor program to another
+  - Safely and securely make a CPI from an Anchor program to an arbitrary non-anchor program
 ---
 
 # TL;DR
@@ -186,55 +186,55 @@ There is already a test in the `tests` directory for this. It's long, but take a
 
 ```ts
 it("Insecure instructions allow attacker to win every time", async () => {
-    // Initialize player one with real metadata program
-    await gameplayProgram.methods
-      .createCharacterInsecure()
-      .accounts({
-        metadataProgram: metadataProgram.programId,
-        authority: playerOne.publicKey,
-      })
-      .signers([playerOne])
-      .rpc()
+  // Initialize player one with real metadata program
+  await gameplayProgram.methods
+    .createCharacterInsecure()
+    .accounts({
+      metadataProgram: metadataProgram.programId,
+      authority: playerOne.publicKey,
+    })
+    .signers([playerOne])
+    .rpc();
 
-    // Initialize attacker with fake metadata program
-    await gameplayProgram.methods
-      .createCharacterInsecure()
-      .accounts({
-        metadataProgram: fakeMetadataProgram.programId,
-        authority: attacker.publicKey,
-      })
-      .signers([attacker])
-      .rpc()
+  // Initialize attacker with fake metadata program
+  await gameplayProgram.methods
+    .createCharacterInsecure()
+    .accounts({
+      metadataProgram: fakeMetadataProgram.programId,
+      authority: attacker.publicKey,
+    })
+    .signers([attacker])
+    .rpc();
 
-    // Fetch both player's metadata accounts
-    const [playerOneMetadataKey] = getMetadataKey(
-      playerOne.publicKey,
-      gameplayProgram.programId,
-      metadataProgram.programId
-    )
+  // Fetch both player's metadata accounts
+  const [playerOneMetadataKey] = getMetadataKey(
+    playerOne.publicKey,
+    gameplayProgram.programId,
+    metadataProgram.programId,
+  );
 
-    const [attackerMetadataKey] = getMetadataKey(
-      attacker.publicKey,
-      gameplayProgram.programId,
-      fakeMetadataProgram.programId
-    )
+  const [attackerMetadataKey] = getMetadataKey(
+    attacker.publicKey,
+    gameplayProgram.programId,
+    fakeMetadataProgram.programId,
+  );
 
-    const playerOneMetadata = await metadataProgram.account.metadata.fetch(
-      playerOneMetadataKey
-    )
+  const playerOneMetadata = await metadataProgram.account.metadata.fetch(
+    playerOneMetadataKey,
+  );
 
-    const attackerMetadata = await fakeMetadataProgram.account.metadata.fetch(
-      attackerMetadataKey
-    )
+  const attackerMetadata = await fakeMetadataProgram.account.metadata.fetch(
+    attackerMetadataKey,
+  );
 
-    // The regular player should have health and power between 0 and 20
-    expect(playerOneMetadata.health).to.be.lessThan(20)
-    expect(playerOneMetadata.power).to.be.lessThan(20)
+  // The regular player should have health and power between 0 and 20
+  expect(playerOneMetadata.health).to.be.lessThan(20);
+  expect(playerOneMetadata.power).to.be.lessThan(20);
 
-    // The attacker will have health and power of 255
-    expect(attackerMetadata.health).to.equal(255)
-    expect(attackerMetadata.power).to.equal(255)
-})
+  // The attacker will have health and power of 255
+  expect(attackerMetadata.health).to.equal(255);
+  expect(attackerMetadata.power).to.equal(255);
+});
 ```
 
 This test effectively walks through the scenario where a regular player and an attacker both create their characters. Only the attacker passes in the program ID of the fake metadata program rather than the actual metadata program. And since the `create_character_insecure` instruction has no program checks, it still executes.
@@ -318,20 +318,20 @@ Now that we have a secure way of initializing a new character, let's create a ne
 
 ```ts
 it("Secure character creation doesn't allow fake program", async () => {
-    try {
-      await gameplayProgram.methods
-        .createCharacterSecure()
-        .accounts({
-          metadataProgram: fakeMetadataProgram.programId,
-          authority: attacker.publicKey,
-        })
-        .signers([attacker])
-        .rpc()
-    } catch (error) {
-      expect(error)
-      console.log(error)
-    }
-})
+  try {
+    await gameplayProgram.methods
+      .createCharacterSecure()
+      .accounts({
+        metadataProgram: fakeMetadataProgram.programId,
+        authority: attacker.publicKey,
+      })
+      .signers([attacker])
+      .rpc();
+  } catch (error) {
+    expect(error);
+    console.log(error);
+  }
+});
 ```
 
 Run `anchor test` if you haven't already. Notice that an error was thrown as expected, detailing that the program ID passed into the instruction is not the expected program ID:

--- a/developers/courses/solana-course/content/arbitrary-cpi.md
+++ b/developers/courses/solana-course/content/arbitrary-cpi.md
@@ -1,26 +1,50 @@
 ---
 title: Arbitrary CPI
 objectives:
-  - Explain the security risks associated with invoking a CPI to an unknown program
-  - Showcase how Anchor’s CPI module prevents this from happening when making a CPI from one Anchor program to another
-  - Safely and securely make a CPI from an Anchor program to an arbitrary non-anchor program
+  - Explain the security risks associated with invoking a CPI to an unknown
+    program
+  - Showcase how Anchor’s CPI module prevents this from happening when making a
+    CPI from one Anchor program to another
+  - Safely and securely make a CPI from an Anchor program to an arbitrary
+    non-anchor program
 ---
 
 # TL;DR
 
-- To generate a CPI, the target program must be passed into the invoking instruction as an account. This means that any target program could be passed into the instruction. Your program should check for incorrect or unexpected programs.
-- Perform program checks in native programs by simply comparing the public key of the passed-in program to the progam you expected.
-- If a program is written in Anchor, then it may have a publicly available CPI module. This makes invoking the program from another Anchor program simple and secure. The Anchor CPI module automatically checks that the address of the program passed in matches the address of the program stored in the module.
+- To generate a CPI, the target program must be passed into the invoking
+  instruction as an account. This means that any target program could be passed
+  into the instruction. Your program should check for incorrect or unexpected
+  programs.
+- Perform program checks in native programs by simply comparing the public key
+  of the passed-in program to the progam you expected.
+- If a program is written in Anchor, then it may have a publicly available CPI
+  module. This makes invoking the program from another Anchor program simple and
+  secure. The Anchor CPI module automatically checks that the address of the
+  program passed in matches the address of the program stored in the module.
 
 # Overview
 
-A cross program invocation (CPI) is when one program invokes an instruction on another program. An “arbitrary CPI” is when a program is structured to issue a CPI to whatever program is passed into the instruction rather than expecting to perform a CPI to one specific program. Given that the callers of your program's instruction can pass any program they'd like into the instruction's list of accounts, failing to verify the address of a passed-in program results in your program performing CPIs to arbitrary programs.
+A cross program invocation (CPI) is when one program invokes an instruction on
+another program. An “arbitrary CPI” is when a program is structured to issue a
+CPI to whatever program is passed into the instruction rather than expecting to
+perform a CPI to one specific program. Given that the callers of your program's
+instruction can pass any program they'd like into the instruction's list of
+accounts, failing to verify the address of a passed-in program results in your
+program performing CPIs to arbitrary programs.
 
-This lack of program checks creates an opportunity for a malicious user to pass in a different program than expected, causing the original program to call an instruction on this mystery program. There’s no telling what the consequences of this CPI could be. It depends on the program logic (both that of the original program and the unexpected program), as well as what other accounts are passed into the original instruction.
+This lack of program checks creates an opportunity for a malicious user to pass
+in a different program than expected, causing the original program to call an
+instruction on this mystery program. There’s no telling what the consequences of
+this CPI could be. It depends on the program logic (both that of the original
+program and the unexpected program), as well as what other accounts are passed
+into the original instruction.
 
 ## Missing program checks
 
-Take the following program as an example. The `cpi` instruction invokes the `transfer` instruction on `token_program`, but there is no code that checks whether or not the `token_program` account passed into the instruction is, in fact, the SPL Token Program.
+Take the following program as an example. The `cpi` instruction invokes the
+`transfer` instruction on `token_program`, but there is no code that checks
+whether or not the `token_program` account passed into the instruction is, in
+fact, the SPL Token Program.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -60,11 +84,14 @@ pub struct Cpi<'info> {
 }
 ```
 
-An attacker could easily call this instruction and pass in a duplicate token program that they created and control.
+An attacker could easily call this instruction and pass in a duplicate token
+program that they created and control.
 
 ## Add program checks
 
-It's possible to fix this vulnerabilty by simply adding a few lines to the `cpi` instruction to check whether or not `token_program`'s public key is that of the SPL Token Program.
+It's possible to fix this vulnerabilty by simply adding a few lines to the `cpi`
+instruction to check whether or not `token_program`'s public key is that of the
+SPL Token Program.
 
 ```rust
 pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
@@ -89,19 +116,34 @@ pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
 }
 ```
 
-Now, if an attacker passes in a different token program, the instruction will return the `ProgramError::IncorrectProgramId` error.
+Now, if an attacker passes in a different token program, the instruction will
+return the `ProgramError::IncorrectProgramId` error.
 
-Depending on the program you’re invoking with your CPI, you can either hard code the address of the expected program ID or use the program’s Rust crate to get the address of the program, if available. In the example above, the `spl_token` crate provides the address of the SPL Token Program.
+Depending on the program you’re invoking with your CPI, you can either hard code
+the address of the expected program ID or use the program’s Rust crate to get
+the address of the program, if available. In the example above, the `spl_token`
+crate provides the address of the SPL Token Program.
 
 ## Use an Anchor CPI module
 
-A simpler way to manage program checks is to use Anchor CPI modules. We learned in a [previous lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/anchor-cpi.md) that Anchor can automatically generate CPI modules to make CPIs into the program simpler. These modules also enhance security by verifying the public key of the program that’s passed into one of its public instructions.
+A simpler way to manage program checks is to use Anchor CPI modules. We learned
+in a
+[previous lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/anchor-cpi.md)
+that Anchor can automatically generate CPI modules to make CPIs into the program
+simpler. These modules also enhance security by verifying the public key of the
+program that’s passed into one of its public instructions.
 
-Every Anchor program uses the `declare_id()` macro to define the address of the program. When a CPI module is generated for a specific program, it uses the address passed into this macro as the "source of truth" and will automatically verify that all CPIs made using its CPI module target this program id.
+Every Anchor program uses the `declare_id()` macro to define the address of the
+program. When a CPI module is generated for a specific program, it uses the
+address passed into this macro as the "source of truth" and will automatically
+verify that all CPIs made using its CPI module target this program id.
 
-While at the core no different than manual program checks, using CPI modules avoids the possibility of forgetting to perform a program check or accidentally typing in the wrong program ID when hard-coding it.
+While at the core no different than manual program checks, using CPI modules
+avoids the possibility of forgetting to perform a program check or accidentally
+typing in the wrong program ID when hard-coding it.
 
-The program below shows an example of using a CPI module for the SPL Token Program to perform the transfer shown in the previous examples.
+The program below shows an example of using a CPI module for the SPL Token
+Program to perform the transfer shown in the previous examples.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -139,15 +181,24 @@ impl<'info> Cpi<'info> {
 }
 ```
 
-Note that, like the example above, Anchor has created a few [wrappers for popular native programs](https://github.com/coral-xyz/anchor/tree/master/spl/src) that allow you to issue CPIs into them as if they were Anchor programs.
+Note that, like the example above, Anchor has created a few
+[wrappers for popular native programs](https://github.com/coral-xyz/anchor/tree/master/spl/src)
+that allow you to issue CPIs into them as if they were Anchor programs.
 
-Additionally and depending on the program you’re making the CPI to, you may be able to use Anchor’s [`Program` account type](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/program/struct.Program.html) to validate the passed-in program in your account validation struct. Between the [`anchor_lang`](https://docs.rs/anchor-lang/latest/anchor_lang) and [`anchor_spl`](https://docs.rs/anchor_spl/latest/) crates, the following `Program` types are provided out of the box:
+Additionally and depending on the program you’re making the CPI to, you may be
+able to use Anchor’s
+[`Program` account type](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/program/struct.Program.html)
+to validate the passed-in program in your account validation struct. Between
+the [`anchor_lang`](https://docs.rs/anchor-lang/latest/anchor_lang) and [`anchor_spl`](https://docs.rs/anchor_spl/latest/) crates,
+the following `Program` types are provided out of the box:
 
 - [`System`](https://docs.rs/anchor-lang/latest/anchor_lang/struct.System.html)
 - [`AssociatedToken`](https://docs.rs/anchor-spl/latest/anchor_spl/associated_token/struct.AssociatedToken.html)
 - [`Token`](https://docs.rs/anchor-spl/latest/anchor_spl/token/struct.Token.html)
 
-If you have access to an Anchor program's CPI module, you typically can import its program type with the following, replacing the program name with the name of the actual program:
+If you have access to an Anchor program's CPI module, you typically can import
+its program type with the following, replacing the program name with the name of
+the actual program:
 
 ```rust
 use other_program::program::OtherProgram;
@@ -155,13 +206,22 @@ use other_program::program::OtherProgram;
 
 # Demo
 
-To show the importance of checking with program you use for CPIs, we're going to work with a simplified and somewhat contrived game. This game represents characters with PDA accounts, and uses a separate "metadata" program to manage character metadata and attributes like health and power.
+To show the importance of checking with program you use for CPIs, we're going to
+work with a simplified and somewhat contrived game. This game represents
+characters with PDA accounts, and uses a separate "metadata" program to manage
+character metadata and attributes like health and power.
 
-While this example is somewhat contrived, it's actually almost identical architecture to how NFTs on Solana work: the SPL Token Program manages the token mints, distribution, and transfers, and a separate metadata program is used to assign metadata to tokens. So the vulnerability we go through here could also be applied to real tokens.
+While this example is somewhat contrived, it's actually almost identical
+architecture to how NFTs on Solana work: the SPL Token Program manages the token
+mints, distribution, and transfers, and a separate metadata program is used to
+assign metadata to tokens. So the vulnerability we go through here could also be
+applied to real tokens.
 
 ### 1. Setup
 
-We'll start with the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/starter). Clone the repository and then open it on the `starter` branch.
+We'll start with the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/starter).
+Clone the repository and then open it on the `starter` branch.
 
 Notice that there are three programs:
 
@@ -171,18 +231,28 @@ Notice that there are three programs:
 
 Additionally, there is already a test in the `tests` directory.
 
-The first program, `gameplay`, is the one that our test directly uses. Take a look at the program. It has two instructions:
+The first program, `gameplay`, is the one that our test directly uses. Take a
+look at the program. It has two instructions:
 
-1. `create_character_insecure` - creates a new character and CPI's into the metadata program to set up the character's initial attributes
-2. `battle_insecure` - pits two characters against each other, assigning a "win" to the character with the highest attributes
+1. `create_character_insecure` - creates a new character and CPI's into the
+   metadata program to set up the character's initial attributes
+2. `battle_insecure` - pits two characters against each other, assigning a "win"
+   to the character with the highest attributes
 
-The second program, `character-metadata`, is meant to be the "approved" program for handling character metadata. Have a look at this program. It has a single instruction for `create_metadata` that creates a new PDA and assigns a pseudo-random value between 0 and 20 for the character's health and power.
+The second program, `character-metadata`, is meant to be the "approved" program
+for handling character metadata. Have a look at this program. It has a single
+instruction for `create_metadata` that creates a new PDA and assigns a
+pseudo-random value between 0 and 20 for the character's health and power.
 
-The last program, `fake-metadata` is a "fake" metadata program meant to illustrate what an attacker might make to exploit our `gameplay` program. This program is almost identical to the `character-metadata` program, only it assigns a character's initial health and power to be the max allowed: 255.
+The last program, `fake-metadata` is a "fake" metadata program meant to
+illustrate what an attacker might make to exploit our `gameplay` program. This
+program is almost identical to the `character-metadata` program, only it assigns
+a character's initial health and power to be the max allowed: 255.
 
 ### 2. Test `create_character_insecure` instruction
 
-There is already a test in the `tests` directory for this. It's long, but take a minute to look at it before we talk through it together:
+There is already a test in the `tests` directory for this. It's long, but take a
+minute to look at it before we talk through it together:
 
 ```ts
 it("Insecure instructions allow attacker to win every time", async () => {
@@ -237,19 +307,32 @@ it("Insecure instructions allow attacker to win every time", async () => {
 });
 ```
 
-This test effectively walks through the scenario where a regular player and an attacker both create their characters. Only the attacker passes in the program ID of the fake metadata program rather than the actual metadata program. And since the `create_character_insecure` instruction has no program checks, it still executes.
+This test effectively walks through the scenario where a regular player and an
+attacker both create their characters. Only the attacker passes in the program
+ID of the fake metadata program rather than the actual metadata program. And
+since the `create_character_insecure` instruction has no program checks, it
+still executes.
 
-The result is that the regular character has the appropriate amount of health and power: each a value between 0 and 20. But the attacker's health and power are each 255, making the attacker unbeatable.
+The result is that the regular character has the appropriate amount of health
+and power: each a value between 0 and 20. But the attacker's health and power
+are each 255, making the attacker unbeatable.
 
-If you haven't already, run `anchor test` to see that this test in fact behaves as described.
+If you haven't already, run `anchor test` to see that this test in fact behaves
+as described.
 
 ### 3. Create a `create_character_secure` instruction
 
-Let's fix this by creating a secure instruction for creating a new character. This instruction should implement proper program checks and use the `character-metadata` program's `cpi` crate to do the CPI rather than just using `invoke`.
+Let's fix this by creating a secure instruction for creating a new character.
+This instruction should implement proper program checks and use the
+`character-metadata` program's `cpi` crate to do the CPI rather than just using
+`invoke`.
 
 If you want to test out your skills, try this on your own before moving ahead.
 
-We'll start by updating our `use` statement at the top of the `gameplay` programs `lib.rs` file. We're giving ourselves access to the program's type for account validation, and the helper function for issuing the `create_metadata` CPI.
+We'll start by updating our `use` statement at the top of the `gameplay`
+programs `lib.rs` file. We're giving ourselves access to the program's type for
+account validation, and the helper function for issuing the `create_metadata`
+CPI.
 
 ```rust
 use character_metadata::{
@@ -259,7 +342,8 @@ use character_metadata::{
 };
 ```
 
-Next let's create a new account validation struct called `CreateCharacterSecure`. This time, we make `metadata_program` a `Program` type:
+Next let's create a new account validation struct called
+`CreateCharacterSecure`. This time, we make `metadata_program` a `Program` type:
 
 ```rust
 #[derive(Accounts)]
@@ -287,7 +371,9 @@ pub struct CreateCharacterSecure<'info> {
 }
 ```
 
-Lastly, we add the `create_character_secure` instruction. It will be the same as before but will use the full functionality of Anchor CPIs rather than using `invoke` directly:
+Lastly, we add the `create_character_secure` instruction. It will be the same as
+before but will use the full functionality of Anchor CPIs rather than using
+`invoke` directly:
 
 ```rust
 pub fn create_character_secure(ctx: Context<CreateCharacterSecure>) -> Result<()> {
@@ -314,7 +400,9 @@ pub fn create_character_secure(ctx: Context<CreateCharacterSecure>) -> Result<()
 
 ### 4. Test `create_character_secure`
 
-Now that we have a secure way of initializing a new character, let's create a new test. This test just needs to attempt to initialize the attacker's character and expect an error to be thrown.
+Now that we have a secure way of initializing a new character, let's create a
+new test. This test just needs to attempt to initialize the attacker's character
+and expect an error to be thrown.
 
 ```ts
 it("Secure character creation doesn't allow fake program", async () => {
@@ -334,7 +422,9 @@ it("Secure character creation doesn't allow fake program", async () => {
 });
 ```
 
-Run `anchor test` if you haven't already. Notice that an error was thrown as expected, detailing that the program ID passed into the instruction is not the expected program ID:
+Run `anchor test` if you haven't already. Notice that an error was thrown as
+expected, detailing that the program ID passed into the instruction is not the
+expected program ID:
 
 ```bash
 'Program log: AnchorError caused by account: metadata_program. Error Code: InvalidProgramId. Error Number: 3008. Error Message: Program ID was not as expected.',
@@ -346,14 +436,22 @@ Run `anchor test` if you haven't already. Notice that an error was thrown as exp
 
 That's all you need to do to protect against arbitrary CPIs!
 
-There may be times where you want more flexibility in your program's CPIs. We certainly won't stop you from architecting the program you need, but please take every precaution possible to ensure no vulnerabilities in your program.
+There may be times where you want more flexibility in your program's CPIs. We
+certainly won't stop you from architecting the program you need, but please take
+every precaution possible to ensure no vulnerabilities in your program.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the same repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that program checks are in place for every program passed into the instructions, particularly those that are invoked via CPI.
+Take some time to review at least one program and ensure that program checks are
+in place for every program passed into the instructions, particularly those that
+are invoked via CPI.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/bump-seed-canonicalization.md
+++ b/developers/courses/solana-course/content/bump-seed-canonicalization.md
@@ -1,18 +1,34 @@
 ---
 title: Bump Seed Canonicalization
 objectives:
-  - Explain the vulnerabilities associated with using PDAs derived without the canonical bump
-  - Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump
-  - Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA
+  - Explain the vulnerabilities associated with using PDAs derived without the
+    canonical bump
+  - Initialize a PDA using Anchor’s `seeds` and `bump` constraints to
+    automatically use the canonical bump
+  - Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is
+    always used in future instructions when deriving a PDA
 ---
 
 # TL;DR
 
-- The [**`create_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) function derives a PDA without searching for the **canonical bump**. This means there are multiple valid bumps, all of which will produce different addresses.
-- Using [**`find_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address) ensures that the highest valid bump, or canonical bump, is used for the derivation, thus creating a deterministic way to find an address given specific seeds.
-- Upon initialization, you can use Anchor's `seeds` and `bump` constraint to ensure that PDA derivations in the account validation struct always use the canonical bump
-- Anchor allows you to **specify a bump** with the `bump = <some_bump>` constraint when verifying the address of a PDA
-- Because `find_program_address` can be expensive, best practice is to store the derived bump in an account’s data field to be referenced later on when re-deriving the address for verification
+- The
+  [**`create_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address)
+  function derives a PDA without searching for the **canonical bump**. This
+  means there are multiple valid bumps, all of which will produce different
+  addresses.
+- Using
+  [**`find_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address)
+  ensures that the highest valid bump, or canonical bump, is used for the
+  derivation, thus creating a deterministic way to find an address given
+  specific seeds.
+- Upon initialization, you can use Anchor's `seeds` and `bump` constraint to
+  ensure that PDA derivations in the account validation struct always use the
+  canonical bump
+- Anchor allows you to **specify a bump** with the `bump = <some_bump>`
+  constraint when verifying the address of a PDA
+- Because `find_program_address` can be expensive, best practice is to store the
+  derived bump in an account’s data field to be referenced later on when
+  re-deriving the address for verification
   ```rust
   #[derive(Accounts)]
   pub struct VerifyAddress<'info> {
@@ -26,15 +42,31 @@ objectives:
 
 # Overview
 
-Bump seeds are a number between 0 and 255, inclusive, used to ensure that an address derived using [`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) is a valid PDA. The **canonical bump** is the highest bump value that produces a valid PDA. The standard in Solana is to _always use the canonical bump_ when deriving PDAs, both for security and convenience.
+Bump seeds are a number between 0 and 255, inclusive, used to ensure that an
+address derived using
+[`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address)
+is a valid PDA. The **canonical bump** is the highest bump value that produces a
+valid PDA. The standard in Solana is to _always use the canonical bump_ when
+deriving PDAs, both for security and convenience.
 
 ## Insecure PDA derivation using `create_program_address`
 
-Given a set of seeds, the `create_program_address` function will produce a valid PDA about 50% of the time. The bump seed is an additional byte added as a seed to "bump" the derived address into valid territory. Since there are 256 possible bump seeds and the function produces valid PDAs approximately 50% of the time, there are many valid bumps for a given set of input seeds.
+Given a set of seeds, the `create_program_address` function will produce a valid
+PDA about 50% of the time. The bump seed is an additional byte added as a seed
+to "bump" the derived address into valid territory. Since there are 256 possible
+bump seeds and the function produces valid PDAs approximately 50% of the time,
+there are many valid bumps for a given set of input seeds.
 
-You can imagine that this could cause confusion for locating accounts when using seeds as a way of mapping between known pieces of information to accounts. Using the canonical bump as the standard ensures that you can always find the right account. More importantly, it avoids security exploits caused by the open-ended nature of allowing multiple bumps.
+You can imagine that this could cause confusion for locating accounts when using
+seeds as a way of mapping between known pieces of information to accounts. Using
+the canonical bump as the standard ensures that you can always find the right
+account. More importantly, it avoids security exploits caused by the open-ended
+nature of allowing multiple bumps.
 
-In the example below, the `set_value` instruction uses a `bump` that was passed in as instruction data to derive a PDA. The instruction then derives the PDA using `create_program_address` function and checks that the `address` matches the public key of the `data` account.
+In the example below, the `set_value` instruction uses a `bump` that was passed
+in as instruction data to derive a PDA. The instruction then derives the PDA
+using `create_program_address` function and checks that the `address` matches
+the public key of the `data` account.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -69,17 +101,30 @@ pub struct Data {
 }
 ```
 
-While the instruction derives the PDA and checks the passed-in account, which is good, it allows the caller to pass in an arbitrary bump. Depending on the context of your program, this could result in undesired behavior or potential exploit.
+While the instruction derives the PDA and checks the passed-in account, which is
+good, it allows the caller to pass in an arbitrary bump. Depending on the
+context of your program, this could result in undesired behavior or potential
+exploit.
 
-If the seed mapping was meant to enforce a one-to-one relationship between PDA and user, for example, this program would not properly enforce that. A user could call the program multiple times with many valid bumps, each producing a different PDA.
+If the seed mapping was meant to enforce a one-to-one relationship between PDA
+and user, for example, this program would not properly enforce that. A user
+could call the program multiple times with many valid bumps, each producing a
+different PDA.
 
 ## Recommended derivation using `find_program_address`
 
-A simple way around this problem is to have the program expect only the canonical bump and use `find_program_address` to derive the PDA.
+A simple way around this problem is to have the program expect only the
+canonical bump and use `find_program_address` to derive the PDA.
 
-The [`find_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address) _always uses the canonical bump_. This function iterates through calling `create_program_address`, starting with a bump of 255 and decrementing the bump by one with each iteration. As soon as a valid address is found, the function returns both the derived PDA and the canonical bump used to derive it.
+The
+[`find_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address)
+_always uses the canonical bump_. This function iterates through calling
+`create_program_address`, starting with a bump of 255 and decrementing the bump
+by one with each iteration. As soon as a valid address is found, the function
+returns both the derived PDA and the canonical bump used to derive it.
 
-This ensures a one-to-one mapping between your input seeds and the address they produce.
+This ensures a one-to-one mapping between your input seeds and the address they
+produce.
 
 ```rust
 pub fn set_value_secure(
@@ -105,7 +150,13 @@ pub fn set_value_secure(
 
 ## Use Anchor’s `seeds` and `bump` constraints
 
-Anchor provides a convenient way to derive PDAs in the account validation struct using the `seeds` and `bump` constraints. These can even be combined with the `init` constraint to initialize the account at the intended address. To protect the program from the vulnerability we’ve been discussing throughout this lesson, Anchor does not even allow you to initialize an account at a PDA using anything but the canonical bump. Instead, it uses `find_program_address` to derive the PDA and subsequently performs the initialization.
+Anchor provides a convenient way to derive PDAs in the account validation struct
+using the `seeds` and `bump` constraints. These can even be combined with the
+`init` constraint to initialize the account at the intended address. To protect
+the program from the vulnerability we’ve been discussing throughout this lesson,
+Anchor does not even allow you to initialize an account at a PDA using anything
+but the canonical bump. Instead, it uses `find_program_address` to derive the
+PDA and subsequently performs the initialization.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -146,11 +197,22 @@ pub struct Data {
 }
 ```
 
-If you aren't initializing an account, you can still validate PDAs with the `seeds` and `bump` constraints. This simply rederives the PDA and compares the derived address with the address of the account passed in.
+If you aren't initializing an account, you can still validate PDAs with the
+`seeds` and `bump` constraints. This simply rederives the PDA and compares the
+derived address with the address of the account passed in.
 
-In this scenario, Anchor _does_ allow you to specify the bump to use to derive the PDA with `bump = <some_bump>`. The intent here is not for you to use arbitrary bumps, but rather to let you optimize your program. The iterative nature of `find_program_address` makes it expensive, so best practice is to store the canonical bump in the PDA account's data upon initializing a PDA, allowing you to reference the bump stored when validating the PDA in subsequent instructions.
+In this scenario, Anchor _does_ allow you to specify the bump to use to derive
+the PDA with `bump = <some_bump>`. The intent here is not for you to use
+arbitrary bumps, but rather to let you optimize your program. The iterative
+nature of `find_program_address` makes it expensive, so best practice is to
+store the canonical bump in the PDA account's data upon initializing a PDA,
+allowing you to reference the bump stored when validating the PDA in subsequent
+instructions.
 
-When you specify the bump to use, Anchor uses `create_program_address` with the provided bump instead of `find_program_address`. This pattern of storing the bump in the account data ensures that your program always uses the canonical bump without degrading performance.
+When you specify the bump to use, Anchor uses `create_program_address` with the
+provided bump instead of `find_program_address`. This pattern of storing the
+bump in the account data ensures that your program always uses the canonical
+bump without degrading performance.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -211,38 +273,59 @@ pub struct Data {
 }
 ```
 
-If you don't specify the bump on the `bump` constraint, Anchor will still use `find_program_address` to derive the PDA using the canonical bump. As a consequence, your instruction will incur a variable amount of compute budget. Programs that are already at risk of exceeding their compute budget should use this with care since there is a chance that the program’s budget may be occasionally and unpredictably exceeded.
+If you don't specify the bump on the `bump` constraint, Anchor will still use
+`find_program_address` to derive the PDA using the canonical bump. As a
+consequence, your instruction will incur a variable amount of compute budget.
+Programs that are already at risk of exceeding their compute budget should use
+this with care since there is a chance that the program’s budget may be
+occasionally and unpredictably exceeded.
 
-On the other hand, if you only need to verify the address of a PDA passed in without initializing an account, you'll be forced to either let Anchor derive the canonical bump or expose your program to unecessary risks. In that case, please use the canonical bump despite the slight mark against performance.
+On the other hand, if you only need to verify the address of a PDA passed in
+without initializing an account, you'll be forced to either let Anchor derive
+the canonical bump or expose your program to unecessary risks. In that case,
+please use the canonical bump despite the slight mark against performance.
 
 # Demo
 
-To demonstrate the security exploits possible when you don't check for the canonical bump, let's work with a program that lets each program user "claim" rewards on time.
+To demonstrate the security exploits possible when you don't check for the
+canonical bump, let's work with a program that lets each program user "claim"
+rewards on time.
 
 ### 1. Setup
 
-Start by getting the code on the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/starter).
+Start by getting the code on the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/starter).
 
-Notice that there are two instructions on the program and a single test in the `tests` directory.
+Notice that there are two instructions on the program and a single test in the
+`tests` directory.
 
 The instructions on the program are:
 
 1. `create_user_insecure`
 2. `claim_insecure`
 
-The `create_user_insecure` instruction simply creates a new account at a PDA derived using the signer's public key and a passed-in bump.
+The `create_user_insecure` instruction simply creates a new account at a PDA
+derived using the signer's public key and a passed-in bump.
 
-The `claim_insecure` instruction mints 10 tokens to the user and then marks the account's rewards as claimed so that they can't claim again.
+The `claim_insecure` instruction mints 10 tokens to the user and then marks the
+account's rewards as claimed so that they can't claim again.
 
-However, the program doesn't explicitly check that the PDAs in question are using the canonical bump.
+However, the program doesn't explicitly check that the PDAs in question are
+using the canonical bump.
 
 Have a look at the program to understand what it does before proceeding.
 
 ### 2. Test insecure instructions
 
-Since the instructions don't explicitly require the `user` PDA to use the canonical bump, an attacker can create multiple accounts per wallet and claim more rewards than should be allowed.
+Since the instructions don't explicitly require the `user` PDA to use the
+canonical bump, an attacker can create multiple accounts per wallet and claim
+more rewards than should be allowed.
 
-The test in the `tests` directory creates a new keypair called `attacker` to represent an attacker. It then loops through all possible bumps and calls `create_user_insecure` and `claim_insecure`. By the end, the test expects that the attacker has been able to claim rewards multiple times and has earned more than the 10 tokens allotted per user.
+The test in the `tests` directory creates a new keypair called `attacker` to
+represent an attacker. It then loops through all possible bumps and calls
+`create_user_insecure` and `claim_insecure`. By the end, the test expects that
+the attacker has been able to claim rewards multiple times and has earned more
+than the 10 tokens allotted per user.
 
 ```ts
 it("Attacker can claim more than reward limit with insecure instructions", async () => {
@@ -296,7 +379,9 @@ it("Attacker can claim more than reward limit with insecure instructions", async
 });
 ```
 
-Run `anchor test` to see that this test passes, showing that the attacker is successful. Since the test calles the instructions for every valid bump, it takes a bit to run, so be patient.
+Run `anchor test` to see that this test passes, showing that the attacker is
+successful. Since the test calles the instructions for every valid bump, it
+takes a bit to run, so be patient.
 
 ```bash
   bump-seed-canonicalization
@@ -311,7 +396,9 @@ Let's demonstrate patching the vulnerability by creating two new instructions:
 1. `create_user_secure`
 2. `claim_secure`
 
-Before we write the account validation or instruction logic, let's create a new user type, `UserSecure`. This new type will add the canonical bump as a field on the struct.
+Before we write the account validation or instruction logic, let's create a new
+user type, `UserSecure`. This new type will add the canonical bump as a field on
+the struct.
 
 ```rust
 #[account]
@@ -322,7 +409,9 @@ pub struct UserSecure {
 }
 ```
 
-Next, let's create account validation structs for each of the new instructions. They'll be very similar to the insecure versions but will let Anchor handle the derivation and deserialization of the PDAs.
+Next, let's create account validation structs for each of the new instructions.
+They'll be very similar to the insecure versions but will let Anchor handle the
+derivation and deserialization of the PDAs.
 
 ```rust
 #[derive(Accounts)]
@@ -371,7 +460,9 @@ pub struct SecureClaim<'info> {
 }
 ```
 
-Finally, let's implement the instruction logic for the two new instructions. The `create_user_secure` instruction simply needs to set the `auth`, `bump` and `rewards_claimed` fields on the `user` account data.
+Finally, let's implement the instruction logic for the two new instructions. The
+`create_user_secure` instruction simply needs to set the `auth`, `bump` and
+`rewards_claimed` fields on the `user` account data.
 
 ```rust
 pub fn create_user_secure(ctx: Context<CreateUserSecure>) -> Result<()> {
@@ -382,7 +473,8 @@ pub fn create_user_secure(ctx: Context<CreateUserSecure>) -> Result<()> {
 }
 ```
 
-The `claim_secure` instruction needs to mint 10 tokens to the user and set the `user` account's `rewards_claimed` field to `true`.
+The `claim_secure` instruction needs to mint 10 tokens to the user and set the
+`user` account's `rewards_claimed` field to `true`.
 
 ```rust
 pub fn claim_secure(ctx: Context<SecureClaim>) -> Result<()> {
@@ -410,9 +502,14 @@ pub fn claim_secure(ctx: Context<SecureClaim>) -> Result<()> {
 
 ### 4. Test secure instructions
 
-Let's go ahead and write a test to show that the attacker can no longer claim more than once using the new instructions.
+Let's go ahead and write a test to show that the attacker can no longer claim
+more than once using the new instructions.
 
-Notice that if you start to loop through using multiple PDAs like the old test, you can't even pass the non-canonical bump to the instructions. However, you can still loop through using the various PDAs and at the end check that only 1 claim happened for a total of 10 tokens. Your final test will look something like this:
+Notice that if you start to loop through using multiple PDAs like the old test,
+you can't even pass the non-canonical bump to the instructions. However, you can
+still loop through using the various PDAs and at the end check that only 1 claim
+happened for a total of 10 tokens. Your final test will look something like
+this:
 
 ```ts
 it.only("Attacker can only claim once with secure instructions", async () => {
@@ -489,14 +586,21 @@ Attacker claimed 119 times and got 1190 tokens
     ✔ Attacker can only claim once with secure instructions (1448ms)
 ```
 
-If you use Anchor for all of the PDA derivations, this particular exploit is pretty simple to avoid. However, if you end up doing anything "non-standard," be careful to design your program to explicitly use the canonical bump!
+If you use Anchor for all of the PDA derivations, this particular exploit is
+pretty simple to avoid. However, if you end up doing anything "non-standard," be
+careful to design your program to explicitly use the canonical bump!
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the same repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that all PDA derivations and checks are using the canonical bump.
+Take some time to review at least one program and ensure that all PDA
+derivations and checks are using the canonical bump.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/bump-seed-canonicalization.md
+++ b/developers/courses/solana-course/content/bump-seed-canonicalization.md
@@ -1,9 +1,9 @@
 ---
 title: Bump Seed Canonicalization
 objectives:
-- Explain the vulnerabilities associated with using PDAs derived without the canonical bump
-- Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump
-- Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA
+  - Explain the vulnerabilities associated with using PDAs derived without the canonical bump
+  - Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump
+  - Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA
 ---
 
 # TL;DR
@@ -13,20 +13,20 @@ objectives:
 - Upon initialization, you can use Anchor's `seeds` and `bump` constraint to ensure that PDA derivations in the account validation struct always use the canonical bump
 - Anchor allows you to **specify a bump** with the `bump = <some_bump>` constraint when verifying the address of a PDA
 - Because `find_program_address` can be expensive, best practice is to store the derived bump in an account’s data field to be referenced later on when re-deriving the address for verification
-    ```rust
-    #[derive(Accounts)]
-    pub struct VerifyAddress<'info> {
-    	#[account(
-        	seeds = [DATA_PDA_SEED.as_bytes()],
-    	    bump = data.bump
-    	)]
-    	data: Account<'info, Data>,
-    }
-    ```
+  ```rust
+  #[derive(Accounts)]
+  pub struct VerifyAddress<'info> {
+  	#[account(
+      	seeds = [DATA_PDA_SEED.as_bytes()],
+  	    bump = data.bump
+  	)]
+  	data: Account<'info, Data>,
+  }
+  ```
 
 # Overview
 
-Bump seeds are a number between 0 and 255, inclusive, used to ensure that an address derived using [`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) is a valid PDA. The **canonical bump** is the highest bump value that produces a valid PDA. The standard in Solana is to *always use the canonical bump* when deriving PDAs, both for security and convenience. 
+Bump seeds are a number between 0 and 255, inclusive, used to ensure that an address derived using [`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) is a valid PDA. The **canonical bump** is the highest bump value that produces a valid PDA. The standard in Solana is to _always use the canonical bump_ when deriving PDAs, both for security and convenience.
 
 ## Insecure PDA derivation using `create_program_address`
 
@@ -75,9 +75,9 @@ If the seed mapping was meant to enforce a one-to-one relationship between PDA a
 
 ## Recommended derivation using `find_program_address`
 
-A simple way around this problem is to have the program expect only the canonical bump and use `find_program_address` to derive the PDA. 
+A simple way around this problem is to have the program expect only the canonical bump and use `find_program_address` to derive the PDA.
 
-The [`find_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address) *always uses the canonical bump*. This function iterates through calling `create_program_address`, starting with a bump of 255 and decrementing the bump by one with each iteration. As soon as a valid address is found, the function returns both the derived PDA and the canonical bump used to derive it.
+The [`find_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address) _always uses the canonical bump_. This function iterates through calling `create_program_address`, starting with a bump of 255 and decrementing the bump by one with each iteration. As soon as a valid address is found, the function returns both the derived PDA and the canonical bump used to derive it.
 
 This ensures a one-to-one mapping between your input seeds and the address they produce.
 
@@ -148,7 +148,7 @@ pub struct Data {
 
 If you aren't initializing an account, you can still validate PDAs with the `seeds` and `bump` constraints. This simply rederives the PDA and compares the derived address with the address of the account passed in.
 
-In this scenario, Anchor *does* allow you to specify the bump to use to derive the PDA with `bump = <some_bump>`. The intent here is not for you to use arbitrary bumps, but rather to let you optimize your program. The iterative nature of `find_program_address` makes it expensive, so best practice is to store the canonical bump in the PDA account's data upon initializing a PDA, allowing you to reference the bump stored when validating the PDA in subsequent instructions.
+In this scenario, Anchor _does_ allow you to specify the bump to use to derive the PDA with `bump = <some_bump>`. The intent here is not for you to use arbitrary bumps, but rather to let you optimize your program. The iterative nature of `find_program_address` makes it expensive, so best practice is to store the canonical bump in the PDA account's data upon initializing a PDA, allowing you to reference the bump stored when validating the PDA in subsequent instructions.
 
 When you specify the bump to use, Anchor uses `create_program_address` with the provided bump instead of `find_program_address`. This pattern of storing the bump in the account data ensures that your program always uses the canonical bump without degrading performance.
 
@@ -230,7 +230,7 @@ The instructions on the program are:
 1. `create_user_insecure`
 2. `claim_insecure`
 
-The `create_user_insecure` instruction simply creates a new account at a PDA derived using the signer's public key and a passed-in bump. 
+The `create_user_insecure` instruction simply creates a new account at a PDA derived using the signer's public key and a passed-in bump.
 
 The `claim_insecure` instruction mints 10 tokens to the user and then marks the account's rewards as claimed so that they can't claim again.
 
@@ -246,56 +246,54 @@ The test in the `tests` directory creates a new keypair called `attacker` to rep
 
 ```ts
 it("Attacker can claim more than reward limit with insecure instructions", async () => {
-    const attacker = Keypair.generate()
-    await safeAirdrop(attacker.publicKey, provider.connection)
-    const ataKey = await getAssociatedTokenAddress(mint, attacker.publicKey)
+  const attacker = Keypair.generate();
+  await safeAirdrop(attacker.publicKey, provider.connection);
+  const ataKey = await getAssociatedTokenAddress(mint, attacker.publicKey);
 
-    let numClaims = 0
+  let numClaims = 0;
 
-    for (let i = 0; i < 256; i++) {
-      try {
-        const pda = createProgramAddressSync(
-          [attacker.publicKey.toBuffer(), Buffer.from([i])],
-          program.programId
-        )
-        await program.methods
-          .createUserInsecure(i)
-          .accounts({
-            user: pda,
-            payer: attacker.publicKey,
-          })
-          .signers([attacker])
-          .rpc()
-        await program.methods
-          .claimInsecure(i)
-          .accounts({
-            user: pda,
-            mint,
-            payer: attacker.publicKey,
-            userAta: ataKey,
-          })
-          .signers([attacker])
-          .rpc()
+  for (let i = 0; i < 256; i++) {
+    try {
+      const pda = createProgramAddressSync(
+        [attacker.publicKey.toBuffer(), Buffer.from([i])],
+        program.programId,
+      );
+      await program.methods
+        .createUserInsecure(i)
+        .accounts({
+          user: pda,
+          payer: attacker.publicKey,
+        })
+        .signers([attacker])
+        .rpc();
+      await program.methods
+        .claimInsecure(i)
+        .accounts({
+          user: pda,
+          mint,
+          payer: attacker.publicKey,
+          userAta: ataKey,
+        })
+        .signers([attacker])
+        .rpc();
 
-        numClaims += 1
-      } catch (error) {
-        if (
-          error.message !== "Invalid seeds, address must fall off the curve"
-        ) {
-          console.log(error)
-        }
+      numClaims += 1;
+    } catch (error) {
+      if (error.message !== "Invalid seeds, address must fall off the curve") {
+        console.log(error);
       }
     }
+  }
 
-    const ata = await getAccount(provider.connection, ataKey)
+  const ata = await getAccount(provider.connection, ataKey);
 
-    console.log(
-      `Attacker claimed ${numClaims} times and got ${Number(ata.amount)} tokens`
-    )
+  console.log(
+    `Attacker claimed ${numClaims} times and got ${Number(ata.amount)} tokens`,
+  );
 
-    expect(numClaims).to.be.greaterThan(1)
-    expect(Number(ata.amount)).to.be.greaterThan(10)
-})
+  expect(numClaims).to.be.greaterThan(1);
+  expect(Number(ata.amount)).to.be.greaterThan(10);
+});
 ```
 
 Run `anchor test` to see that this test passes, showing that the attacker is successful. Since the test calles the instructions for every valid bump, it takes a bit to run, so be patient.
@@ -418,70 +416,70 @@ Notice that if you start to loop through using multiple PDAs like the old test, 
 
 ```ts
 it.only("Attacker can only claim once with secure instructions", async () => {
-    const attacker = Keypair.generate()
-    await safeAirdrop(attacker.publicKey, provider.connection)
-    const ataKey = await getAssociatedTokenAddress(mint, attacker.publicKey)
-    const [userPDA] = findProgramAddressSync(
-      [attacker.publicKey.toBuffer()],
-      program.programId
-    )
+  const attacker = Keypair.generate();
+  await safeAirdrop(attacker.publicKey, provider.connection);
+  const ataKey = await getAssociatedTokenAddress(mint, attacker.publicKey);
+  const [userPDA] = findProgramAddressSync(
+    [attacker.publicKey.toBuffer()],
+    program.programId,
+  );
 
-    await program.methods
-      .createUserSecure()
-      .accounts({
-        payer: attacker.publicKey,
-      })
-      .signers([attacker])
-      .rpc()
+  await program.methods
+    .createUserSecure()
+    .accounts({
+      payer: attacker.publicKey,
+    })
+    .signers([attacker])
+    .rpc();
 
-    await program.methods
-      .claimSecure()
-      .accounts({
-        payer: attacker.publicKey,
-        userAta: ataKey,
-        mint,
-        user: userPDA,
-      })
-      .signers([attacker])
-      .rpc()
+  await program.methods
+    .claimSecure()
+    .accounts({
+      payer: attacker.publicKey,
+      userAta: ataKey,
+      mint,
+      user: userPDA,
+    })
+    .signers([attacker])
+    .rpc();
 
-    let numClaims = 1
+  let numClaims = 1;
 
-    for (let i = 0; i < 256; i++) {
-      try {
-        const pda = createProgramAddressSync(
-          [attacker.publicKey.toBuffer(), Buffer.from([i])],
-          program.programId
-        )
-        await program.methods
-          .createUserSecure()
-          .accounts({
-            user: pda,
-            payer: attacker.publicKey,
-          })
-          .signers([attacker])
-          .rpc()
+  for (let i = 0; i < 256; i++) {
+    try {
+      const pda = createProgramAddressSync(
+        [attacker.publicKey.toBuffer(), Buffer.from([i])],
+        program.programId,
+      );
+      await program.methods
+        .createUserSecure()
+        .accounts({
+          user: pda,
+          payer: attacker.publicKey,
+        })
+        .signers([attacker])
+        .rpc();
 
-        await program.methods
-          .claimSecure()
-          .accounts({
-            payer: attacker.publicKey,
-            userAta: ataKey,
-            mint,
-            user: pda,
-          })
-          .signers([attacker])
-          .rpc()
+      await program.methods
+        .claimSecure()
+        .accounts({
+          payer: attacker.publicKey,
+          userAta: ataKey,
+          mint,
+          user: pda,
+        })
+        .signers([attacker])
+        .rpc();
 
-        numClaims += 1
-      } catch {}
-    }
+      numClaims += 1;
+    } catch {}
+  }
 
-    const ata = await getAccount(provider.connection, ataKey)
+  const ata = await getAccount(provider.connection, ataKey);
 
-    expect(Number(ata.amount)).to.equal(10)
-    expect(numClaims).to.equal(1)
-})
+  expect(Number(ata.amount)).to.equal(10);
+  expect(numClaims).to.equal(1);
+});
 ```
 
 ```bash

--- a/developers/courses/solana-course/content/closing-accounts.md
+++ b/developers/courses/solana-course/content/closing-accounts.md
@@ -1,16 +1,23 @@
 ---
 title: Closing Accounts and Revival Attacks
 objectives:
-  - Explain the various security vulnerabilities associated with closing program accounts incorrectly
+  - Explain the various security vulnerabilities associated with closing program
+    accounts incorrectly
   - Close program accounts safely and securely using native Rust
-  - Close program accounts safely and securely using the Anchor `close` constraint
+  - Close program accounts safely and securely using the Anchor `close`
+    constraint
 ---
 
 # TL;DR
 
-- **Closing an account** improperly creates an opportunity for reinitialization/revival attacks
-- The Solana runtime **garbage collects accounts** when they are no longer rent exempt. Closing accounts involves transferring the lamports stored in the account for rent exemption to another account of your choosing.
-- You can use the Anchor `#[account(close = <address_to_send_lamports>)]` constraint to securely close accounts and set the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`
+- **Closing an account** improperly creates an opportunity for
+  reinitialization/revival attacks
+- The Solana runtime **garbage collects accounts** when they are no longer rent
+  exempt. Closing accounts involves transferring the lamports stored in the
+  account for rent exemption to another account of your choosing.
+- You can use the Anchor `#[account(close = <address_to_send_lamports>)]`
+  constraint to securely close accounts and set the account discriminator to the
+  `CLOSED_ACCOUNT_DISCRIMINATOR`
   ```rust
   #[account(mut, close = receiver)]
   pub data_account: Account<'info, MyData>,
@@ -20,20 +27,29 @@ objectives:
 
 # Overview
 
-While it sounds simple, closing accounts properly can be tricky. There are a number of ways an attacker could circumvent having the account closed if you don't follow specific steps.
+While it sounds simple, closing accounts properly can be tricky. There are a
+number of ways an attacker could circumvent having the account closed if you
+don't follow specific steps.
 
-To get a better understanding of these attack vectors, let’s explore each of these scenarios in depth.
+To get a better understanding of these attack vectors, let’s explore each of
+these scenarios in depth.
 
 ## Insecure account closing
 
-At its core, closing an account involves transferring its lamports to a separate account, thus triggering the Solana runtime to garbage collect the first account. This resets the owner from the owning program to the system program.
+At its core, closing an account involves transferring its lamports to a separate
+account, thus triggering the Solana runtime to garbage collect the first
+account. This resets the owner from the owning program to the system program.
 
 Take a look at the example below. The instruction requires two accounts:
 
 1. `account_to_close` - the account to be closed
 2. `destination` - the account that should receive the closed account’s lamports
 
-The program logic is intended to close an account by simply increasing the `destination` account’s lamports by the amount stored in the `account_to_close` and setting the `account_to_close` lamports to 0. With this program, after a full transaction is processed, the `account_to_close` will be garbage collected by the runtime.
+The program logic is intended to close an account by simply increasing the
+`destination` account’s lamports by the amount stored in the `account_to_close`
+and setting the `account_to_close` lamports to 0. With this program, after a
+full transaction is processed, the `account_to_close` will be garbage collected
+by the runtime.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -68,17 +84,36 @@ pub struct Data {
 }
 ```
 
-However, the garbage collection doesn't occur until the transaction completes. And since there can be multiple instructions in a transaction, this creates an opportunity for an attacker to invoke the instruction to close the account but also include in the transaction a transfer to refund the account's rent exemption lamports. The result is that the account _will not_ be garbage collected, opening up a path for the attacker to cause unintended behavior in the program and even drain a protocol.
+However, the garbage collection doesn't occur until the transaction completes.
+And since there can be multiple instructions in a transaction, this creates an
+opportunity for an attacker to invoke the instruction to close the account but
+also include in the transaction a transfer to refund the account's rent
+exemption lamports. The result is that the account _will not_ be garbage
+collected, opening up a path for the attacker to cause unintended behavior in
+the program and even drain a protocol.
 
 ## Secure account closing
 
-The two most important things you can do to close this loophole are to zero out the account data and add an account discriminator that represents the account has been closed. You need _both_ of these things to avoid unintended program behavior.
+The two most important things you can do to close this loophole are to zero out
+the account data and add an account discriminator that represents the account
+has been closed. You need _both_ of these things to avoid unintended program
+behavior.
 
-An account with zeroed out data can still be used for some things, especially if it's a PDA whose address derivation is used within the program for verification purposes. However, the damage may be potentially limited if the attacker can't access the previously-stored data.
+An account with zeroed out data can still be used for some things, especially if
+it's a PDA whose address derivation is used within the program for verification
+purposes. However, the damage may be potentially limited if the attacker can't
+access the previously-stored data.
 
-To further secure the program, however, closed accounts should be given an account discriminator that designates it as "closed," and all instructions should perform checks on all passed-in accounts that return an error if the account is marked closed.
+To further secure the program, however, closed accounts should be given an
+account discriminator that designates it as "closed," and all instructions
+should perform checks on all passed-in accounts that return an error if the
+account is marked closed.
 
-Look at the example below. This program transfers the lamports out of an account, zeroes out the account data, and sets an account discriminator in a single instruction in hopes of preventing a subsequent instruction from utilizing this account again before it has been garbage collected. Failing to do any one of these things would result in a security vulnerability.
+Look at the example below. This program transfers the lamports out of an
+account, zeroes out the account data, and sets an account discriminator in a
+single instruction in hopes of preventing a subsequent instruction from
+utilizing this account again before it has been garbage collected. Failing to do
+any one of these things would result in a security vulnerability.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -128,13 +163,26 @@ pub struct Data {
 }
 ```
 
-Note that the example above is using Anchor's `CLOSED_ACCOUNT_DISCRIMINATOR`. This is simply an account discriminator where each byte is `255`. The discriminator doesn't have any inherent meaning, but if you couple it with account validation checks that return errors any time an account with this discriminator is passed to an instruction, you'll stop your program from unintentionally processing an instruction with a closed account.
+Note that the example above is using Anchor's `CLOSED_ACCOUNT_DISCRIMINATOR`.
+This is simply an account discriminator where each byte is `255`. The
+discriminator doesn't have any inherent meaning, but if you couple it with
+account validation checks that return errors any time an account with this
+discriminator is passed to an instruction, you'll stop your program from
+unintentionally processing an instruction with a closed account.
 
 ### Manual Force Defund
 
-There is still one small issue. While the practice of zeroing out account data and adding a "closed" account discriminator will stop your program from being exploited, a user can still keep an account from being garbage collected by refunding the account's lamports before the end of an instruction. This results in one or potentially many accounts existing in a limbo state where they cannot be used but also cannot be garbage collected.
+There is still one small issue. While the practice of zeroing out account data
+and adding a "closed" account discriminator will stop your program from being
+exploited, a user can still keep an account from being garbage collected by
+refunding the account's lamports before the end of an instruction. This results
+in one or potentially many accounts existing in a limbo state where they cannot
+be used but also cannot be garbage collected.
 
-To handle this edge case, you may consider adding an instruction that will allow _anyone_ to defund accounts tagged with the "closed" account discriminator. The only account validation this instruction would perform is to ensure that the account being defunded is marked as closed. It may look something like this:
+To handle this edge case, you may consider adding an instruction that will allow
+_anyone_ to defund accounts tagged with the "closed" account discriminator. The
+only account validation this instruction would perform is to ensure that the
+account being defunded is marked as closed. It may look something like this:
 
 ```rust
 use anchor_lang::__private::CLOSED_ACCOUNT_DISCRIMINATOR;
@@ -175,19 +223,25 @@ pub struct ForceDefund<'info> {
 }
 ```
 
-Since anyone can call this instruction, this can act as a deterrent to attempted revival attacks since the attacker is paying for account rent exemption but anyone else can claim the lamports in a refunded account for themselves.
+Since anyone can call this instruction, this can act as a deterrent to attempted
+revival attacks since the attacker is paying for account rent exemption but
+anyone else can claim the lamports in a refunded account for themselves.
 
-While not necessary, this can help eliminate the waste of space and lamports associated with these "limbo" accounts.
+While not necessary, this can help eliminate the waste of space and lamports
+associated with these "limbo" accounts.
 
 ## Use the Anchor `close` constraint
 
-Fortunately, Anchor makes all of this much simpler with the `#[account(close = <target_account>)]` constraint. This constraint handles everything required to securely close an account:
+Fortunately, Anchor makes all of this much simpler with the
+`#[account(close = <target_account>)]` constraint. This constraint handles
+everything required to securely close an account:
 
 1. Transfers the account’s lamports to the given `<target_account>`
 2. Zeroes out the account data
 3. Sets the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR` variant
 
-All you have to do is add it in the account validation struct to the account you want closed:
+All you have to do is add it in the account validation struct to the account you
+want closed:
 
 ```rust
 #[derive(Accounts)]
@@ -202,40 +256,62 @@ pub struct CloseAccount {
 }
 ```
 
-The `force_defund` instruction is an optional addition that you’ll have to implement on your own if you’d like to utilize it.
+The `force_defund` instruction is an optional addition that you’ll have to
+implement on your own if you’d like to utilize it.
 
 # Demo
 
-To clarify how an attacker might take advantage of a revival attack, let's work with a simple lottery program that uses program account state to manage a user's participation in the lottery.
+To clarify how an attacker might take advantage of a revival attack, let's work
+with a simple lottery program that uses program account state to manage a user's
+participation in the lottery.
 
 ## 1. Setup
 
-Start by getting the code on the `starter` branch from the [following repo](https://github.com/Unboxed-Software/solana-closing-accounts/tree/starter).
+Start by getting the code on the `starter` branch from the
+[following repo](https://github.com/Unboxed-Software/solana-closing-accounts/tree/starter).
 
-The code has two instructions on the program and two tests in the `tests` directory.
+The code has two instructions on the program and two tests in the `tests`
+directory.
 
 The program instructions are:
 
 1. `enter_lottery`
 2. `redeem_rewards_insecure`
 
-When a user calls `enter_lottery`, the program will initialize an account to store some state about the user's lottery entry.
+When a user calls `enter_lottery`, the program will initialize an account to
+store some state about the user's lottery entry.
 
-Since this is a simplified example rather than a fully-fledge lottery program, once a user has entered the lottery they can call the `redeem_rewards_insecure` instruction at any time. This instruction will mint the user an amount of Reward tokens proportional to the amount of times the user has entered the lottery. After minting the rewards, the program closes the user's lottery entry.
+Since this is a simplified example rather than a fully-fledge lottery program,
+once a user has entered the lottery they can call the `redeem_rewards_insecure`
+instruction at any time. This instruction will mint the user an amount of Reward
+tokens proportional to the amount of times the user has entered the lottery.
+After minting the rewards, the program closes the user's lottery entry.
 
-Take a minute to familiarize yourself with the program code. The `enter_lottery` instruction simply creates an account at a PDA mapped to the user and initializes some state on it.
+Take a minute to familiarize yourself with the program code. The `enter_lottery`
+instruction simply creates an account at a PDA mapped to the user and
+initializes some state on it.
 
-The `redeem_rewards_insecure` instruction performs some account and data validation, mints tokens to the given token account, then closes the lottery account by removing its lamports.
+The `redeem_rewards_insecure` instruction performs some account and data
+validation, mints tokens to the given token account, then closes the lottery
+account by removing its lamports.
 
-However, notice the `redeem_rewards_insecure` instruction _only_ transfers out the account's lamports, leaving the account open to revival attacks.
+However, notice the `redeem_rewards_insecure` instruction _only_ transfers out
+the account's lamports, leaving the account open to revival attacks.
 
 ## 2. Test Insecure Program
 
-An attacker that successfully keeps their account from closing can then call `redeem_rewards_insecure` multiple times, claiming more rewards than they are owed.
+An attacker that successfully keeps their account from closing can then call
+`redeem_rewards_insecure` multiple times, claiming more rewards than they are
+owed.
 
-Some starter tests have already been written that showcase this vulnerability. Take a look at the `closing-accounts.ts` file in the `tests` directory. There is some setup in the `before` function, then a test that simply creates a new lottery entry for `attacker`.
+Some starter tests have already been written that showcase this vulnerability.
+Take a look at the `closing-accounts.ts` file in the `tests` directory. There is
+some setup in the `before` function, then a test that simply creates a new
+lottery entry for `attacker`.
 
-Finally, there's a test that demonstrates how an attacker can keep the account alive even after claiming rewards and then claim rewards again. That test looks like this:
+Finally, there's a test that demonstrates how an attacker can keep the account
+alive even after claiming rewards and then claim rewards again. That test looks
+like this:
 
 ```typescript
 it("attacker  can close + refund lottery acct + claim multiple rewards", async () => {
@@ -289,16 +365,23 @@ it("attacker  can close + refund lottery acct + claim multiple rewards", async (
 This test does the following:
 
 1. Calls `redeem_rewards_insecure` to redeem the user's rewards
-2. In the same transaction, adds an instruction to refund the user's `lottery_entry` before it can actually be closed
+2. In the same transaction, adds an instruction to refund the user's
+   `lottery_entry` before it can actually be closed
 3. Successfully repeats steps 1 and 2, redeeming rewards for a second time.
 
-You can theoretically repeat steps 1-2 infinitely until either a) the program has no more rewards to give or b) someone notices and patches the exploit. This would obviously be a severe problem in any real program as it allows a malicious attacker to drain an entire rewards pool.
+You can theoretically repeat steps 1-2 infinitely until either a) the program
+has no more rewards to give or b) someone notices and patches the exploit. This
+would obviously be a severe problem in any real program as it allows a malicious
+attacker to drain an entire rewards pool.
 
 ## 3. Create a `redeem_rewards_secure` instruction
 
-To prevent this from happening we're going to create a new instruction that closes the lottery account seucrely using the Anchor `close` constraint. Feel free to try this out on your own if you'd like.
+To prevent this from happening we're going to create a new instruction that
+closes the lottery account seucrely using the Anchor `close` constraint. Feel
+free to try this out on your own if you'd like.
 
-The new account validation struct called `RedeemWinningsSecure` should look like this:
+The new account validation struct called `RedeemWinningsSecure` should look like
+this:
 
 ```rust
 #[derive(Accounts)]
@@ -334,9 +417,16 @@ pub struct RedeemWinningsSecure<'info> {
 }
 ```
 
-It should be the exact same as the original `RedeemWinnings` account validation struct, except there is an additional `close = user` constraint on the `lottery_entry` account. This will tell Anchor to close the account by zeroing out the data, transferring its lamports to the `user` account, and setting the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`. This last step is what will prevent the account from being used again if the program has attempted to close it already.
+It should be the exact same as the original `RedeemWinnings` account validation
+struct, except there is an additional `close = user` constraint on the
+`lottery_entry` account. This will tell Anchor to close the account by zeroing
+out the data, transferring its lamports to the `user` account, and setting the
+account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`. This last step is
+what will prevent the account from being used again if the program has attempted
+to close it already.
 
-Then, we can create a `mint_ctx` method on the new `RedeemWinningsSecure` struct to help with the minting CPI to the token program.
+Then, we can create a `mint_ctx` method on the new `RedeemWinningsSecure` struct
+to help with the minting CPI to the token program.
 
 ```Rust
 impl<'info> RedeemWinningsSecure <'info> {
@@ -374,11 +464,14 @@ pub fn redeem_winnings_secure(ctx: Context<RedeemWinningsSecure>) -> Result<()> 
 }
 ```
 
-This logic simply calculates the rewards for the claiming user and transfers the rewards. However, because of the `close` constraint in the account validation struct, the attacker shouldn't be able to call this instruction multiple times.
+This logic simply calculates the rewards for the claiming user and transfers the
+rewards. However, because of the `close` constraint in the account validation
+struct, the attacker shouldn't be able to call this instruction multiple times.
 
 ## 4. Test the Program
 
-To test our new secure instruction, let's create a new test that trys to call `redeemingWinningsSecure` twice. We expect the second call to throw an error.
+To test our new secure instruction, let's create a new test that trys to call
+`redeemingWinningsSecure` twice. We expect the second call to throw an error.
 
 ```typescript
 it("attacker cannot claim multiple rewards with secure claim", async () => {
@@ -434,7 +527,8 @@ it("attacker cannot claim multiple rewards with secure claim", async () => {
 });
 ```
 
-Run `anchor test` to see that the test passes. The output will look something like this:
+Run `anchor test` to see that the test passes. The output will look something
+like this:
 
 ```bash
   closing-accounts
@@ -444,16 +538,26 @@ AnchorError caused by account: lottery_entry. Error Code: AccountDiscriminatorMi
     ✔ attacker cannot claim multiple rewards with secure claim (414ms)
 ```
 
-Note, this does not prevent the malicious user from refunding their account altogether - it just protects our program from accidentally re-using the account when it should be closed. We haven't implemented a `force_defund` instruction so far, but we could. If you're feeling up for it, give it a try yourself!
+Note, this does not prevent the malicious user from refunding their account
+altogether - it just protects our program from accidentally re-using the account
+when it should be closed. We haven't implemented a `force_defund` instruction so
+far, but we could. If you're feeling up for it, give it a try yourself!
 
-The simplest and most secure way to close accounts is using Anchor's `close` constraint. If you ever need more custom behavior and can't use this constraint, make sure to replicate its functionality to ensure your program is secure.
+The simplest and most secure way to close accounts is using Anchor's `close`
+constraint. If you ever need more custom behavior and can't use this constraint,
+make sure to replicate its functionality to ensure your program is secure.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-closing-accounts/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the same repository](https://github.com/Unboxed-Software/solana-closing-accounts/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that when accounts are closed they're not susceptible to revival attacks.
+Take some time to review at least one program and ensure that when accounts are
+closed they're not susceptible to revival attacks.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/closing-accounts.md
+++ b/developers/courses/solana-course/content/closing-accounts.md
@@ -1,9 +1,9 @@
 ---
 title: Closing Accounts and Revival Attacks
 objectives:
-- Explain the various security vulnerabilities associated with closing program accounts incorrectly
-- Close program accounts safely and securely using native Rust
-- Close program accounts safely and securely using the Anchor `close` constraint
+  - Explain the various security vulnerabilities associated with closing program accounts incorrectly
+  - Close program accounts safely and securely using native Rust
+  - Close program accounts safely and securely using the Anchor `close` constraint
 ---
 
 # TL;DR
@@ -11,12 +11,12 @@ objectives:
 - **Closing an account** improperly creates an opportunity for reinitialization/revival attacks
 - The Solana runtime **garbage collects accounts** when they are no longer rent exempt. Closing accounts involves transferring the lamports stored in the account for rent exemption to another account of your choosing.
 - You can use the Anchor `#[account(close = <address_to_send_lamports>)]` constraint to securely close accounts and set the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`
-    ```rust
-    #[account(mut, close = receiver)]
-    pub data_account: Account<'info, MyData>,
-    #[account(mut)]
-    pub receiver: SystemAccount<'info>
-    ```
+  ```rust
+  #[account(mut, close = receiver)]
+  pub data_account: Account<'info, MyData>,
+  #[account(mut)]
+  pub receiver: SystemAccount<'info>
+  ```
 
 # Overview
 
@@ -68,11 +68,11 @@ pub struct Data {
 }
 ```
 
-However, the garbage collection doesn't occur until the transaction completes. And since there can be multiple instructions in a transaction, this creates an opportunity for an attacker to invoke the instruction to close the account but also include in the transaction a transfer to refund the account's rent exemption lamports. The result is that the account *will not* be garbage collected, opening up a path for the attacker to cause unintended behavior in the program and even drain a protocol.
+However, the garbage collection doesn't occur until the transaction completes. And since there can be multiple instructions in a transaction, this creates an opportunity for an attacker to invoke the instruction to close the account but also include in the transaction a transfer to refund the account's rent exemption lamports. The result is that the account _will not_ be garbage collected, opening up a path for the attacker to cause unintended behavior in the program and even drain a protocol.
 
 ## Secure account closing
 
-The two most important things you can do to close this loophole are to zero out the account data and add an account discriminator that represents the account has been closed. You need *both* of these things to avoid unintended program behavior.
+The two most important things you can do to close this loophole are to zero out the account data and add an account discriminator that represents the account has been closed. You need _both_ of these things to avoid unintended program behavior.
 
 An account with zeroed out data can still be used for some things, especially if it's a PDA whose address derivation is used within the program for verification purposes. However, the damage may be potentially limited if the attacker can't access the previously-stored data.
 
@@ -134,7 +134,7 @@ Note that the example above is using Anchor's `CLOSED_ACCOUNT_DISCRIMINATOR`. Th
 
 There is still one small issue. While the practice of zeroing out account data and adding a "closed" account discriminator will stop your program from being exploited, a user can still keep an account from being garbage collected by refunding the account's lamports before the end of an instruction. This results in one or potentially many accounts existing in a limbo state where they cannot be used but also cannot be garbage collected.
 
-To handle this edge case, you may consider adding an instruction that will allow *anyone* to defund accounts tagged with the "closed" account discriminator. The only account validation this instruction would perform is to ensure that the account being defunded is marked as closed. It may look something like this:
+To handle this edge case, you may consider adding an instruction that will allow _anyone_ to defund accounts tagged with the "closed" account discriminator. The only account validation this instruction would perform is to ensure that the account being defunded is marked as closed. It may look something like this:
 
 ```rust
 use anchor_lang::__private::CLOSED_ACCOUNT_DISCRIMINATOR;
@@ -193,7 +193,7 @@ All you have to do is add it in the account validation struct to the account you
 #[derive(Accounts)]
 pub struct CloseAccount {
     #[account(
-        mut, 
+        mut,
         close = receiver
     )]
     pub data_account: Account<'info, MyData>,
@@ -227,7 +227,7 @@ Take a minute to familiarize yourself with the program code. The `enter_lottery`
 
 The `redeem_rewards_insecure` instruction performs some account and data validation, mints tokens to the given token account, then closes the lottery account by removing its lamports.
 
-However, notice the `redeem_rewards_insecure` instruction *only* transfers out the account's lamports, leaving the account open to revival attacks.
+However, notice the `redeem_rewards_insecure` instruction _only_ transfers out the account's lamports, leaving the account open to revival attacks.
 
 ## 2. Test Insecure Program
 
@@ -239,54 +239,55 @@ Finally, there's a test that demonstrates how an attacker can keep the account a
 
 ```typescript
 it("attacker  can close + refund lottery acct + claim multiple rewards", async () => {
-    // claim multiple times
-    for (let i = 0; i < 2; i++) {
-      const tx = new Transaction()
-      // instruction claims rewards, program will try to close account
-      tx.add(
-        await program.methods
-          .redeemWinningsInsecure()
-          .accounts({
-            lotteryEntry: attackerLotteryEntry,
-            user: attacker.publicKey,
-            userAta: attackerAta,
-            rewardMint: rewardMint,
-            mintAuth: mintAuth,
-            tokenProgram: TOKEN_PROGRAM_ID,
-          })
-          .instruction()
-      )
-
-      // user adds instruction to refund dataAccount lamports
-      const rentExemptLamports =
-        await provider.connection.getMinimumBalanceForRentExemption(
-          82,
-          "confirmed"
-        )
-      tx.add(
-        SystemProgram.transfer({
-          fromPubkey: attacker.publicKey,
-          toPubkey: attackerLotteryEntry,
-          lamports: rentExemptLamports,
+  // claim multiple times
+  for (let i = 0; i < 2; i++) {
+    const tx = new Transaction();
+    // instruction claims rewards, program will try to close account
+    tx.add(
+      await program.methods
+        .redeemWinningsInsecure()
+        .accounts({
+          lotteryEntry: attackerLotteryEntry,
+          user: attacker.publicKey,
+          userAta: attackerAta,
+          rewardMint: rewardMint,
+          mintAuth: mintAuth,
+          tokenProgram: TOKEN_PROGRAM_ID,
         })
-      )
-      // send tx
-      await sendAndConfirmTransaction(provider.connection, tx, [attacker])
-      await new Promise((x) => setTimeout(x, 5000))
-    }
+        .instruction(),
+    );
 
-    const ata = await getAccount(provider.connection, attackerAta)
-    const lotteryEntry = await program.account.lotteryAccount.fetch(
-      attackerLotteryEntry
-    )
+    // user adds instruction to refund dataAccount lamports
+    const rentExemptLamports =
+      await provider.connection.getMinimumBalanceForRentExemption(
+        82,
+        "confirmed",
+      );
+    tx.add(
+      SystemProgram.transfer({
+        fromPubkey: attacker.publicKey,
+        toPubkey: attackerLotteryEntry,
+        lamports: rentExemptLamports,
+      }),
+    );
+    // send tx
+    await sendAndConfirmTransaction(provider.connection, tx, [attacker]);
+    await new Promise(x => setTimeout(x, 5000));
+  }
 
-    expect(Number(ata.amount)).to.equal(
-      lotteryEntry.timestamp.toNumber() * 10 * 2
-    )
-})
+  const ata = await getAccount(provider.connection, attackerAta);
+  const lotteryEntry = await program.account.lotteryAccount.fetch(
+    attackerLotteryEntry,
+  );
+
+  expect(Number(ata.amount)).to.equal(
+    lotteryEntry.timestamp.toNumber() * 10 * 2,
+  );
+});
 ```
 
 This test does the following:
+
 1. Calls `redeem_rewards_insecure` to redeem the user's rewards
 2. In the same transaction, adds an instruction to refund the user's `lottery_entry` before it can actually be closed
 3. Successfully repeats steps 1 and 2, redeeming rewards for a second time.
@@ -381,56 +382,56 @@ To test our new secure instruction, let's create a new test that trys to call `r
 
 ```typescript
 it("attacker cannot claim multiple rewards with secure claim", async () => {
-    const tx = new Transaction()
-    // instruction claims rewards, program will try to close account
-    tx.add(
-      await program.methods
-        .redeemWinningsSecure()
-        .accounts({
-          lotteryEntry: attackerLotteryEntry,
-          user: attacker.publicKey,
-          userAta: attackerAta,
-          rewardMint: rewardMint,
-          mintAuth: mintAuth,
-          tokenProgram: TOKEN_PROGRAM_ID,
-        })
-        .instruction()
-    )
-
-    // user adds instruction to refund dataAccount lamports
-    const rentExemptLamports =
-      await provider.connection.getMinimumBalanceForRentExemption(
-        82,
-        "confirmed"
-      )
-    tx.add(
-      SystemProgram.transfer({
-        fromPubkey: attacker.publicKey,
-        toPubkey: attackerLotteryEntry,
-        lamports: rentExemptLamports,
+  const tx = new Transaction();
+  // instruction claims rewards, program will try to close account
+  tx.add(
+    await program.methods
+      .redeemWinningsSecure()
+      .accounts({
+        lotteryEntry: attackerLotteryEntry,
+        user: attacker.publicKey,
+        userAta: attackerAta,
+        rewardMint: rewardMint,
+        mintAuth: mintAuth,
+        tokenProgram: TOKEN_PROGRAM_ID,
       })
-    )
-    // send tx
-    await sendAndConfirmTransaction(provider.connection, tx, [attacker])
+      .instruction(),
+  );
 
-    try {
-      await program.methods
-        .redeemWinningsSecure()
-        .accounts({
-          lotteryEntry: attackerLotteryEntry,
-          user: attacker.publicKey,
-          userAta: attackerAta,
-          rewardMint: rewardMint,
-          mintAuth: mintAuth,
-          tokenProgram: TOKEN_PROGRAM_ID,
-        })
-        .signers([attacker])
-        .rpc()
-    } catch (error) {
-      console.log(error.message)
-      expect(error)
-    }
-})
+  // user adds instruction to refund dataAccount lamports
+  const rentExemptLamports =
+    await provider.connection.getMinimumBalanceForRentExemption(
+      82,
+      "confirmed",
+    );
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: attacker.publicKey,
+      toPubkey: attackerLotteryEntry,
+      lamports: rentExemptLamports,
+    }),
+  );
+  // send tx
+  await sendAndConfirmTransaction(provider.connection, tx, [attacker]);
+
+  try {
+    await program.methods
+      .redeemWinningsSecure()
+      .accounts({
+        lotteryEntry: attackerLotteryEntry,
+        user: attacker.publicKey,
+        userAta: attackerAta,
+        rewardMint: rewardMint,
+        mintAuth: mintAuth,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([attacker])
+      .rpc();
+  } catch (error) {
+    console.log(error.message);
+    expect(error);
+  }
+});
 ```
 
 Run `anchor test` to see that the test passes. The output will look something like this:

--- a/developers/courses/solana-course/content/cpi.md
+++ b/developers/courses/solana-course/content/cpi.md
@@ -1,10 +1,10 @@
 ---
 title: Cross Program Invocations
 objectives:
-- Explain Cross-Program Invocations (CPIs)
-- Describe how to construct and use CPIs
-- Explain how a program provides a signature for a PDA
-- Avoid common pitfalls and troubleshoot common errors associated with CPIs
+  - Explain Cross-Program Invocations (CPIs)
+  - Describe how to construct and use CPIs
+  - Explain how a program provides a signature for a PDA
+  - Avoid common pitfalls and troubleshoot common errors associated with CPIs
 ---
 
 # TL;DR
@@ -19,7 +19,6 @@ objectives:
 ## What is a CPI?
 
 A Cross-Program Invocation (CPI) is a direct call from one program into another. Just as any client can call any program using the JSON RPC, any program can call any other program directly. The only requirement for invoking an instruction on another program from within your program is that you construct the instruction correctly. You can make CPIs to native programs, other programs you've created, and third party programs. CPIs essentially turn the entire Solana ecosystem into one giant API that is at your disposal as a developer.
-
 
 CPIs have a similar make up to instructions that you are used to creating client side. There are some intricacies and differences depending on if you are using `invoke` or `invoke_signed`. We'll be covering both of these later in this lesson.
 
@@ -73,7 +72,6 @@ pub struct Instruction {
 }
 ```
 
-
 Depending on the program you're making the call to, there may be a crate available with helper functions for creating the `Instruction` object. Many individuals and organizations create publicly available crates alongside their programs that expose these sorts of functions to simplify calling their programs. This is similar to the Typescript libraries we've used in this course (e.g. [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/), [@solana/spl-token](https://solana-labs.github.io/solana-program-library/token/js/)). For example, in this lesson's demo we'll be using the `spl_token` crate to create minting instructions.
 In all other cases, you'll need to create the `Instruction` instance from scratch.
 
@@ -88,9 +86,7 @@ assert_eq!(v[1], 2);
 assert_eq!(v[2], 3);
 ```
 
-
 The `accounts` field of the `Instruction` struct expects a vector of type [`AccountMeta`](https://docs.rs/solana-program/latest/solana_program/instruction/struct.AccountMeta.html). The `AccountMeta` struct has the following definition:
-
 
 ```rust
 pub struct AccountMeta {
@@ -113,9 +109,7 @@ vec![
 ]
 ```
 
-
 The final field of the instruction object is the data, as a byte buffer of course. You can create a byte buffer in Rust using the `vec` macro again, which has an implemented function allowing you to create a vector of certain length. Once you have initialized an empty vector, you would construct the byte buffer similar to how you would client-side. Determine the data required by the callee program and the serialization format used and write your code to match. Feel free to read up on some of the [features of the `vec` macro available to you here](https://doc.rust-lang.org/alloc/vec/struct.Vec.html#).
-
 
 ```rust
 let mut vec = Vec::with_capacity(3);
@@ -157,9 +151,7 @@ There's no need to include a signature because the Solana runtime passes along t
 
 ### CPI with `invoke_signed`
 
-
 Using `invoke_signed` is a little different just because there is an additional field that requires the seeds used to derive any PDAs that must sign the transaction. You may recall from previous lessons that PDAs do not lie on the Ed25519 curve and, therefore, do not have a corresponding private key. You’ve been told that programs can provide signatures for their PDAs, but have not learned how that actually happens - until now. Programs provide signatures for their PDAs with the `invoke_signed` function. The first two fields of `invoke_signed` are the same as `invoke`, but there is an additional `signers_seeds` field that comes into play here.
-
 
 ```rust
 invoke_signed(
@@ -174,7 +166,6 @@ invoke_signed(
 While PDAs have no private keys of their own, they can be used by a program to issue an instruction that includes the PDA as a signer. The only way for the runtime to verify that the PDA belongs to the calling program is for the calling program to supply the seeds used to generate the address in the `signers_seeds` field.
 
 The Solana runtime will internally call [`create_program_address`](https://docs.rs/solana-program/1.4.4/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) using the seeds provided and the `program_id` of the calling program. It can then compare the result against the addresses supplied in the instruction. If any of the addresses match, then the runtime knows that indeed the program associated with this address is the caller and thus is authorized to be a signer.
-
 
 ## Best Practices and common pitfalls
 
@@ -210,8 +201,7 @@ To see this in action, view this [transaction in the explorer](https://explorer.
 
 CPIs are a very important feature of the Solana ecosystem and they make all programs deployed interoperable with each other. With CPIs there is no need to re-invent the wheel when it comes to development. This creates the opportunity for building new protocols and applications on top of what’s already been built, just like building blocks or Lego bricks. It’s important to remember that CPIs are a two-way street and the same is true for any programs that you deploy! If you build something cool and useful, developers have the ability to build on top of what you’ve done or just plug your protocol into whatever it is that they are building. Composability is a big part of what makes crypto so unique and CPIs are what makes this possible on Solana.
 
-
-Another important aspect of CPIs is that they allow programs to sign for their PDAs. As you have probably noticed by now, PDAs are used very frequently in Solana development because they allow programs to control specific addresses in such a way that no external user can generate transactions with valid signatures for those addresses. This can be *very* useful for many applications in Web3 (e.g. DeFi, NFTs, etc.) Without CPIs, PDAs would not be nearly as useful because there would be no way for a program to sign transactions involving them - essentially turning them black holes (once something is sent to a PDA, there would be no way to get it back out w/o CPIs!)
+Another important aspect of CPIs is that they allow programs to sign for their PDAs. As you have probably noticed by now, PDAs are used very frequently in Solana development because they allow programs to control specific addresses in such a way that no external user can generate transactions with valid signatures for those addresses. This can be _very_ useful for many applications in Web3 (e.g. DeFi, NFTs, etc.) Without CPIs, PDAs would not be nearly as useful because there would be no way for a program to sign transactions involving them - essentially turning them black holes (once something is sent to a PDA, there would be no way to get it back out w/o CPIs!)
 
 # Demo
 

--- a/developers/courses/solana-course/content/cpi.md
+++ b/developers/courses/solana-course/content/cpi.md
@@ -9,22 +9,43 @@ objectives:
 
 # TL;DR
 
-- A **Cross-Program Invocation (CPI)** is a call from one program to another, targeting a specific instruction on the program called
-- CPIs are made using the commands `invoke` or `invoke_signed`, the latter being how programs provide signatures for PDAs that they own
-- CPIs make programs in the Solana ecosystem completely interoperable because all public instructions of a program can be invoked by another program via a CPI
-- Because we have no control over the accounts and data submitted to a program, it's important to verify all of the parameters passed into a CPI to ensure program security
+- A **Cross-Program Invocation (CPI)** is a call from one program to another,
+  targeting a specific instruction on the program called
+- CPIs are made using the commands `invoke` or `invoke_signed`, the latter being
+  how programs provide signatures for PDAs that they own
+- CPIs make programs in the Solana ecosystem completely interoperable because
+  all public instructions of a program can be invoked by another program via a
+  CPI
+- Because we have no control over the accounts and data submitted to a program,
+  it's important to verify all of the parameters passed into a CPI to ensure
+  program security
 
 # Overview
 
 ## What is a CPI?
 
-A Cross-Program Invocation (CPI) is a direct call from one program into another. Just as any client can call any program using the JSON RPC, any program can call any other program directly. The only requirement for invoking an instruction on another program from within your program is that you construct the instruction correctly. You can make CPIs to native programs, other programs you've created, and third party programs. CPIs essentially turn the entire Solana ecosystem into one giant API that is at your disposal as a developer.
+A Cross-Program Invocation (CPI) is a direct call from one program into another.
+Just as any client can call any program using the JSON RPC, any program can call
+any other program directly. The only requirement for invoking an instruction on
+another program from within your program is that you construct the instruction
+correctly. You can make CPIs to native programs, other programs you've created,
+and third party programs. CPIs essentially turn the entire Solana ecosystem into
+one giant API that is at your disposal as a developer.
 
-CPIs have a similar make up to instructions that you are used to creating client side. There are some intricacies and differences depending on if you are using `invoke` or `invoke_signed`. We'll be covering both of these later in this lesson.
+CPIs have a similar make up to instructions that you are used to creating client
+side. There are some intricacies and differences depending on if you are using
+`invoke` or `invoke_signed`. We'll be covering both of these later in this
+lesson.
 
 ## How to make a CPI
 
-CPIs are made using the [`invoke`](https://docs.rs/solana-program/1.10.19/solana_program/program/fn.invoke.html) or [`invoke_signed`](https://docs.rs/solana-program/1.10.19/solana_program/program/fn.invoke_signed.html) function from the `solana_program` crate. You use `invoke` to essentially pass through the original transaction signature that was passed into your program. You use `invoke_signed` to have your program "sign" for its PDAs.
+CPIs are made using the
+[`invoke`](https://docs.rs/solana-program/1.10.19/solana_program/program/fn.invoke.html)
+or
+[`invoke_signed`](https://docs.rs/solana-program/1.10.19/solana_program/program/fn.invoke_signed.html)
+function from the `solana_program` crate. You use `invoke` to essentially pass
+through the original transaction signature that was passed into your program.
+You use `invoke_signed` to have your program "sign" for its PDAs.
 
 ```rust
 // Used when there are not signatures for PDAs needed
@@ -41,9 +62,14 @@ pub fn invoke_signed(
 ) -> ProgramResult
 ```
 
-CPIs extend the privileges of the caller to the callee. If the instruction the callee program is processing contains an account that was marked as a signer or writable when originally passed into the caller program, then it will be considered a signer or writable account in the invoked program as well.
+CPIs extend the privileges of the caller to the callee. If the instruction the
+callee program is processing contains an account that was marked as a signer or
+writable when originally passed into the caller program, then it will be
+considered a signer or writable account in the invoked program as well.
 
-It's important to note that you as the developer decide which accounts to pass into the CPI. You can think of a CPI as building another instruction from scratch with only information that was passed into your program.
+It's important to note that you as the developer decide which accounts to pass
+into the CPI. You can think of a CPI as building another instruction from
+scratch with only information that was passed into your program.
 
 ### CPI with `invoke`
 
@@ -59,8 +85,10 @@ invoke(
 ```
 
 - `program_id` - the public key of the program you are going to invoke
-- `account` - a list of account metadata as a vector. You need to include every account that the invoked program will read from or write to
-- `data` - a byte buffer representing the data being passed to the callee program as a vector
+- `account` - a list of account metadata as a vector. You need to include every
+  account that the invoked program will read from or write to
+- `data` - a byte buffer representing the data being passed to the callee
+  program as a vector
 
 The `Instruction` type has the following definition:
 
@@ -72,12 +100,23 @@ pub struct Instruction {
 }
 ```
 
-Depending on the program you're making the call to, there may be a crate available with helper functions for creating the `Instruction` object. Many individuals and organizations create publicly available crates alongside their programs that expose these sorts of functions to simplify calling their programs. This is similar to the Typescript libraries we've used in this course (e.g. [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/), [@solana/spl-token](https://solana-labs.github.io/solana-program-library/token/js/)). For example, in this lesson's demo we'll be using the `spl_token` crate to create minting instructions.
-In all other cases, you'll need to create the `Instruction` instance from scratch.
+Depending on the program you're making the call to, there may be a crate
+available with helper functions for creating the `Instruction` object. Many
+individuals and organizations create publicly available crates alongside their
+programs that expose these sorts of functions to simplify calling their
+programs. This is similar to the Typescript libraries we've used in this course
+(e.g. [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/),
+[@solana/spl-token](https://solana-labs.github.io/solana-program-library/token/js/)).
+For example, in this lesson's demo we'll be using the `spl_token` crate to
+create minting instructions. In all other cases, you'll need to create the
+`Instruction` instance from scratch.
 
-While the `program_id` field is fairly straightforward, the `accounts` and `data` fields require some explanation.
+While the `program_id` field is fairly straightforward, the `accounts` and
+`data` fields require some explanation.
 
-Both the `accounts` and `data` fields are of type `Vec`, or vector. You can use the [`vec`](https://doc.rust-lang.org/std/macro.vec.html) macro to construct a vector using array notation, like so:
+Both the `accounts` and `data` fields are of type `Vec`, or vector. You can use
+the [`vec`](https://doc.rust-lang.org/std/macro.vec.html) macro to construct a
+vector using array notation, like so:
 
 ```rust
 let v = vec![1, 2, 3];
@@ -86,7 +125,9 @@ assert_eq!(v[1], 2);
 assert_eq!(v[2], 3);
 ```
 
-The `accounts` field of the `Instruction` struct expects a vector of type [`AccountMeta`](https://docs.rs/solana-program/latest/solana_program/instruction/struct.AccountMeta.html). The `AccountMeta` struct has the following definition:
+The `accounts` field of the `Instruction` struct expects a vector of type
+[`AccountMeta`](https://docs.rs/solana-program/latest/solana_program/instruction/struct.AccountMeta.html).
+The `AccountMeta` struct has the following definition:
 
 ```rust
 pub struct AccountMeta {
@@ -109,7 +150,14 @@ vec![
 ]
 ```
 
-The final field of the instruction object is the data, as a byte buffer of course. You can create a byte buffer in Rust using the `vec` macro again, which has an implemented function allowing you to create a vector of certain length. Once you have initialized an empty vector, you would construct the byte buffer similar to how you would client-side. Determine the data required by the callee program and the serialization format used and write your code to match. Feel free to read up on some of the [features of the `vec` macro available to you here](https://doc.rust-lang.org/alloc/vec/struct.Vec.html#).
+The final field of the instruction object is the data, as a byte buffer of
+course. You can create a byte buffer in Rust using the `vec` macro again, which
+has an implemented function allowing you to create a vector of certain length.
+Once you have initialized an empty vector, you would construct the byte buffer
+similar to how you would client-side. Determine the data required by the callee
+program and the serialization format used and write your code to match. Feel
+free to read up on some of the
+[features of the `vec` macro available to you here](https://doc.rust-lang.org/alloc/vec/struct.Vec.html#).
 
 ```rust
 let mut vec = Vec::with_capacity(3);
@@ -118,15 +166,31 @@ vec.push(2);
 vec.extend_from_slice(&number_variable.to_le_bytes());
 ```
 
-The [`extend_from_slice`](https://doc.rust-lang.org/alloc/vec/struct.Vec.html#method.extend_from_slice) method is probably new to you. It's a method on vectors that takes a slice as input, iterates over the slice, clones each element, and then appends it to the `Vec`.
+The
+[`extend_from_slice`](https://doc.rust-lang.org/alloc/vec/struct.Vec.html#method.extend_from_slice)
+method is probably new to you. It's a method on vectors that takes a slice as
+input, iterates over the slice, clones each element, and then appends it to the
+`Vec`.
 
 ### Pass a list of accounts
 
-In addition to the instruction, both `invoke` and `invoke_signed` also require a list of `account_info` objects. Just like the list of `AccountMeta` objects you added to the instruction, you must include all of the accounts that the program you're calling will read from or write to.
+In addition to the instruction, both `invoke` and `invoke_signed` also require a
+list of `account_info` objects. Just like the list of `AccountMeta` objects you
+added to the instruction, you must include all of the accounts that the program
+you're calling will read from or write to.
 
-By the time you make a CPI in your program, you should have already grabbed all the `account_info` objects that were passed into your program and stored them in variables. You'll construct your list of `account_info` objects for the CPI by choosing which of these accounts to copy and send along.
+By the time you make a CPI in your program, you should have already grabbed all
+the `account_info` objects that were passed into your program and stored them in
+variables. You'll construct your list of `account_info` objects for the CPI by
+choosing which of these accounts to copy and send along.
 
-You can copy each `account_info` object that you need to pass into the CPI using the [`Clone`](https://docs.rs/solana-program/1.10.19/solana_program/account_info/struct.AccountInfo.html#impl-Clone) trait that is implemented on the `account_info` struct in the `solana_program` crate. This `Clone` trait returns a copy of the [`account_info`](https://docs.rs/solana-program/1.10.19/solana_program/account_info/struct.AccountInfo.html) instance.
+You can copy each `account_info` object that you need to pass into the CPI using
+the
+[`Clone`](https://docs.rs/solana-program/1.10.19/solana_program/account_info/struct.AccountInfo.html#impl-Clone)
+trait that is implemented on the `account_info` struct in the `solana_program`
+crate. This `Clone` trait returns a copy of the
+[`account_info`](https://docs.rs/solana-program/1.10.19/solana_program/account_info/struct.AccountInfo.html)
+instance.
 
 ```rust
 &[first_account.clone(), second_account.clone(), third_account.clone()]
@@ -134,7 +198,8 @@ You can copy each `account_info` object that you need to pass into the CPI using
 
 ### CPI with `invoke`
 
-With both the instruction and the list of accounts created, you can perform a call to `invoke`.
+With both the instruction and the list of accounts created, you can perform a
+call to `invoke`.
 
 ```rust
 invoke(
@@ -147,11 +212,22 @@ invoke(
 )?;
 ```
 
-There's no need to include a signature because the Solana runtime passes along the original signature passed into your program. Remember, `invoke` won't work if a signature is required on behalf of a PDA. For that, you'll need to use `invoke_signed`.
+There's no need to include a signature because the Solana runtime passes along
+the original signature passed into your program. Remember, `invoke` won't work
+if a signature is required on behalf of a PDA. For that, you'll need to use
+`invoke_signed`.
 
 ### CPI with `invoke_signed`
 
-Using `invoke_signed` is a little different just because there is an additional field that requires the seeds used to derive any PDAs that must sign the transaction. You may recall from previous lessons that PDAs do not lie on the Ed25519 curve and, therefore, do not have a corresponding private key. You’ve been told that programs can provide signatures for their PDAs, but have not learned how that actually happens - until now. Programs provide signatures for their PDAs with the `invoke_signed` function. The first two fields of `invoke_signed` are the same as `invoke`, but there is an additional `signers_seeds` field that comes into play here.
+Using `invoke_signed` is a little different just because there is an additional
+field that requires the seeds used to derive any PDAs that must sign the
+transaction. You may recall from previous lessons that PDAs do not lie on the
+Ed25519 curve and, therefore, do not have a corresponding private key. You’ve
+been told that programs can provide signatures for their PDAs, but have not
+learned how that actually happens - until now. Programs provide signatures for
+their PDAs with the `invoke_signed` function. The first two fields of
+`invoke_signed` are the same as `invoke`, but there is an additional
+`signers_seeds` field that comes into play here.
 
 ```rust
 invoke_signed(
@@ -163,79 +239,157 @@ invoke_signed(
 )?;
 ```
 
-While PDAs have no private keys of their own, they can be used by a program to issue an instruction that includes the PDA as a signer. The only way for the runtime to verify that the PDA belongs to the calling program is for the calling program to supply the seeds used to generate the address in the `signers_seeds` field.
+While PDAs have no private keys of their own, they can be used by a program to
+issue an instruction that includes the PDA as a signer. The only way for the
+runtime to verify that the PDA belongs to the calling program is for the calling
+program to supply the seeds used to generate the address in the `signers_seeds`
+field.
 
-The Solana runtime will internally call [`create_program_address`](https://docs.rs/solana-program/1.4.4/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) using the seeds provided and the `program_id` of the calling program. It can then compare the result against the addresses supplied in the instruction. If any of the addresses match, then the runtime knows that indeed the program associated with this address is the caller and thus is authorized to be a signer.
+The Solana runtime will internally
+call [`create_program_address`](https://docs.rs/solana-program/1.4.4/solana_program/pubkey/struct.Pubkey.html#method.create_program_address)
+using the seeds provided and the `program_id` of the calling program. It can
+then compare the result against the addresses supplied in the instruction. If
+any of the addresses match, then the runtime knows that indeed the program
+associated with this address is the caller and thus is authorized to be a
+signer.
 
 ## Best Practices and common pitfalls
 
 ### Security checks
 
-There are some common mistakes and things to remember when utilizing CPIs that are important to your program’s security and robustness. The first thing to remember is that, as we know by now, we have no control over what information is passed into our programs. For this reason, it’s important to always verify the `program_id`, accounts, and data passed into the CPI. Without these security checks, someone could submit a transaction that invokes an instruction on a completely different program than was expected, which is not ideal.
+There are some common mistakes and things to remember when utilizing CPIs that
+are important to your program’s security and robustness. The first thing to
+remember is that, as we know by now, we have no control over what information is
+passed into our programs. For this reason, it’s important to always verify the
+`program_id`, accounts, and data passed into the CPI. Without these security
+checks, someone could submit a transaction that invokes an instruction on a
+completely different program than was expected, which is not ideal.
 
-Fortunately, there are inherent checks on the validity of any PDAs that are marked as signers within the `invoke_signed` function. All other accounts and `instruction_data` should be verified somewhere in your program code before making the CPI. It's also important to make sure you’re targeting the intended instruction on the program you are invoking. The easiest way to do this is to read the source code of the program you will be invoking just as you would if you were constructing an instruction from the client side.
+Fortunately, there are inherent checks on the validity of any PDAs that are
+marked as signers within the `invoke_signed` function. All other accounts and
+`instruction_data` should be verified somewhere in your program code before
+making the CPI. It's also important to make sure you’re targeting the intended
+instruction on the program you are invoking. The easiest way to do this is to
+read the source code of the program you will be invoking just as you would if
+you were constructing an instruction from the client side.
 
 ### Common errors
 
-There are some common errors you might receive when executing a CPI, they usually mean you are constructing the CPI with incorrect information. For example, you may come across an error message similar to this:
+There are some common errors you might receive when executing a CPI, they
+usually mean you are constructing the CPI with incorrect information. For
+example, you may come across an error message similar to this:
 
 ```text
 EF1M4SPfKcchb6scq297y8FPCaLvj5kGjwMzjTM68wjA's signer privilege escalated
 Program returned error: "Cross-program invocation with unauthorized signer or writable account"
 ```
 
-This message is a little misleading, because “signer privilege escalated” does not seem like a problem but, in reality, it means that you are incorrectly signing for the address in the message. If you are using `invoke_signed` and receive this error, then it likely means that the seeds you are providing are incorrect. An example transaction that failed with this error can be found [here](https://explorer.solana.com/tx/3mxbShkerH9ZV1rMmvDfaAhLhJJqrmMjcsWzanjkARjBQurhf4dounrDCUkGunH1p9M4jEwef9parueyHVw6r2Et?cluster=devnet).
+This message is a little misleading, because “signer privilege escalated” does
+not seem like a problem but, in reality, it means that you are incorrectly
+signing for the address in the message. If you are using `invoke_signed` and
+receive this error, then it likely means that the seeds you are providing are
+incorrect. An example transaction that failed with this error can be found
+[here](https://explorer.solana.com/tx/3mxbShkerH9ZV1rMmvDfaAhLhJJqrmMjcsWzanjkARjBQurhf4dounrDCUkGunH1p9M4jEwef9parueyHVw6r2Et?cluster=devnet).
 
-Another similar error is thrown when an account that's written to isn't marked as `writable` inside the `AccountMeta` struct.
+Another similar error is thrown when an account that's written to isn't marked
+as `writable` inside the `AccountMeta` struct.
 
 ```text
 2qoeXa9fo8xVHzd2h9mVcueh6oK3zmAiJxCTySM5rbLZ's writable privilege escalated
 Program returned error: "Cross-program invocation with unauthorized signer or writable account"
 ```
 
-Remember, any account whose data may be mutated by the program during execution must be specified as writable. During execution, writing to an account that was not specified as writable will cause the transaction to fail. Writing to an account that is not owned by the program will cause the transaction to fail. Any account whose lamport balance may be mutated by the program during execution must be specified as writable. During execution, mutating the lamports of an account that was not specified as writable will cause the transaction to fail. While subtracting lamports from an account not owned by the program will cause the transaction to fail, adding lamports to any account is allowed, as long is it is mutable.
+Remember, any account whose data may be mutated by the program during execution
+must be specified as writable. During execution, writing to an account that was
+not specified as writable will cause the transaction to fail. Writing to an
+account that is not owned by the program will cause the transaction to fail. Any
+account whose lamport balance may be mutated by the program during execution
+must be specified as writable. During execution, mutating the lamports of an
+account that was not specified as writable will cause the transaction to fail.
+While subtracting lamports from an account not owned by the program will cause
+the transaction to fail, adding lamports to any account is allowed, as long is
+it is mutable.
 
-To see this in action, view this [transaction in the explorer](https://explorer.solana.com/tx/ExB9YQJiSzTZDBqx4itPaa4TpT8VK4Adk7GU5pSoGEzNz9fa7PPZsUxssHGrBbJRnCvhoKgLCWnAycFB7VYDbBg?cluster=devnet).
+To see this in action, view this
+[transaction in the explorer](https://explorer.solana.com/tx/ExB9YQJiSzTZDBqx4itPaa4TpT8VK4Adk7GU5pSoGEzNz9fa7PPZsUxssHGrBbJRnCvhoKgLCWnAycFB7VYDbBg?cluster=devnet).
 
 ## Why CPIs matter?
 
-CPIs are a very important feature of the Solana ecosystem and they make all programs deployed interoperable with each other. With CPIs there is no need to re-invent the wheel when it comes to development. This creates the opportunity for building new protocols and applications on top of what’s already been built, just like building blocks or Lego bricks. It’s important to remember that CPIs are a two-way street and the same is true for any programs that you deploy! If you build something cool and useful, developers have the ability to build on top of what you’ve done or just plug your protocol into whatever it is that they are building. Composability is a big part of what makes crypto so unique and CPIs are what makes this possible on Solana.
+CPIs are a very important feature of the Solana ecosystem and they make all
+programs deployed interoperable with each other. With CPIs there is no need to
+re-invent the wheel when it comes to development. This creates the opportunity
+for building new protocols and applications on top of what’s already been built,
+just like building blocks or Lego bricks. It’s important to remember that CPIs
+are a two-way street and the same is true for any programs that you deploy! If
+you build something cool and useful, developers have the ability to build on top
+of what you’ve done or just plug your protocol into whatever it is that they are
+building. Composability is a big part of what makes crypto so unique and CPIs
+are what makes this possible on Solana.
 
-Another important aspect of CPIs is that they allow programs to sign for their PDAs. As you have probably noticed by now, PDAs are used very frequently in Solana development because they allow programs to control specific addresses in such a way that no external user can generate transactions with valid signatures for those addresses. This can be _very_ useful for many applications in Web3 (e.g. DeFi, NFTs, etc.) Without CPIs, PDAs would not be nearly as useful because there would be no way for a program to sign transactions involving them - essentially turning them black holes (once something is sent to a PDA, there would be no way to get it back out w/o CPIs!)
+Another important aspect of CPIs is that they allow programs to sign for their
+PDAs. As you have probably noticed by now, PDAs are used very frequently in
+Solana development because they allow programs to control specific addresses in
+such a way that no external user can generate transactions with valid signatures
+for those addresses. This can be _very_ useful for many applications in Web3
+(e.g. DeFi, NFTs, etc.) Without CPIs, PDAs would not be nearly as useful because
+there would be no way for a program to sign transactions involving them -
+essentially turning them black holes (once something is sent to a PDA, there
+would be no way to get it back out w/o CPIs!)
 
 # Demo
 
-Now let's get some hands on experience with CPIs by making some additions to the Movie Review program again. If you're dropping into this lesson without having gone through prior lessons, the Movie Review program allows users to submit movie reviews and have them stored in PDA accounts.
+Now let's get some hands on experience with CPIs by making some additions to the
+Movie Review program again. If you're dropping into this lesson without having
+gone through prior lessons, the Movie Review program allows users to submit
+movie reviews and have them stored in PDA accounts.
 
-Last lesson, we added the ability to leave comments on other movie reviews using PDAs. In this lesson, we’re going to work on having the program mint tokens to the reviewer or commenter anytime a review or comment is submitted.
+Last lesson, we added the ability to leave comments on other movie reviews using
+PDAs. In this lesson, we’re going to work on having the program mint tokens to
+the reviewer or commenter anytime a review or comment is submitted.
 
-To implement this, we'll have to invoke the SPL Token Program's `MintTo` instruction using a CPI. If you need a refresher on tokens, token mints, and minting new tokens, have a look at the [Token Program lesson](./token-program.md) before moving forward with this demo.
+To implement this, we'll have to invoke the SPL Token Program's `MintTo`
+instruction using a CPI. If you need a refresher on tokens, token mints, and
+minting new tokens, have a look at the
+[Token Program lesson](./token-program.md) before moving forward with this demo.
 
 ### 1. Get starter code and add dependencies
 
-To get started, we will be using the final state of the Movie Review program from the previous PDA lesson. So, if you just completed that lesson then you’re all set and ready to go. If you are just jumping in here, no worries, you can [download the starter code here](https://github.com/Unboxed-Software/solana-movie-program/tree/solution-add-comments). We'll be using the `solution-add-comments` branch as our starting point.
+To get started, we will be using the final state of the Movie Review program
+from the previous PDA lesson. So, if you just completed that lesson then you’re
+all set and ready to go. If you are just jumping in here, no worries, you can
+[download the starter code here](https://github.com/Unboxed-Software/solana-movie-program/tree/solution-add-comments).
+We'll be using the `solution-add-comments` branch as our starting point.
 
 ### 2. Add dependencies to `Cargo.toml`
 
-Before we get started we need to add two new dependencies to the `Cargo.toml` file underneath `[dependencies]`. We'll be using the `spl-token` and `spl-associated-token-account` crates in addition to the existing dependencies.
+Before we get started we need to add two new dependencies to the `Cargo.toml`
+file underneath `[dependencies]`. We'll be using the `spl-token` and
+`spl-associated-token-account` crates in addition to the existing dependencies.
 
 ```text
 spl-token = { version="~3.2.0", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version="=1.0.5", features = [ "no-entrypoint" ] }
 ```
 
-After adding the above, run `cargo check` in your console to have cargo resolve your dependencies and ensure that you are ready to continue. Depending on your setup you may need to modify crate versions before moving on.
+After adding the above, run `cargo check` in your console to have cargo resolve
+your dependencies and ensure that you are ready to continue. Depending on your
+setup you may need to modify crate versions before moving on.
 
 ### 3. Add necessary accounts to `add_movie_review`
 
-Because we want users to be minted tokens upon creating a review, it makes sense to add minting logic inside the `add_movie_review` function. Since we'll be minting tokens, the `add_movie_review` instruction requires a few new accounts to be passed in:
+Because we want users to be minted tokens upon creating a review, it makes sense
+to add minting logic inside the `add_movie_review` function. Since we'll be
+minting tokens, the `add_movie_review` instruction requires a few new accounts
+to be passed in:
 
 - `token_mint` - the mint address of the token
 - `mint_auth` - address of the authority of the token mint
-- `user_ata` - user’s associated token account for this mint (where the tokens will be minted)
+- `user_ata` - user’s associated token account for this mint (where the tokens
+  will be minted)
 - `token_program` - address of the token program
 
-We'll start by adding these new accounts to the area of the function that iterates through the passed in accounts:
+We'll start by adding these new accounts to the area of the function that
+iterates through the passed in accounts:
 
 ```rust
 // Inside add_movie_review
@@ -256,11 +410,14 @@ let system_program = next_account_info(account_info_iter)?;
 let token_program = next_account_info(account_info_iter)?;
 ```
 
-There is no additional `instruction_data` required for the new functionality, so no changes need to be made to how data is deserialized. The only additional information that’s needed is the extra accounts.
+There is no additional `instruction_data` required for the new functionality, so
+no changes need to be made to how data is deserialized. The only additional
+information that’s needed is the extra accounts.
 
 ### 4. Mint tokens to the reviewer in `add_movie_review`
 
-Before we dive into the minting logic, let's import the address of the Token program and the constant `LAMPORTS_PER_SOL` at the top of the file.
+Before we dive into the minting logic, let's import the address of the Token
+program and the constant `LAMPORTS_PER_SOL` at the top of the file.
 
 ```rust
 // Inside processor.rs
@@ -269,13 +426,22 @@ use spl_associated_token_account::get_associated_token_address;
 use spl_token::{instruction::initialize_mint, ID as TOKEN_PROGRAM_ID};
 ```
 
-Now we can move on to the logic that handles the actual minting of the tokens! We’ll be adding this to the very end of the `add_movie_review` function right before `Ok(())` is returned.
+Now we can move on to the logic that handles the actual minting of the tokens!
+We’ll be adding this to the very end of the `add_movie_review` function right
+before `Ok(())` is returned.
 
-Minting tokens requires a signature by the mint authority. Since the program needs to be able to mint tokens, the mint authority needs to be an account that the program can sign for. In other words, it needs to be a PDA account owned by the program.
+Minting tokens requires a signature by the mint authority. Since the program
+needs to be able to mint tokens, the mint authority needs to be an account that
+the program can sign for. In other words, it needs to be a PDA account owned by
+the program.
 
-We'll also be structuring our token mint such that the mint account is a PDA account that we can derive deterministically. This way we can always verify that the `token_mint` account passed into the program is the expected account.
+We'll also be structuring our token mint such that the mint account is a PDA
+account that we can derive deterministically. This way we can always verify that
+the `token_mint` account passed into the program is the expected account.
 
-Let's go ahead and derive the token mint and mint authority addresses using the `find_program_address` function with the seeds “token_mint” and "token_auth," respectively.
+Let's go ahead and derive the token mint and mint authority addresses using the
+`find_program_address` function with the seeds “token_mint” and "token_auth,"
+respectively.
 
 ```rust
 // Mint tokens here
@@ -285,7 +451,8 @@ let (mint_auth_pda, _mint_auth_bump) =
     Pubkey::find_program_address(&[b"token_auth"], program_id);
 ```
 
-Next, we'll perform security checks against each of the new accounts passed into the program. Always remember to verify accounts!
+Next, we'll perform security checks against each of the new accounts passed into
+the program. Always remember to verify accounts!
 
 ```rust
 if *token_mint.key != mint_pda {
@@ -309,7 +476,12 @@ if *token_program.key != TOKEN_PROGRAM_ID {
 }
 ```
 
-Finally, we can issue a CPI to the `mint_to` function of the token program with the correct accounts using `invoke_signed`. The `spl_token` crate provides a `mint_to` helper function for creating the minting instruction. This is great because it means we don't have to manually build the entire instruction from scratch. Rather, we can simply pass in the arguments required by the function. Here's the function signature:
+Finally, we can issue a CPI to the `mint_to` function of the token program with
+the correct accounts using `invoke_signed`. The `spl_token` crate provides a
+`mint_to` helper function for creating the minting instruction. This is great
+because it means we don't have to manually build the entire instruction from
+scratch. Rather, we can simply pass in the arguments required by the function.
+Here's the function signature:
 
 ```rust
 // Inside the token program, returns an Instruction object
@@ -323,7 +495,9 @@ pub fn mint_to(
 ) -> Result<Instruction, ProgramError>
 ```
 
-Then we provide copies of the `token_mint`, `user_ata`, and `mint_auth` accounts. And, most relevant to this lesson, we provide the seeds used to find the `token_mint` address, including the bump seed.
+Then we provide copies of the `token_mint`, `user_ata`, and `mint_auth`
+accounts. And, most relevant to this lesson, we provide the seeds used to find
+the `token_mint` address, including the bump seed.
 
 ```rust
 msg!("Minting 10 tokens to User associated token account");
@@ -346,13 +520,26 @@ invoke_signed(
 Ok(())
 ```
 
-Note that we are using `invoke_signed` and not `invoke` here. The Token program requires the `mint_auth` account to sign for this transaction. Since the `mint_auth` account is a PDA, only the program it was derived from can sign on its behalf. When `invoke_signed` is called, the Solana runtime calls `create_program_address` with the seeds and bump provided and then compares the derived address with all of the addresses of the provided `AccountInfo` objects. If any of the addresses match the derived address, the runtime knows that the matching account is a PDA of this program and that the program is signing this transaction for this account.
+Note that we are using `invoke_signed` and not `invoke` here. The Token program
+requires the `mint_auth` account to sign for this transaction. Since the
+`mint_auth` account is a PDA, only the program it was derived from can sign on
+its behalf. When `invoke_signed` is called, the Solana runtime calls
+`create_program_address` with the seeds and bump provided and then compares the
+derived address with all of the addresses of the provided `AccountInfo` objects.
+If any of the addresses match the derived address, the runtime knows that the
+matching account is a PDA of this program and that the program is signing this
+transaction for this account.
 
-At this point, the `add_movie_review` instruction should be fully functional and will mint ten tokens to the reviewer when a review is created.
+At this point, the `add_movie_review` instruction should be fully functional and
+will mint ten tokens to the reviewer when a review is created.
 
 ### 5. Repeat for `add_comment`
 
-Our updates to the `add_comment` function will be almost identical to what we did for the `add_movie_review` function above. The only difference is that we’ll change the amount of tokens minted for a comment from ten to five so that adding reviews are weighted above commenting. First, update the accounts with the same four additional accounts as in the `add_movie_review` function.
+Our updates to the `add_comment` function will be almost identical to what we
+did for the `add_movie_review` function above. The only difference is that we’ll
+change the amount of tokens minted for a comment from ten to five so that adding
+reviews are weighted above commenting. First, update the accounts with the same
+four additional accounts as in the `add_movie_review` function.
 
 ```rust
 // Inside add_comment
@@ -369,7 +556,9 @@ let system_program = next_account_info(account_info_iter)?;
 let token_program = next_account_info(account_info_iter)?;
 ```
 
-Next, move to the bottom of the `add_comment` function just before the `Ok(())`. Then derive the token mint and mint authority accounts. Remember, both are PDAs derived from seeds "token_mint" and "token_authority" respectively.
+Next, move to the bottom of the `add_comment` function just before the `Ok(())`.
+Then derive the token mint and mint authority accounts. Remember, both are PDAs
+derived from seeds "token_mint" and "token_authority" respectively.
 
 ```rust
 // Mint tokens here
@@ -403,7 +592,8 @@ if *token_program.key != TOKEN_PROGRAM_ID {
 }
 ```
 
-Finally, use `invoke_signed` to send the `mint_to` instruction to the Token program, sending five tokens to the commenter.
+Finally, use `invoke_signed` to send the `mint_to` instruction to the Token
+program, sending five tokens to the commenter.
 
 ```rust
 msg!("Minting 5 tokens to User associated token account");
@@ -428,9 +618,16 @@ Ok(())
 
 ### 6. Set up the token mint
 
-We've written all the code needed to mint tokens to reviewers and commenters, but all of it assumes that there is a token mint at the PDA derived with the seed "token_mint." For this to work, we're going to set up an additional instruction for initializing the token mint. It will be written such that it can only be called once and it doesn't particularly matter who calls it.
+We've written all the code needed to mint tokens to reviewers and commenters,
+but all of it assumes that there is a token mint at the PDA derived with the
+seed "token_mint." For this to work, we're going to set up an additional
+instruction for initializing the token mint. It will be written such that it can
+only be called once and it doesn't particularly matter who calls it.
 
-Given that throughout this lesson we've already hammered home all of the concepts associated with PDAs and CPIs multiple times, we're going to walk through this bit with less explanation than the prior steps. Start by adding a fourth instruction variant to the `MovieInstruction` enum in `instruction.rs`.
+Given that throughout this lesson we've already hammered home all of the
+concepts associated with PDAs and CPIs multiple times, we're going to walk
+through this bit with less explanation than the prior steps. Start by adding a
+fourth instruction variant to the `MovieInstruction` enum in `instruction.rs`.
 
 ```rust
 pub enum MovieInstruction {
@@ -451,7 +648,8 @@ pub enum MovieInstruction {
 }
 ```
 
-Be sure to add it to the `match` statement in the `unpack` function in the same file under the variant `3`.
+Be sure to add it to the `match` statement in the `unpack` function in the same
+file under the variant `3`.
 
 ```rust
 impl MovieInstruction {
@@ -489,7 +687,9 @@ impl MovieInstruction {
 }
 ```
 
-In the `process_instruction` function in the `processor.rs` file, add the new instruction to the `match` statement and call a function `initialize_token_mint`.
+In the `process_instruction` function in the `processor.rs` file, add the new
+instruction to the `match` statement and call a function
+`initialize_token_mint`.
 
 ```rust
 pub fn process_instruction(
@@ -515,7 +715,13 @@ pub fn process_instruction(
 }
 ```
 
-Lastly, declare and implement the `initialize_token_mint` function. This function will derive the token mint and mint authority PDAs, create the token mint account, and then initialize the token mint. We won't explain all of this in detail, but it's worth reading through the code, especially given that the creation and initialization of the token mint both involve CPIs. Again, if you need a refresher on tokens and mints, have a look at the [Token Program lesson](./token-program.md).
+Lastly, declare and implement the `initialize_token_mint` function. This
+function will derive the token mint and mint authority PDAs, create the token
+mint account, and then initialize the token mint. We won't explain all of this
+in detail, but it's worth reading through the code, especially given that the
+creation and initialization of the token mint both involve CPIs. Again, if you
+need a refresher on tokens and mints, have a look at the
+[Token Program lesson](./token-program.md).
 
 ```rust
 pub fn initialize_token_mint(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
@@ -591,20 +797,48 @@ pub fn initialize_token_mint(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
 
 ### 7. Build and deploy
 
-Now we’re ready to build and deploy our program! You can build the program by running `cargo build-bpf` and then running the command that is returned, it should look something like `solana program deploy <PATH>`.
+Now we’re ready to build and deploy our program! You can build the program by
+running `cargo build-bpf` and then running the command that is returned, it
+should look something like `solana program deploy <PATH>`.
 
-Before you can start testing whether or not adding a review or comment sends you tokens, you need to initialize the program's token mint. You can use [this script](https://github.com/Unboxed-Software/solana-movie-token-client) to do that. Once you'd cloned that repository, replace the `PROGRAM_ID` in `index.ts` with your program's ID. Then run `npm install` and then `npm start`. The script assumes you're deploying to Devnet. If you're deploying locally, then make sure to tailor the script accordingly.
+Before you can start testing whether or not adding a review or comment sends you
+tokens, you need to initialize the program's token mint. You can use
+[this script](https://github.com/Unboxed-Software/solana-movie-token-client) to
+do that. Once you'd cloned that repository, replace the `PROGRAM_ID` in
+`index.ts` with your program's ID. Then run `npm install` and then `npm start`.
+The script assumes you're deploying to Devnet. If you're deploying locally, then
+make sure to tailor the script accordingly.
 
-Once you've initialized your token mint, you can use the [Movie Review frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-add-tokens) to test adding reviews and comments. Again, the code assumes you're on Devnet so please act accordingly.
+Once you've initialized your token mint, you can use the
+[Movie Review frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-add-tokens)
+to test adding reviews and comments. Again, the code assumes you're on Devnet so
+please act accordingly.
 
-After submitting a review, you should see 10 new tokens in your wallet! When you add a comment, you should receive 5 tokens. They won't have a fancy name or image since we didn't add any metadata to the token, but you get the idea.
+After submitting a review, you should see 10 new tokens in your wallet! When you
+add a comment, you should receive 5 tokens. They won't have a fancy name or
+image since we didn't add any metadata to the token, but you get the idea.
 
-If you need more time with the concepts from this lesson or got stuck along the way, feel free to [take a look at the solution code](https://github.com/Unboxed-Software/solana-movie-program/tree/solution-add-tokens). Note that the solution to this demo is on the `solution-add-tokens` branch.
+If you need more time with the concepts from this lesson or got stuck along the
+way, feel free to
+[take a look at the solution code](https://github.com/Unboxed-Software/solana-movie-program/tree/solution-add-tokens).
+Note that the solution to this demo is on the `solution-add-tokens` branch.
 
 # Challenge
 
-To apply what you've learned about CPIs in this lesson, think about how you could incorporate them into the Student Intro program. You could do something similar to what we did in the demo here and add some functionality to mint tokens to users when they introduce themselves. Or if you're feeling really ambitious, think about how you could take all that you have learned so far in the course and create something completely new from scratch.
+To apply what you've learned about CPIs in this lesson, think about how you
+could incorporate them into the Student Intro program. You could do something
+similar to what we did in the demo here and add some functionality to mint
+tokens to users when they introduce themselves. Or if you're feeling really
+ambitious, think about how you could take all that you have learned so far in
+the course and create something completely new from scratch.
 
-A great example would be to build a decentralized Stack Overflow. The program could use tokens to determine a user's overall rating, mint tokens when questions are answered correctly, allow users to upvote answers, etc. All of that is possible and you now have the skills and knowledge to go and build something like it on your own!
+A great example would be to build a decentralized Stack Overflow. The program
+could use tokens to determine a user's overall rating, mint tokens when
+questions are answered correctly, allow users to upvote answers, etc. All of
+that is possible and you now have the skills and knowledge to go and build
+something like it on your own!
 
-Congratulations on reaching the end of Module 4! Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%204), so that we can continue to improve the course.
+Congratulations on reaching the end of Module 4! Feel free to share some quick
+feedback
+[here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%204), so
+that we can continue to improve the course.

--- a/developers/courses/solana-course/content/deserialize-custom-data.md
+++ b/developers/courses/solana-course/content/deserialize-custom-data.md
@@ -1,10 +1,10 @@
 ---
 title: Deserialize Custom Account Data
 objectives:
-- Explain Program Derived Accounts
-- Derive PDAs given specific seeds
-- Fetch a program’s accounts
-- Use Borsh to deserialize custom data
+  - Explain Program Derived Accounts
+  - Derive PDAs given specific seeds
+  - Fetch a program’s accounts
+  - Use Borsh to deserialize custom data
 ---
 
 # TL;DR
@@ -26,7 +26,7 @@ Programs themselves, however, are stateless. They cannot modify the data within 
 
 ### PDA
 
-PDA stands for Program Derived Address. As the name suggests, it refers to an address (public key) derived from a program and some seeds. In a previous lesson, we discussed public/private keys and how they are used on Solana. Unlike a keypair, a PDA *does not* have a corresponding private key. The purpose of a PDA is to create an address that a program can sign for in the same way a user may sign for a transaction with their wallet.
+PDA stands for Program Derived Address. As the name suggests, it refers to an address (public key) derived from a program and some seeds. In a previous lesson, we discussed public/private keys and how they are used on Solana. Unlike a keypair, a PDA _does not_ have a corresponding private key. The purpose of a PDA is to create an address that a program can sign for in the same way a user may sign for a transaction with their wallet.
 
 When you submit a transaction to a program and expect the program to then update state or store data in some way, that program is using one or more PDAs. This is important to understand when developing client-side for two reasons:
 
@@ -35,9 +35,9 @@ When you submit a transaction to a program and expect the program to then update
 
 ### Finding PDAs
 
-PDAs are not technically created. Rather, they are *found* or *derived* based on one or more input seeds.
+PDAs are not technically created. Rather, they are _found_ or _derived_ based on one or more input seeds.
 
-Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic function ensures that every point along the curve has a corresponding point somewhere else on the curve, allowing for public/private keys. PDAs are addresses that lie *off* the ed2559 Elliptic curve and therefore cannot be signed for by a private key (since there isn’t one). This ensures that the program is the only valid signer for that address.
+Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic function ensures that every point along the curve has a corresponding point somewhere else on the curve, allowing for public/private keys. PDAs are addresses that lie _off_ the ed2559 Elliptic curve and therefore cannot be signed for by a private key (since there isn’t one). This ensures that the program is the only valid signer for that address.
 
 To find a public key that does not lie on the ed2559 curve, the program ID and seeds of the developer’s choice (like a string of text) are passed through the function [`findProgramAddress(seeds, programid)`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html#findProgramAddress). This function combines the program ID, seeds, and a bump seed into a buffer and passes it into a SHA256 hash to see whether or not the resulting address is on the curve. If the address is on the curve (~50% chance it is), then the bump seed is decremented by 1 and the address is calculated again. The bump seed starts at 255 and progressively iterates down to `bump = 254`, `bump = 253`, etc. until an address is found with the given seeds and bump that does not lie on the ed2559 curve. The `findProgramAddress` function returns the resulting address and the bump used to kick it off the curve. This way, the address can be generated anywhere as long as you have the bump and seeds.
 
@@ -50,30 +50,28 @@ PDAs are a unique concept and are one of the hardest parts of Solana development
 The derivation of PDAs is important because the seeds used to find a PDA are what we use to locate the data. For example, a simple program that only uses a single PDA to store global program state might use a simple seed phrase like “GLOBAL_STATE”. If the client wanted to read data from this PDA, it could derive the address using the program ID and this same seed.
 
 ```tsx
-const [pda, bump] = await findProgramAddress(Buffer.from("GLOBAL_STATE"), programId)
+const [pda, bump] = await findProgramAddress(
+  Buffer.from("GLOBAL_STATE"),
+  programId,
+);
 ```
 
 In more complex programs that store user-specific data, it’s common to use a user’s public key as the seed. This separates each user’s data into its own PDA. The separation makes it possible for the client to locate each user’s data by finding the address using the program ID and the user’s public key.
 
 ```tsx
 const [pda, bump] = await web3.PublicKey.findProgramAddress(
-	[
-		publicKey.toBuffer()
-	],
-	programId
-)
+  [publicKey.toBuffer()],
+  programId,
+);
 ```
 
 Also, when there are multiple accounts per user, a program may use one or more additional seeds to create and identify accounts. For example, in a note-taking app there may be one account per note where each PDA is derived with the user’s public key and the note’s title.
 
 ```tsx
 const [pda, bump] = await web3.PublicKey.findProgramAddress(
-	[
-		publicKey.toBuffer(),
-		Buffer.from('First Note')
-	],
-	programId
-)
+  [publicKey.toBuffer(), Buffer.from("First Note")],
+  programId,
+);
 ```
 
 ### Getting Multiple Program Accounts
@@ -82,11 +80,11 @@ In addition to deriving addresses, you can fetch all accounts created by a progr
 
 ```tsx
 const accounts = connection.getProgramAccounts(programId).then(accounts => {
-	accounts.map(({ pubkey, account }) => {
-		console.log('Account:', pubkey)
-		console.log('Data buffer:', account.data)
-	})
-})
+  accounts.map(({ pubkey, account }) => {
+    console.log("Account:", pubkey);
+    console.log("Data buffer:", account.data);
+  });
+});
 ```
 
 ## Deserializing custom account data
@@ -101,10 +99,10 @@ To properly deserialize data from an on-chain program, you will have to create a
 import * as borsh from "@project-serum/borsh";
 
 borshAccountSchema = borsh.struct([
-	borsh.bool('initialized'),
-	borsh.u16('playerId'),
-	borsh.str('name')
-])
+  borsh.bool("initialized"),
+  borsh.u16("playerId"),
+  borsh.str("name"),
+]);
 ```
 
 Once you have your layout defined, simply call `.decode(buffer)` on the schema.
@@ -113,12 +111,12 @@ Once you have your layout defined, simply call `.decode(buffer)` on the schema.
 import * as borsh from "@project-serum/borsh";
 
 borshAccountSchema = borsh.struct([
-	borsh.bool('initialized'),
-	borsh.u16('playerId'),
-	borsh.str('name')
-])
+  borsh.bool("initialized"),
+  borsh.u16("playerId"),
+  borsh.str("name"),
+]);
 
-const { playerId, name } = borshAccountSchema.decode(buffer)
+const { playerId, name } = borshAccountSchema.decode(buffer);
 ```
 
 # Demo
@@ -169,7 +167,7 @@ export class Movie {
 }
 ```
 
-Remember, the order here *matters*. It needs to match how the account data is structured.
+Remember, the order here _matters_. It needs to match how the account data is structured.
 
 ### 3. Create a method to deserialize data
 
@@ -215,35 +213,37 @@ The method first checks whether or not the buffer exists and returns `null` if i
 Now that we have a way to deserialize account data, we need to actually fetch the accounts. Open `MovieList.tsx` and import `@solana/web3.js`. Then, create a new `Connection` inside the `MovieList` component. Finally, replace the line `setMovies(Movie.mocks)` inside `useEffect` with a call to `connection.getProgramAccounts`. Take the resulting array and convert it into an array of movies and call `setMovies`.
 
 ```tsx
-import { Card } from './Card'
-import { FC, useEffect, useState } from 'react'
-import { Movie } from '../models/Movie'
-import * as web3 from '@solana/web3.js'
+import { Card } from "./Card";
+import { FC, useEffect, useState } from "react";
+import { Movie } from "../models/Movie";
+import * as web3 from "@solana/web3.js";
 
-const MOVIE_REVIEW_PROGRAM_ID = 'CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN'
+const MOVIE_REVIEW_PROGRAM_ID = "CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN";
 
 export const MovieList: FC = () => {
-	const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
-	const [movies, setMovies] = useState<Movie[]>([])
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const [movies, setMovies] = useState<Movie[]>([]);
 
-	useEffect(() => {
-		connection.getProgramAccounts(new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID)).then(async (accounts) => {
-			const movies: Movie[] = accounts.map(({ account }) => {
-				return Movie.deserialize(account.data)
-			})
+  useEffect(() => {
+    connection
+      .getProgramAccounts(new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID))
+      .then(async accounts => {
+        const movies: Movie[] = accounts.map(({ account }) => {
+          return Movie.deserialize(account.data);
+        });
 
-			setMovies(movies)
-		})
-	}, [])
+        setMovies(movies);
+      });
+  }, []);
 
-	return (
-		<div>
-			{
-				movies.map((movie, i) => <Card key={i} movie={movie} /> )
-			}
-		</div>
-	)
-}
+  return (
+    <div>
+      {movies.map((movie, i) => (
+        <Card key={i} movie={movie} />
+      ))}
+    </div>
+  );
+};
 ```
 
 At this point, you should be able to run the app and see the list of movie reviews retrieved from the program!

--- a/developers/courses/solana-course/content/deserialize-custom-data.md
+++ b/developers/courses/solana-course/content/deserialize-custom-data.md
@@ -9,45 +9,95 @@ objectives:
 
 # TL;DR
 
-- **Program Derived Addresses**, or PDAs, are addresses that do not have a corresponding private key. The concept of PDAs allows for programs to sign for transactions themselves and allows for storing and locating data.
+- **Program Derived Addresses**, or PDAs, are addresses that do not have a
+  corresponding private key. The concept of PDAs allows for programs to sign for
+  transactions themselves and allows for storing and locating data.
 - You can derive a PDA using the `findProgramAddress(seeds, programid)` method.
-- You can get an array of all the accounts belonging to a program using `getProgramAccounts(programId)`.
-- Account data needs to be deserialized using the same layout used to store it in the first place. You can use `@project-serum/borsh` to create a schema.
+- You can get an array of all the accounts belonging to a program using
+  `getProgramAccounts(programId)`.
+- Account data needs to be deserialized using the same layout used to store it
+  in the first place. You can use `@project-serum/borsh` to create a schema.
 
 # Overview
 
-In the last lesson, we serialized custom instruction data that was subsequently stored on-chain by a Solana program. In this lesson, we’ll cover in greater detail how programs use accounts, how to retrieve them, and how to deserialize the data they store.
+In the last lesson, we serialized custom instruction data that was subsequently
+stored on-chain by a Solana program. In this lesson, we’ll cover in greater
+detail how programs use accounts, how to retrieve them, and how to deserialize
+the data they store.
 
 ## Programs
 
-As the saying goes, everything in Solana is an account. Even programs. Programs are accounts that store code and are marked as executable. This code can be executed by the Solana runtime when instructed to do so.
+As the saying goes, everything in Solana is an account. Even programs. Programs
+are accounts that store code and are marked as executable. This code can be
+executed by the Solana runtime when instructed to do so.
 
-Programs themselves, however, are stateless. They cannot modify the data within their account. They can only persist state by storing data in other accounts that can be referenced at some other point in time. Understanding how these accounts are used and how to find them is crucial to client-side Solana development.
+Programs themselves, however, are stateless. They cannot modify the data within
+their account. They can only persist state by storing data in other accounts
+that can be referenced at some other point in time. Understanding how these
+accounts are used and how to find them is crucial to client-side Solana
+development.
 
 ### PDA
 
-PDA stands for Program Derived Address. As the name suggests, it refers to an address (public key) derived from a program and some seeds. In a previous lesson, we discussed public/private keys and how they are used on Solana. Unlike a keypair, a PDA _does not_ have a corresponding private key. The purpose of a PDA is to create an address that a program can sign for in the same way a user may sign for a transaction with their wallet.
+PDA stands for Program Derived Address. As the name suggests, it refers to an
+address (public key) derived from a program and some seeds. In a previous
+lesson, we discussed public/private keys and how they are used on Solana. Unlike
+a keypair, a PDA _does not_ have a corresponding private key. The purpose of a
+PDA is to create an address that a program can sign for in the same way a user
+may sign for a transaction with their wallet.
 
-When you submit a transaction to a program and expect the program to then update state or store data in some way, that program is using one or more PDAs. This is important to understand when developing client-side for two reasons:
+When you submit a transaction to a program and expect the program to then update
+state or store data in some way, that program is using one or more PDAs. This is
+important to understand when developing client-side for two reasons:
 
-1. When submitting a transaction to a program, the client needs to include all addresses for accounts that will be written to or read from. This means that unlike more traditional client-server architectures, the client needs to have implementation-specific knowledge about the Solana program. The client needs to know which PDA is going to be used to store data so that it can include that address in the transaction.
-2. Similarly, when reading data from a program, the client needs to know which account(s) to read from.
+1. When submitting a transaction to a program, the client needs to include all
+   addresses for accounts that will be written to or read from. This means that
+   unlike more traditional client-server architectures, the client needs to have
+   implementation-specific knowledge about the Solana program. The client needs
+   to know which PDA is going to be used to store data so that it can include
+   that address in the transaction.
+2. Similarly, when reading data from a program, the client needs to know which
+   account(s) to read from.
 
 ### Finding PDAs
 
-PDAs are not technically created. Rather, they are _found_ or _derived_ based on one or more input seeds.
+PDAs are not technically created. Rather, they are _found_ or _derived_ based on
+one or more input seeds.
 
-Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic function ensures that every point along the curve has a corresponding point somewhere else on the curve, allowing for public/private keys. PDAs are addresses that lie _off_ the ed2559 Elliptic curve and therefore cannot be signed for by a private key (since there isn’t one). This ensures that the program is the only valid signer for that address.
+Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic
+function ensures that every point along the curve has a corresponding point
+somewhere else on the curve, allowing for public/private keys. PDAs are
+addresses that lie _off_ the ed2559 Elliptic curve and therefore cannot be
+signed for by a private key (since there isn’t one). This ensures that the
+program is the only valid signer for that address.
 
-To find a public key that does not lie on the ed2559 curve, the program ID and seeds of the developer’s choice (like a string of text) are passed through the function [`findProgramAddress(seeds, programid)`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html#findProgramAddress). This function combines the program ID, seeds, and a bump seed into a buffer and passes it into a SHA256 hash to see whether or not the resulting address is on the curve. If the address is on the curve (~50% chance it is), then the bump seed is decremented by 1 and the address is calculated again. The bump seed starts at 255 and progressively iterates down to `bump = 254`, `bump = 253`, etc. until an address is found with the given seeds and bump that does not lie on the ed2559 curve. The `findProgramAddress` function returns the resulting address and the bump used to kick it off the curve. This way, the address can be generated anywhere as long as you have the bump and seeds.
+To find a public key that does not lie on the ed2559 curve, the program ID and
+seeds of the developer’s choice (like a string of text) are passed through the
+function
+[`findProgramAddress(seeds, programid)`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html#findProgramAddress).
+This function combines the program ID, seeds, and a bump seed into a buffer and
+passes it into a SHA256 hash to see whether or not the resulting address is on
+the curve. If the address is on the curve (~50% chance it is), then the bump
+seed is decremented by 1 and the address is calculated again. The bump seed
+starts at 255 and progressively iterates down to `bump = 254`, `bump = 253`,
+etc. until an address is found with the given seeds and bump that does not lie
+on the ed2559 curve. The `findProgramAddress` function returns the resulting
+address and the bump used to kick it off the curve. This way, the address can be
+generated anywhere as long as you have the bump and seeds.
 
 ![Screenshot of ed2559 curve](../assets/ed2559-curve.png)
 
-PDAs are a unique concept and are one of the hardest parts of Solana development to understand. If you don’t get it right away, don’t worry. It’ll make more sense the more you practice.
+PDAs are a unique concept and are one of the hardest parts of Solana development
+to understand. If you don’t get it right away, don’t worry. It’ll make more
+sense the more you practice.
 
 ### Why Does This Matter?
 
-The derivation of PDAs is important because the seeds used to find a PDA are what we use to locate the data. For example, a simple program that only uses a single PDA to store global program state might use a simple seed phrase like “GLOBAL_STATE”. If the client wanted to read data from this PDA, it could derive the address using the program ID and this same seed.
+The derivation of PDAs is important because the seeds used to find a PDA are
+what we use to locate the data. For example, a simple program that only uses a
+single PDA to store global program state might use a simple seed phrase like
+“GLOBAL_STATE”. If the client wanted to read data from this PDA, it could derive
+the address using the program ID and this same seed.
 
 ```tsx
 const [pda, bump] = await findProgramAddress(
@@ -56,7 +106,10 @@ const [pda, bump] = await findProgramAddress(
 );
 ```
 
-In more complex programs that store user-specific data, it’s common to use a user’s public key as the seed. This separates each user’s data into its own PDA. The separation makes it possible for the client to locate each user’s data by finding the address using the program ID and the user’s public key.
+In more complex programs that store user-specific data, it’s common to use a
+user’s public key as the seed. This separates each user’s data into its own PDA.
+The separation makes it possible for the client to locate each user’s data by
+finding the address using the program ID and the user’s public key.
 
 ```tsx
 const [pda, bump] = await web3.PublicKey.findProgramAddress(
@@ -65,7 +118,10 @@ const [pda, bump] = await web3.PublicKey.findProgramAddress(
 );
 ```
 
-Also, when there are multiple accounts per user, a program may use one or more additional seeds to create and identify accounts. For example, in a note-taking app there may be one account per note where each PDA is derived with the user’s public key and the note’s title.
+Also, when there are multiple accounts per user, a program may use one or more
+additional seeds to create and identify accounts. For example, in a note-taking
+app there may be one account per note where each PDA is derived with the user’s
+public key and the note’s title.
 
 ```tsx
 const [pda, bump] = await web3.PublicKey.findProgramAddress(
@@ -76,7 +132,11 @@ const [pda, bump] = await web3.PublicKey.findProgramAddress(
 
 ### Getting Multiple Program Accounts
 
-In addition to deriving addresses, you can fetch all accounts created by a program using `connection.getProgramAccounts(programId)`. This returns an array of objects where each object has `pubkey` property representing the public key of the account and an `account` property of type `AccountInfo`. You can use the `account` property to get the account data.
+In addition to deriving addresses, you can fetch all accounts created by a
+program using `connection.getProgramAccounts(programId)`. This returns an array
+of objects where each object has `pubkey` property representing the public key
+of the account and an `account` property of type `AccountInfo`. You can use the
+`account` property to get the account data.
 
 ```tsx
 const accounts = connection.getProgramAccounts(programId).then(accounts => {
@@ -89,11 +149,22 @@ const accounts = connection.getProgramAccounts(programId).then(accounts => {
 
 ## Deserializing custom account data
 
-The `data` property on an `AccountInfo` object is a buffer. To use it efficiently, you’ll need to write code that deserializes it into something more usable. This is similar to the serialization process we covered last lesson. Just as before, we’ll use [Borsh](https://borsh.io/) and `@project-serum/borsh`. If you need a refresher on either of these, have a look at the previous lesson.
+The `data` property on an `AccountInfo` object is a buffer. To use it
+efficiently, you’ll need to write code that deserializes it into something more
+usable. This is similar to the serialization process we covered last lesson.
+Just as before, we’ll use [Borsh](https://borsh.io/) and `@project-serum/borsh`.
+If you need a refresher on either of these, have a look at the previous lesson.
 
-Deserializing requires knowledge of the account layout ahead of time. When creating your own programs, you will define how this is done as part of that process. Many programs also have documentation on how to deserialize the account data. Otherwise, if the program code is available you can look at the source and determine the structure that way.
+Deserializing requires knowledge of the account layout ahead of time. When
+creating your own programs, you will define how this is done as part of that
+process. Many programs also have documentation on how to deserialize the account
+data. Otherwise, if the program code is available you can look at the source and
+determine the structure that way.
 
-To properly deserialize data from an on-chain program, you will have to create a client-side schema mirroring how the data is stored in the account. For example, the following might be the schema for an account storing metadata about a player in an on-chain game.
+To properly deserialize data from an on-chain program, you will have to create a
+client-side schema mirroring how the data is stored in the account. For example,
+the following might be the schema for an account storing metadata about a player
+in an on-chain game.
 
 ```tsx
 import * as borsh from "@project-serum/borsh";
@@ -121,32 +192,52 @@ const { playerId, name } = borshAccountSchema.decode(buffer);
 
 # Demo
 
-Let’s practice this together by continuing to work on the Movie Review app from the last lesson. No worries if you’re just jumping into this lesson - it should be possible to follow either way.
+Let’s practice this together by continuing to work on the Movie Review app from
+the last lesson. No worries if you’re just jumping into this lesson - it should
+be possible to follow either way.
 
-As a refresher, this project uses a Solana program deployed on Devnet which lets users review movies. Last lesson, we added functionality to the frontend skeleton letting users submit movie reviews but the list of reviews is still showing mock data. Let’s fix that by fetching the program’s storage accounts and deserializing the data stored there.
+As a refresher, this project uses a Solana program deployed on Devnet which lets
+users review movies. Last lesson, we added functionality to the frontend
+skeleton letting users submit movie reviews but the list of reviews is still
+showing mock data. Let’s fix that by fetching the program’s storage accounts and
+deserializing the data stored there.
 
 ![Screenshot of movie review frontend](../assets/movie-reviews-frontend.png)
 
 ### 1. Download the starter code
 
-If you didn’t complete the demo from the last lesson or just want to make sure that you didn’t miss anything, you can download the [starter code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-serialize-instruction-data).
+If you didn’t complete the demo from the last lesson or just want to make sure
+that you didn’t miss anything, you can download the
+[starter code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-serialize-instruction-data).
 
-The project is a fairly simple Next.js application. It includes the `WalletContextProvider` we created in the Wallets lesson, a `Card` component for displaying a movie review, a `MovieList` component that displays reviews in a list, a `Form` component for submitting a new review, and a `Movie.ts` file that contains a class definition for a `Movie` object.
+The project is a fairly simple Next.js application. It includes the
+`WalletContextProvider` we created in the Wallets lesson, a `Card` component for
+displaying a movie review, a `MovieList` component that displays reviews in a
+list, a `Form` component for submitting a new review, and a `Movie.ts` file that
+contains a class definition for a `Movie` object.
 
-Note that when you run `npm run dev`, the reviews displayed on the page are mocks. We’ll be swapping those out for the real deal.
+Note that when you run `npm run dev`, the reviews displayed on the page are
+mocks. We’ll be swapping those out for the real deal.
 
 ### 2. Create the buffer layout
 
-Remember that to properly interact with a Solana program, you need to know how its data is structured.
+Remember that to properly interact with a Solana program, you need to know how
+its data is structured.
 
-The Movie Review program creates a separate account for each movie review and stores the following data in the account’s `data`:
+The Movie Review program creates a separate account for each movie review and
+stores the following data in the account’s `data`:
 
-1. `initialized` as a boolean representing whether or not the account has been initialized.
-2. `rating` as an unsigned, 8-bit integer representing the rating out of 5 that the reviewer gave the movie.
+1. `initialized` as a boolean representing whether or not the account has been
+   initialized.
+2. `rating` as an unsigned, 8-bit integer representing the rating out of 5 that
+   the reviewer gave the movie.
 3. `title` as a string representing the title of the reviewed movie.
 4. `description` as a string representing the written portion of the review.
 
-Let’s configure a `borsh` layout in the `Movie` class to represent the movie account data layout. Start by importing `@project-serum/borsh`. Next, create a `borshAccountSchema` static property and set it to the appropriate `borsh` struct containing the properties listed above.
+Let’s configure a `borsh` layout in the `Movie` class to represent the movie
+account data layout. Start by importing `@project-serum/borsh`. Next, create a
+`borshAccountSchema` static property and set it to the appropriate `borsh`
+struct containing the properties listed above.
 
 ```tsx
 import * as borsh from '@project-serum/borsh'
@@ -167,11 +258,14 @@ export class Movie {
 }
 ```
 
-Remember, the order here _matters_. It needs to match how the account data is structured.
+Remember, the order here _matters_. It needs to match how the account data is
+structured.
 
 ### 3. Create a method to deserialize data
 
-Now that we have the buffer layout set up, let’s create a static method in `Movie` called `deserialize` that will take an optional `Buffer` and return a `Movie` object or `null`.
+Now that we have the buffer layout set up, let’s create a static method in
+`Movie` called `deserialize` that will take an optional `Buffer` and return a
+`Movie` object or `null`.
 
 ```tsx
 import * as borsh from '@project-serum/borsh'
@@ -206,11 +300,19 @@ export class Movie {
 }
 ```
 
-The method first checks whether or not the buffer exists and returns `null` if it doesn’t. Next, it uses the layout we created to decode the buffer, then uses the data to construct and return an instance of `Movie`. If the decoding fails, the method logs the error and returns `null`.
+The method first checks whether or not the buffer exists and returns `null` if
+it doesn’t. Next, it uses the layout we created to decode the buffer, then uses
+the data to construct and return an instance of `Movie`. If the decoding fails,
+the method logs the error and returns `null`.
 
 ### 4. Fetch movie review accounts
 
-Now that we have a way to deserialize account data, we need to actually fetch the accounts. Open `MovieList.tsx` and import `@solana/web3.js`. Then, create a new `Connection` inside the `MovieList` component. Finally, replace the line `setMovies(Movie.mocks)` inside `useEffect` with a call to `connection.getProgramAccounts`. Take the resulting array and convert it into an array of movies and call `setMovies`.
+Now that we have a way to deserialize account data, we need to actually fetch
+the accounts. Open `MovieList.tsx` and import `@solana/web3.js`. Then, create a
+new `Connection` inside the `MovieList` component. Finally, replace the line
+`setMovies(Movie.mocks)` inside `useEffect` with a call to
+`connection.getProgramAccounts`. Take the resulting array and convert it into an
+array of movies and call `setMovies`.
 
 ```tsx
 import { Card } from "./Card";
@@ -246,27 +348,47 @@ export const MovieList: FC = () => {
 };
 ```
 
-At this point, you should be able to run the app and see the list of movie reviews retrieved from the program!
+At this point, you should be able to run the app and see the list of movie
+reviews retrieved from the program!
 
-Depending on how many reviews have been submitted, this may take a long time to load or may lock up your browser entirely. But don’t worry — next lesson we’ll learn how to page and filter accounts so you can be more surgical with what you load.
+Depending on how many reviews have been submitted, this may take a long time to
+load or may lock up your browser entirely. But don’t worry — next lesson we’ll
+learn how to page and filter accounts so you can be more surgical with what you
+load.
 
-If you need more time with this project to feel comfortable with these concepts, have a look at the [solution code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-deserialize-account-data) before continuing.
+If you need more time with this project to feel comfortable with these concepts,
+have a look at the
+[solution code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-deserialize-account-data)
+before continuing.
 
 # Challenge
 
-Now it’s your turn to build something independently. Last lesson, you worked on the Student Intros app to serialize instruction data and send a new intro to the network. Now, it's time to fetch and deserialize the program's account data. Remember, the Solana program that supports this is at `HdE95RSVsdb315jfJtaykXhXY478h53X6okDupVfY9yf`.
+Now it’s your turn to build something independently. Last lesson, you worked on
+the Student Intros app to serialize instruction data and send a new intro to the
+network. Now, it's time to fetch and deserialize the program's account data.
+Remember, the Solana program that supports this is at
+`HdE95RSVsdb315jfJtaykXhXY478h53X6okDupVfY9yf`.
 
 ![Screenshot of Student Intros frontend](../assets/student-intros-frontend.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
-2. Create the account buffer layout in `StudentIntro.ts`. The account data contains:
-   1. `initialized` as an unsigned, 8-bit integer representing the instruction to run (should be 1).
+1. You can build this from scratch or you can download the starter code
+   [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
+2. Create the account buffer layout in `StudentIntro.ts`. The account data
+   contains:
+   1. `initialized` as an unsigned, 8-bit integer representing the instruction
+      to run (should be 1).
    2. `name` as a string representing the student's name.
-   3. `message` as a string representing the message the student shared about their Solana journey.
-3. Create a static method in `StudentIntro.ts` that will use the buffer layout to deserialize an account data buffer into a `StudentIntro` object.
-4. In the `StudentIntroList` component's `useEffect`, get the program's accounts and deserialize their data into a list of `StudentIntro` objects.
-5. Instead of mock data, you should now be seeing student introductions from the network!
+   3. `message` as a string representing the message the student shared about
+      their Solana journey.
+3. Create a static method in `StudentIntro.ts` that will use the buffer layout
+   to deserialize an account data buffer into a `StudentIntro` object.
+4. In the `StudentIntroList` component's `useEffect`, get the program's accounts
+   and deserialize their data into a list of `StudentIntro` objects.
+5. Instead of mock data, you should now be seeing student introductions from the
+   network!
 
-If you get really stumped, feel free to check out the solution code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-deserialize-account-data).
+If you get really stumped, feel free to check out the solution code
+[here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-deserialize-account-data).
 
-As always, get creative with these challenges and take them beyond the instructions if you want!
+As always, get creative with these challenges and take them beyond the
+instructions if you want!

--- a/developers/courses/solana-course/content/deserialize-instruction-data.md
+++ b/developers/courses/solana-course/content/deserialize-instruction-data.md
@@ -1,13 +1,13 @@
 ---
 title: Create a Basic Program, Part 1 - Handle Instruction Data
 objectives:
-- Assign mutable and immutable variables in Rust
-- Create and use Rust structs and enums
-- Use Rust match statements
-- Add implementations to Rust types
-- Deserialize instruction data into Rust data types
-- Execute different program logic for different types of instructions
-- Explain the structure of a smart contract on Solana
+  - Assign mutable and immutable variables in Rust
+  - Create and use Rust structs and enums
+  - Use Rust match statements
+  - Add implementations to Rust types
+  - Deserialize instruction data into Rust data types
+  - Execute different program logic for different types of instructions
+  - Explain the structure of a smart contract on Solana
 ---
 
 # TL;DR

--- a/developers/courses/solana-course/content/deserialize-instruction-data.md
+++ b/developers/courses/solana-course/content/deserialize-instruction-data.md
@@ -12,20 +12,35 @@ objectives:
 
 # TL;DR
 
-- Most programs support **multiple discrete instructions** - you decide when writing your program what these instructions are and what data must accompany them
+- Most programs support **multiple discrete instructions** - you decide when
+  writing your program what these instructions are and what data must accompany
+  them
 - Rust **enums** are often used to represent discrete program instructions
-- You can use the `borsh` crate and the `derive` attribute to provide Borsh deserialization and serialization functionality to Rust structs
-- Rust `match` expressions help create conditional code paths based on the provided instruction
+- You can use the `borsh` crate and the `derive` attribute to provide Borsh
+  deserialization and serialization functionality to Rust structs
+- Rust `match` expressions help create conditional code paths based on the
+  provided instruction
 
 # Overview
 
-One of the most basic elements of a Solana program is the logic for handling instruction data. Most programs support multiple related functions and use differences in instruction data to determine which code path to execute. For example, two different data formats in the instruction data passed to the program may represent instructions for creating a new piece of data vs deleting the same piece of data.
+One of the most basic elements of a Solana program is the logic for handling
+instruction data. Most programs support multiple related functions and use
+differences in instruction data to determine which code path to execute. For
+example, two different data formats in the instruction data passed to the
+program may represent instructions for creating a new piece of data vs deleting
+the same piece of data.
 
-Since instruction data is provided to your program's entry point as a byte array, it's common to create a Rust data type to represent instructions in a way that's more usable throughout your code. This lesson will walk through how to set up such a type, how to deserialize the instruction data into this format, and how to execute the proper code path based on the instruction passed into the program's entry point.
+Since instruction data is provided to your program's entry point as a byte
+array, it's common to create a Rust data type to represent instructions in a way
+that's more usable throughout your code. This lesson will walk through how to
+set up such a type, how to deserialize the instruction data into this format,
+and how to execute the proper code path based on the instruction passed into the
+program's entry point.
 
 ## Rust basics
 
-Before we dive into the specifics of a basic Solana program, let's talk about the Rust basics we'll be using throughout this lesson.
+Before we dive into the specifics of a basic Solana program, let's talk about
+the Rust basics we'll be using throughout this lesson.
 
 ### Variables
 
@@ -35,7 +50,10 @@ Variable assignment in Rust happens with the `let` keyword.
 let age = 33;
 ```
 
-Variables in Rust by default are immutable, meaning a variable's value cannot be changed once it has been set. In order to create a variable that we'd like to change at some point in the future, we use the `mut` keyword. Defining a variable with this keyword means that the value stored in it can change.
+Variables in Rust by default are immutable, meaning a variable's value cannot be
+changed once it has been set. In order to create a variable that we'd like to
+change at some point in the future, we use the `mut` keyword. Defining a
+variable with this keyword means that the value stored in it can change.
 
 ```rust
 // compiler will throw error
@@ -47,11 +65,17 @@ let mut mutable_age = 33;
 mutable_age = 34;
 ```
 
-The Rust compiler guarantees that immutable variables truly cannot change so that you don’t have to keep track of it yourself. This makes your code easier to reason through and simplifies debugging.
+The Rust compiler guarantees that immutable variables truly cannot change so
+that you don’t have to keep track of it yourself. This makes your code easier to
+reason through and simplifies debugging.
 
 ### Structs
 
-A struct, or structure, is a custom data type that lets you package together and name multiple related values that make up a meaningful group. Each piece of data in a struct can be of different types and each has a name associated with it. These pieces of data are called **fields**. They behave similarly to properties in other languages.
+A struct, or structure, is a custom data type that lets you package together and
+name multiple related values that make up a meaningful group. Each piece of data
+in a struct can be of different types and each has a name associated with it.
+These pieces of data are called **fields**. They behave similarly to properties
+in other languages.
 
 ```rust
 struct User {
@@ -61,7 +85,8 @@ struct User {
 }
 ```
 
-To use a struct after we’ve defined it, we create an instance of that struct by specifying concrete values for each of the fields.
+To use a struct after we’ve defined it, we create an instance of that struct by
+specifying concrete values for each of the fields.
 
 ```rust
 let mut user1 = User {
@@ -79,7 +104,8 @@ user1.age = 37;
 
 ### Enumerations
 
-Enumerations (or Enums) are a data struct that allow you to define a type by enumerating its possible variants. An example of an enum may look like:
+Enumerations (or Enums) are a data struct that allow you to define a type by
+enumerating its possible variants. An example of an enum may look like:
 
 ```rust
 enum LightStatus {
@@ -88,9 +114,11 @@ enum LightStatus {
 }
 ```
 
-The `LightStatus` enum has two possible variants in this situation: it's either `On` or `Off`.
+The `LightStatus` enum has two possible variants in this situation: it's either
+`On` or `Off`.
 
-You can also embed values into enum variants, similar to adding fields to a struct.
+You can also embed values into enum variants, similar to adding fields to a
+struct.
 
 ```rust
 enum LightStatus {
@@ -103,11 +131,16 @@ enum LightStatus {
 let light_status = LightStatus::On { color: String::from("red") };
 ```
 
-In this example, setting a variable to the `On` variant of `LightStatus` requires also setting the value of `color`.
+In this example, setting a variable to the `On` variant of `LightStatus`
+requires also setting the value of `color`.
 
 ### Match statements
 
-Match statements are very similar to `switch` statements in C/C++. The `match` statement allows you to compare a value against a series of patterns and then execute code based on which pattern matches the value. Patterns can be made of literal values, variable names, wildcards, and more. The match statement must include all possible scenarios, otherwise the code will not compile.
+Match statements are very similar to `switch` statements in C/C++. The `match`
+statement allows you to compare a value against a series of patterns and then
+execute code based on which pattern matches the value. Patterns can be made of
+literal values, variable names, wildcards, and more. The match statement must
+include all possible scenarios, otherwise the code will not compile.
 
 ```rust
 enum Coin {
@@ -129,7 +162,8 @@ fn value_in_cents(coin: Coin) -> u8 {
 
 ### Implementations
 
-The `impl` keyword is used in Rust to define a type's implementations. Functions and constants can both be defined in an implementation.
+The `impl` keyword is used in Rust to define a type's implementations. Functions
+and constants can both be defined in an implementation.
 
 ```rust
 struct Example {
@@ -151,13 +185,15 @@ impl Example {
 }
 ```
 
-The function `boo` here can only be called on the type itself rather than an instance of the type, like so:
+The function `boo` here can only be called on the type itself rather than an
+instance of the type, like so:
 
 ```rust
 Example::boo();
 ```
 
-Meanwhile, `answer` requires a mutable instance of `Example` and can be called with dot syntax:
+Meanwhile, `answer` requires a mutable instance of `Example` and can be called
+with dot syntax:
 
 ```rust
 let mut example = Example { number: 3 };
@@ -166,21 +202,35 @@ example.answer();
 
 ### Traits and attributes
 
-You won't be creating your own traits or attributes at this stage, so we won't provide an in depth explanation of either. However, you will be using the `derive` attribute macro and some traits provided by the `borsh` crate, so it's important you have a high level understanding of each.
+You won't be creating your own traits or attributes at this stage, so we won't
+provide an in depth explanation of either. However, you will be using the
+`derive` attribute macro and some traits provided by the `borsh` crate, so it's
+important you have a high level understanding of each.
 
-Traits describe an abstract interface that types can implement. If a trait defines a function `bark()` and a type then adopts that trait, the type must then implement the `bark()` function.
+Traits describe an abstract interface that types can implement. If a trait
+defines a function `bark()` and a type then adopts that trait, the type must
+then implement the `bark()` function.
 
-[Attributes](https://doc.rust-lang.org/rust-by-example/attribute.html) add metadata to a type and can be used for many different purposes.
+[Attributes](https://doc.rust-lang.org/rust-by-example/attribute.html) add
+metadata to a type and can be used for many different purposes.
 
-When you add the [`derive` attribute](https://doc.rust-lang.org/rust-by-example/trait/derive.html) to a type and provide one or more supported traits, code is generated under the hood to automatically implement the traits for that type. We'll provide a concrete example of this shortly.
+When you add the
+[`derive` attribute](https://doc.rust-lang.org/rust-by-example/trait/derive.html)
+to a type and provide one or more supported traits, code is generated under the
+hood to automatically implement the traits for that type. We'll provide a
+concrete example of this shortly.
 
 ## Representing instructions as a Rust data type
 
 Now that we've covered the Rust basics, let's apply them to Solana programs.
 
-More often than not, programs will have more than one function. For example, you may have a program that acts as the backend for a note-taking app. Assume this program accepts instructions for creating a new note, updating an existing note, and deleting an existing note.
+More often than not, programs will have more than one function. For example, you
+may have a program that acts as the backend for a note-taking app. Assume this
+program accepts instructions for creating a new note, updating an existing note,
+and deleting an existing note.
 
-Since instructions have discrete types, they're usually a great fit for an enum data type.
+Since instructions have discrete types, they're usually a great fit for an enum
+data type.
 
 ```rust
 enum NoteInstruction {
@@ -200,17 +250,29 @@ enum NoteInstruction {
 }
 ```
 
-Notice that each variant of the `NoteInstruction` enum comes with embedded data that will be used by the program to accomplish the tasks of creating, updating, and deleting a note, respectively.
+Notice that each variant of the `NoteInstruction` enum comes with embedded data
+that will be used by the program to accomplish the tasks of creating, updating,
+and deleting a note, respectively.
 
 ## Deserialize instruction data
 
-Instruction data is passed to the program as a byte array, so you need a way to deterministically convert that array into an instance of the instruction enum type.
+Instruction data is passed to the program as a byte array, so you need a way to
+deterministically convert that array into an instance of the instruction enum
+type.
 
-In previous modules, we used Borsh for client-side serialization and deserialization. To use Borsh program-side, we use the `borsh` crate. This crate provides traits for `BorshDeserialize` and `BorshSerialize` that you can apply to your types using the `derive` attribute.
+In previous modules, we used Borsh for client-side serialization and
+deserialization. To use Borsh program-side, we use the `borsh` crate. This crate
+provides traits for `BorshDeserialize` and `BorshSerialize` that you can apply
+to your types using the `derive` attribute.
 
-To make deserializing instruction data simple, you can create a struct representing the data and use the `derive` attribute to apply the `BorshDeserialize` trait to the struct. This implements the methods defined in `BorshDeserialize`, including the `try_from_slice` method that we'll be using to deserialize the instruction data.
+To make deserializing instruction data simple, you can create a struct
+representing the data and use the `derive` attribute to apply the
+`BorshDeserialize` trait to the struct. This implements the methods defined in
+`BorshDeserialize`, including the `try_from_slice` method that we'll be using to
+deserialize the instruction data.
 
-Remember, the struct itself needs to match the structure of the data in the byte array.
+Remember, the struct itself needs to match the structure of the data in the byte
+array.
 
 ```rust
 #[derive(BorshDeserialize)]
@@ -221,9 +283,17 @@ struct NoteInstructionPayload {
 }
 ```
 
-Once this struct has been created, you can create an implementation for your instruction enum to handle the logic associated with deserializing instruction data. It's common to see this done inside a function called `unpack` that accepts the instruction data as an argument and returns the appropriate instance of the enum with the deserialized data.
+Once this struct has been created, you can create an implementation for your
+instruction enum to handle the logic associated with deserializing instruction
+data. It's common to see this done inside a function called `unpack` that
+accepts the instruction data as an argument and returns the appropriate instance
+of the enum with the deserialized data.
 
-It's standard practice to structure your program to expect the first byte (or other fixed number of bytes) to be an identifier for which instruction the program should run. This could be an integer or a string identifier. For this example, we'll use the first byte and map integers 0, 1, and 2 to instructions create, update, and delete, respectively.
+It's standard practice to structure your program to expect the first byte (or
+other fixed number of bytes) to be an identifier for which instruction the
+program should run. This could be an integer or a string identifier. For this
+example, we'll use the first byte and map integers 0, 1, and 2 to instructions
+create, update, and delete, respectively.
 
 ```rust
 impl NoteInstruction {
@@ -259,15 +329,25 @@ impl NoteInstruction {
 
 There's a lot in this example so let's take it one step at a time:
 
-1. This function starts by using the `split_first` function on the `input` parameter to return a tuple. The first element, `variant`, is the first byte from the byte array and the second element, `rest`, is the rest of the byte array.
-2. The function then uses the `try_from_slice` method on `NoteInstructionPayload` to deserialize the rest of the byte array into an instance of `NoteInstructionPayload` called `payload`
-3. Finally, the function uses a `match` statement on `variant` to create and return the appropriate enum instance using information from `payload`
+1. This function starts by using the `split_first` function on the `input`
+   parameter to return a tuple. The first element, `variant`, is the first byte
+   from the byte array and the second element, `rest`, is the rest of the byte
+   array.
+2. The function then uses the `try_from_slice` method on
+   `NoteInstructionPayload` to deserialize the rest of the byte array into an
+   instance of `NoteInstructionPayload` called `payload`
+3. Finally, the function uses a `match` statement on `variant` to create and
+   return the appropriate enum instance using information from `payload`
 
-Note that there is Rust syntax in this function that we haven't explained yet. The `ok_or` and `unwrap` functions are used for error handling and will be discussed in detail in another lesson.
+Note that there is Rust syntax in this function that we haven't explained yet.
+The `ok_or` and `unwrap` functions are used for error handling and will be
+discussed in detail in another lesson.
 
 ## Program logic
 
-With a way to deserialize instruction data into a custom Rust type, you can then use appropriate control flow to execute different code paths in your program based on which instruction is passed into your program's entry point.
+With a way to deserialize instruction data into a custom Rust type, you can then
+use appropriate control flow to execute different code paths in your program
+based on which instruction is passed into your program's entry point.
 
 ```rust
 entrypoint!(process_instruction);
@@ -294,25 +374,41 @@ pub fn process_instruction(
 }
 ```
 
-For simple programs where there are only one or two instructions to execute, it may be fine to write the logic inside the match statement. For programs with many different possible instructions to match against, your code will be much more readable if the logic for each instruction is written in a separate function and simply called from inside the `match` statement.
+For simple programs where there are only one or two instructions to execute, it
+may be fine to write the logic inside the match statement. For programs with
+many different possible instructions to match against, your code will be much
+more readable if the logic for each instruction is written in a separate
+function and simply called from inside the `match` statement.
 
 ## Program file structure
 
-The [Hello World lesson’s](hello-world-program.md) program was simple enough that it could be confined to one file. But as the complexity of a program grows, it's important to maintain a project structure that remains readable and extensible. This involves encapsulating code into functions and data structures as we've done so far. But it also involves grouping related code into separate files.
+The [Hello World lesson’s](hello-world-program.md) program was simple enough
+that it could be confined to one file. But as the complexity of a program grows,
+it's important to maintain a project structure that remains readable and
+extensible. This involves encapsulating code into functions and data structures
+as we've done so far. But it also involves grouping related code into separate
+files.
 
-For example, a good portion of the code we've worked through so far has to do with defining and deserializing instructions. That code should live in its own file rather than be written in the same file as the entry point. By doing so, we would then have 2 files, one with the program entry point and the other with the instruction code:
+For example, a good portion of the code we've worked through so far has to do
+with defining and deserializing instructions. That code should live in its own
+file rather than be written in the same file as the entry point. By doing so, we
+would then have 2 files, one with the program entry point and the other with the
+instruction code:
 
 - **lib.rs**
 - **instruction.rs**
 
-Once you start splitting your program up like this you will need to make sure you register all of the files in one central location. We’ll be doing this in `lib.rs`. **You must register every file in your program like this.**
+Once you start splitting your program up like this you will need to make sure
+you register all of the files in one central location. We’ll be doing this in
+`lib.rs`. **You must register every file in your program like this.**
 
 ```rust
 // This would be inside lib.rs
 pub mod instruction;
 ```
 
-Additionally, any declarations that you would like to be available through `use` statements in other files will need to be prefaced with the `pub` keyword:
+Additionally, any declarations that you would like to be available through `use`
+statements in other files will need to be prefaced with the `pub` keyword:
 
 ```rust
 pub enum NoteInstruction { ... }
@@ -320,15 +416,22 @@ pub enum NoteInstruction { ... }
 
 ## Demo
 
-For this lesson’s demo, we’ll be building out the first half of the Movie Review program that we worked with in Module 1. This program stores movie reviews submitted by users.
+For this lesson’s demo, we’ll be building out the first half of the Movie Review
+program that we worked with in Module 1. This program stores movie reviews
+submitted by users.
 
-For now, we'll focus on deserializing the instruction data. The following lesson will focus on the second half of this program.
+For now, we'll focus on deserializing the instruction data. The following lesson
+will focus on the second half of this program.
 
 ### 1. Entry point
 
-We’ll be using [Solana Playground](https://beta.solpg.io/) again to build out this program. Solana Playground saves state in your browser, so everything you did in the previous lesson may still be there. If it is, let's clear everything out from the current `lib.rs` file.
+We’ll be using [Solana Playground](https://beta.solpg.io/) again to build out
+this program. Solana Playground saves state in your browser, so everything you
+did in the previous lesson may still be there. If it is, let's clear everything
+out from the current `lib.rs` file.
 
-Inside lib.rs, we’re going to bring in the following crates and define where we’d like our entry point to the program to be with the `entrypoint` macro.
+Inside lib.rs, we’re going to bring in the following crates and define where
+we’d like our entry point to the program to be with the `entrypoint` macro.
 
 ```rust
 use solana_program::{
@@ -355,9 +458,13 @@ pub fn process_instruction(
 
 ### 2. Deserialize instruction data
 
-Before we continue with the processor logic, we should define our supported instructions and implement our deserialization function.
+Before we continue with the processor logic, we should define our supported
+instructions and implement our deserialization function.
 
-For readability, let's create a new file called `instruction.rs`. Inside this new file, add `use` statements for `BorshDeserialize` and `ProgramError`, then create a `MovieInstruction` enum with an `AddMovieReview` variant. This variant should have embedded values for `title,` `rating`, and `description`.
+For readability, let's create a new file called `instruction.rs`. Inside this
+new file, add `use` statements for `BorshDeserialize` and `ProgramError`, then
+create a `MovieInstruction` enum with an `AddMovieReview` variant. This variant
+should have embedded values for `title,` `rating`, and `description`.
 
 ```rust
 use borsh::{BorshDeserialize};
@@ -372,7 +479,9 @@ pub enum MovieInstruction {
 }
 ```
 
-Next, define a `MovieReviewPayload` struct. This will act as an intermediary type for deserializtion so it should use the `derive` attribute macro to provide a default implementation for the `BorshDeserialize` trait.
+Next, define a `MovieReviewPayload` struct. This will act as an intermediary
+type for deserializtion so it should use the `derive` attribute macro to provide
+a default implementation for the `BorshDeserialize` trait.
 
 ```rust
 #[derive(BorshDeserialize)]
@@ -383,11 +492,16 @@ struct MovieReviewPayload {
 }
 ```
 
-Finally, create an implementation for the `MovieInstruction` enum that defines and implements a function called `unpack` that takes a byte array as an argument and returns a `Result` type. This function should:
+Finally, create an implementation for the `MovieInstruction` enum that defines
+and implements a function called `unpack` that takes a byte array as an argument
+and returns a `Result` type. This function should:
 
-1. Use the `split_first` function to split the first byte of the array from the rest of the array
+1. Use the `split_first` function to split the first byte of the array from the
+   rest of the array
 2. Deserialize the rest of the array into an instance of `MovieReviewPayload`
-3. Use a `match` statement to return the `AddMovieReview` variant of `MovieInstruction` if the first byte of the array was a 0 or return a program error otherwise
+3. Use a `match` statement to return the `AddMovieReview` variant of
+   `MovieInstruction` if the first byte of the array was a 0 or return a program
+   error otherwise
 
 ```rust
 impl MovieInstruction {
@@ -413,16 +527,23 @@ impl MovieInstruction {
 
 ### 3. Program logic
 
-With the instruction deserialization handled, we can return to the `lib.rs` file to handle some of our program logic.
+With the instruction deserialization handled, we can return to the `lib.rs` file
+to handle some of our program logic.
 
-Remember, since we added code to a different file, we need to register it in the `lib.rs` file using `pub mod instruction;`. Then we can add a `use` statement to bring the `MovieInstruction` type into scope.
+Remember, since we added code to a different file, we need to register it in the
+`lib.rs` file using `pub mod instruction;`. Then we can add a `use` statement to
+bring the `MovieInstruction` type into scope.
 
 ```rust
 pub mod instruction;
 use instruction::{MovieInstruction};
 ```
 
-Next, let's define a new function `add_movie_review` that takes as arguments `program_id`, `accounts`, `title`, `rating`, and `description`. It should also return an instance of `ProgramResult` Inside this function, let's simply log our values for now and we'll revisit the rest of the implementation of the function in the next lesson.
+Next, let's define a new function `add_movie_review` that takes as arguments
+`program_id`, `accounts`, `title`, `rating`, and `description`. It should also
+return an instance of `ProgramResult` Inside this function, let's simply log our
+values for now and we'll revisit the rest of the implementation of the function
+in the next lesson.
 
 ```rust
 pub fn add_movie_review(
@@ -443,7 +564,11 @@ pub fn add_movie_review(
 }
 ```
 
-With that done, we can call `add_movie_review` from `process_instruction` (the function we set as our entry point). In order to pass all the required arguments to the function, we'll first need to call the `unpack` we created on `MovieInstruction`, then use a `match` statement to ensure that the instruction we've received is the `AddMovieReview` variant.
+With that done, we can call `add_movie_review` from `process_instruction` (the
+function we set as our entry point). In order to pass all the required arguments
+to the function, we'll first need to call the `unpack` we created on
+`MovieInstruction`, then use a `match` statement to ensure that the instruction
+we've received is the `AddMovieReview` variant.
 
 ```rust
 pub fn process_instruction(
@@ -463,20 +588,46 @@ pub fn process_instruction(
 }
 ```
 
-And just like that, your program should be functional enough to log the instruction data passed in when a transaction is submitted!
+And just like that, your program should be functional enough to log the
+instruction data passed in when a transaction is submitted!
 
-Build and deploy your program from Solana Program just like in the last lesson. If you haven't changed the program ID since going through the last lesson, it will automatically deploy to the same ID. If you'd like it to have a separate address you can generate a new program ID from the playground before deploying.
+Build and deploy your program from Solana Program just like in the last lesson.
+If you haven't changed the program ID since going through the last lesson, it
+will automatically deploy to the same ID. If you'd like it to have a separate
+address you can generate a new program ID from the playground before deploying.
 
-You can test your program by submitting a transaction with the right instruction data. For that, feel free to use [this script](https://github.com/Unboxed-Software/solana-movie-client) or [the frontend](https://github.com/Unboxed-Software/solana-movie-frontend) we built in the [Serialize Custom Instruction Data lesson](serialize-instruction-data.md). In both cases, make sure you copy and paste the program ID for your program into the appropriate area of the source code to make sure you're testing the right program.
+You can test your program by submitting a transaction with the right instruction
+data. For that, feel free to use
+[this script](https://github.com/Unboxed-Software/solana-movie-client) or
+[the frontend](https://github.com/Unboxed-Software/solana-movie-frontend) we
+built in the
+[Serialize Custom Instruction Data lesson](serialize-instruction-data.md). In
+both cases, make sure you copy and paste the program ID for your program into
+the appropriate area of the source code to make sure you're testing the right
+program.
 
-If you need to spend some more time with this demo before moving on, please do! You can also have a look at the program [solution code](https://beta.solpg.io/62aa9ba3b5e36a8f6716d45b) if you get stuck.
+If you need to spend some more time with this demo before moving on, please do!
+You can also have a look at the program
+[solution code](https://beta.solpg.io/62aa9ba3b5e36a8f6716d45b) if you get
+stuck.
 
 # Challenge
 
-For this lesson's challenge, try replicating the Student Intro program from Module 1. Recall that we created a frontend application that lets students introduce themselves! The program takes a user's name and a short message as the `instruction_data` and creates an account to store the data on-chain.
+For this lesson's challenge, try replicating the Student Intro program from
+Module 1. Recall that we created a frontend application that lets students
+introduce themselves! The program takes a user's name and a short message as the
+`instruction_data` and creates an account to store the data on-chain.
 
-Using what you've learned in this lesson, build the Student Intro program to the point where you can print the `name` and `message` provided by the user to the program logs when the program is invoked.
+Using what you've learned in this lesson, build the Student Intro program to the
+point where you can print the `name` and `message` provided by the user to the
+program logs when the program is invoked.
 
-You can test your program by building the [frontend](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data) we created in the [Serialize Custom Instruction Data lesson](serialize-instruction-data.md) and then checking the program logs on Solana Explorer. Remember to replace the program ID in the frontend code with the one you've deployed.
+You can test your program by building the
+[frontend](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data)
+we created in the
+[Serialize Custom Instruction Data lesson](serialize-instruction-data.md) and
+then checking the program logs on Solana Explorer. Remember to replace the
+program ID in the frontend code with the one you've deployed.
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://beta.solpg.io/62b0ce53f6273245aca4f5b0).
+Try to do this independently if you can! But if you get stuck, feel free to
+reference the [solution code](https://beta.solpg.io/62b0ce53f6273245aca4f5b0).

--- a/developers/courses/solana-course/content/duplicate-mutable-accounts.md
+++ b/developers/courses/solana-course/content/duplicate-mutable-accounts.md
@@ -1,15 +1,19 @@
 ---
 title: Duplicate Mutable Accounts
 objectives:
-  - Explain the security risks associated with instructions that require two mutable accounts of the same type and how to avoid them
+  - Explain the security risks associated with instructions that require two
+    mutable accounts of the same type and how to avoid them
   - Implement a check for duplicate mutable accounts using long-form Rust
   - Implement a check for duplicate mutable accounts using Anchor constraints
 ---
 
 # TL;DR
 
-- When an instruction requires two mutable accounts of the same type, an attacker can pass in the same account twice, causing the account to be mutated in unintended ways.
-- To check for duplicate mutable accounts in Rust, simply compare the public keys of the two accounts and throw an error if they are the same.
+- When an instruction requires two mutable accounts of the same type, an
+  attacker can pass in the same account twice, causing the account to be mutated
+  in unintended ways.
+- To check for duplicate mutable accounts in Rust, simply compare the public
+  keys of the two accounts and throw an error if they are the same.
 
   ```rust
   if ctx.accounts.account_one.key() == ctx.accounts.account_two.key() {
@@ -17,19 +21,38 @@ objectives:
   }
   ```
 
-- In Anchor, you can use `constraint` to add an explicit constraint to an account checking that it is not the same as another account.
+- In Anchor, you can use `constraint` to add an explicit constraint to an
+  account checking that it is not the same as another account.
 
 # Overview
 
-Duplicate Mutable Accounts refers to an instruction that requires two mutable accounts of the same type. When this occurs, you should validate that two accounts are different to prevent the same account from being passed into the instruction twice.
+Duplicate Mutable Accounts refers to an instruction that requires two mutable
+accounts of the same type. When this occurs, you should validate that two
+accounts are different to prevent the same account from being passed into the
+instruction twice.
 
-Since the program treats each account as separate, passing in the same account twice could result in the second account being mutated in unintended ways. This could result in very minor issues, or catastrophic ones - it really depends on what data the code changes and how these accounts are used. Regardless, this is a vulnerability all developers should be aware of.
+Since the program treats each account as separate, passing in the same account
+twice could result in the second account being mutated in unintended ways. This
+could result in very minor issues, or catastrophic ones - it really depends on
+what data the code changes and how these accounts are used. Regardless, this is
+a vulnerability all developers should be aware of.
 
 ### No check
 
-For example, imagine a program that updates a `data` field for `user_a` and `user_b` in a single instruction. The value that the instruction sets for `user_a` is different from `user_b`. Without verifying that `user_a` and `user_b` are different, the program would update the `data` field on the `user_a` account, then update the `data` field a second time with a different value under the assumption that `user_b` is a separate account.
+For example, imagine a program that updates a `data` field for `user_a` and
+`user_b` in a single instruction. The value that the instruction sets for
+`user_a` is different from `user_b`. Without verifying that `user_a` and
+`user_b` are different, the program would update the `data` field on the
+`user_a` account, then update the `data` field a second time with a different
+value under the assumption that `user_b` is a separate account.
 
-You can see this example in the code below.Tthere is no check to verify that `user_a` and `user_b` are not the same account. Passing in the same account for `user_a` and `user_b` will result in the `data` field for the account being set to `b` even though the intent is to set both values `a` and `b` on separate accounts. Depending on what `data` represents, this could be a minor unintended side-effect, or it could mean a severe security risk. allowing `user_a` and `user_b` to be the same account could result in
+You can see this example in the code below.Tthere is no check to verify that
+`user_a` and `user_b` are not the same account. Passing in the same account for
+`user_a` and `user_b` will result in the `data` field for the account being set
+to `b` even though the intent is to set both values `a` and `b` on separate
+accounts. Depending on what `data` represents, this could be a minor unintended
+side-effect, or it could mean a severe security risk. allowing `user_a` and
+`user_b` to be the same account could result in
 
 ```rust
 use anchor_lang::prelude::*;
@@ -64,7 +87,9 @@ pub struct User {
 
 ### Add check in instruction
 
-To fix this problem with plan Rust, simply add a check in the instruction logic to verify that the public key of `user_a` isn't the same as the public key of `user_b`, returning an error if they are the same.
+To fix this problem with plan Rust, simply add a check in the instruction logic
+to verify that the public key of `user_a` isn't the same as the public key of
+`user_b`, returning an error if they are the same.
 
 ```rust
 if ctx.accounts.user_a.key() == ctx.accounts.user_b.key() {
@@ -110,11 +135,16 @@ pub struct User {
 
 ### Use Anchor `constraint`
 
-An even better solution if you're using Anchor is to add the check to the account validation struct instead of the instruction logic.
+An even better solution if you're using Anchor is to add the check to the
+account validation struct instead of the instruction logic.
 
-You can use the `#[account(..)]` attribute macro and the `constraint` keyword to add a manual constraint to an account. The `constraint` keyword will check whether the expression that follows evaluates to true or false, returning an error if the expression evaluates to false.
+You can use the `#[account(..)]` attribute macro and the `constraint` keyword to
+add a manual constraint to an account. The `constraint` keyword will check
+whether the expression that follows evaluates to true or false, returning an
+error if the expression evaluates to false.
 
-The example below moves the check from the instruction logic to the account validation struct by adding a `constraint` to the `#[account(..)]` attribute.
+The example below moves the check from the instruction logic to the account
+validation struct by adding a `constraint` to the `#[account(..)]` attribute.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -150,21 +180,37 @@ pub struct User {
 
 # Demo
 
-Let’s practice by creating a simple Rock Paper Scissors program to demonstrate how failing to check for duplicate mutable accounts can cause undefined behavior within your program.
+Let’s practice by creating a simple Rock Paper Scissors program to demonstrate
+how failing to check for duplicate mutable accounts can cause undefined behavior
+within your program.
 
-This program will initialize “player” accounts and have a separate instruction that requires two player accounts to represent starting a game of rock paper scissors.
+This program will initialize “player” accounts and have a separate instruction
+that requires two player accounts to represent starting a game of rock paper
+scissors.
 
 - An `initialize` instruction to initialize a `PlayerState` account
-- A `rock_paper_scissors_shoot_insecure` instruction that requires two `PlayerState` accounts, but does not check that the accounts passed into the instruction are different
-- A `rock_paper_scissors_shoot_secure` instruction that is the same as the `rock_paper_scissors_shoot_insecure` instruction but adds a constraint that ensures the two player accounts are different
+- A `rock_paper_scissors_shoot_insecure` instruction that requires two
+  `PlayerState` accounts, but does not check that the accounts passed into the
+  instruction are different
+- A `rock_paper_scissors_shoot_secure` instruction that is the same as the
+  `rock_paper_scissors_shoot_insecure` instruction but adds a constraint that
+  ensures the two player accounts are different
 
 ### 1. Starter
 
-To get started, download the starter code on the `starter` branch of [this repository](https://github.com/unboxed-software/solana-duplicate-mutable-accounts/tree/starter). The starter code includes a program with two instructions and the boilerplate setup for the test file.
+To get started, download the starter code on the `starter` branch
+of [this repository](https://github.com/unboxed-software/solana-duplicate-mutable-accounts/tree/starter).
+The starter code includes a program with two instructions and the boilerplate
+setup for the test file.
 
-The `initialize` instruction initializes a new `PlayerState` account that stores the public key of a player and a `choice` field that is set to `None`.
+The `initialize` instruction initializes a new `PlayerState` account that stores
+the public key of a player and a `choice` field that is set to `None`.
 
-The `rock_paper_scissors_shoot_insecure` instruction requires two `PlayerState` accounts and requires a choice from the `RockPaperScissors` enum for each player, but does not check that the accounts passed into the instruction are different. This means a single account can be used for both `PlayerState` accounts in the instruction.
+The `rock_paper_scissors_shoot_insecure` instruction requires two `PlayerState`
+accounts and requires a choice from the `RockPaperScissors` enum for each
+player, but does not check that the accounts passed into the instruction are
+different. This means a single account can be used for both `PlayerState`
+accounts in the instruction.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -231,9 +277,11 @@ pub enum RockPaperScissors {
 
 ### 2. Test `rock_paper_scissors_shoot_insecure` instruction
 
-The test file includes the code to invoke the `initialize` instruction twice to create two player accounts.
+The test file includes the code to invoke the `initialize` instruction twice to
+create two player accounts.
 
-Add a test to invoke the `rock_paper_scissors_shoot_insecure` instruction by passing in the `playerOne.publicKey` for as both `playerOne` and `playerTwo`.
+Add a test to invoke the `rock_paper_scissors_shoot_insecure` instruction by
+passing in the `playerOne.publicKey` for as both `playerOne` and `playerTwo`.
 
 ```ts
 describe("duplicate-mutable-accounts", () => {
@@ -254,7 +302,11 @@ describe("duplicate-mutable-accounts", () => {
 })
 ```
 
-Run `anchor test` to see that the transactions completes successfully, even though the same account is used as two accounts in the instruction. Since the `playerOne` account is used as both players in the instruction, note the `choice` stored on the `playerOne` account is also overridden and set incorrectly as `scissors`.
+Run `anchor test` to see that the transactions completes successfully, even
+though the same account is used as two accounts in the instruction. Since the
+`playerOne` account is used as both players in the instruction, note the
+`choice` stored on the `playerOne` account is also overridden and set
+incorrectly as `scissors`.
 
 ```bash
 duplicate-mutable-accounts
@@ -263,11 +315,18 @@ duplicate-mutable-accounts
   ✔ Invoke insecure instruction (406ms)
 ```
 
-Not only does allowing duplicate accounts not make a whole lot of sense for the game, it also causes undefined behavior. If we were to build out this program further, the program only has one chosen option and therefore can't compare against a second option. The game would end in a draw every time. It's also unclear to a human whether `playerOne`'s choice should be rock or scissors, so the program behavior is strange.
+Not only does allowing duplicate accounts not make a whole lot of sense for the
+game, it also causes undefined behavior. If we were to build out this program
+further, the program only has one chosen option and therefore can't compare
+against a second option. The game would end in a draw every time. It's also
+unclear to a human whether `playerOne`'s choice should be rock or scissors, so
+the program behavior is strange.
 
 ### 3. Add `rock_paper_scissors_shoot_secure` instruction
 
-Next, return to `lib.rs` and add a `rock_paper_scissors_shoot_secure` instruction that uses the `#[account(...)]` macro to add an additional `constraint` to check that `player_one` and `player_two` are different accounts.
+Next, return to `lib.rs` and add a `rock_paper_scissors_shoot_secure`
+instruction that uses the `#[account(...)]` macro to add an additional
+`constraint` to check that `player_one` and `player_two` are different accounts.
 
 ```rust
 #[program]
@@ -300,7 +359,11 @@ pub struct RockPaperScissorsSecure<'info> {
 
 ### 7. Test `rock_paper_scissors_shoot_secure` instruction
 
-To test the `rock_paper_scissors_shoot_secure` instruction, we’ll invoke the instruction twice. First, we’ll invoke the instruction using two different player accounts to check that the instruction works as intended. Then, we’ll invoke the instruction using the `playerOne.publicKey` as both player accounts, which we expect to fail.
+To test the `rock_paper_scissors_shoot_secure` instruction, we’ll invoke the
+instruction twice. First, we’ll invoke the instruction using two different
+player accounts to check that the instruction works as intended. Then, we’ll
+invoke the instruction using the `playerOne.publicKey` as both player accounts,
+which we expect to fail.
 
 ```ts
 describe("duplicate-mutable-accounts", () => {
@@ -337,7 +400,8 @@ describe("duplicate-mutable-accounts", () => {
 })
 ```
 
-Run `anchor test` to see that the instruction works as intended and using the `playerOne` account twice returns the expected error.
+Run `anchor test` to see that the instruction works as intended and using the
+`playerOne` account twice returns the expected error.
 
 ```bash
 'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS invoke [1]',
@@ -347,14 +411,25 @@ Run `anchor test` to see that the instruction works as intended and using the `p
 'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS failed: custom program error: 0x7d3'
 ```
 
-The simple constraint is all it takes to close this loophole. While somewhat contrived, this example illustrates the odd behavior that can occur if you write your program under the assumption that two same-typed accounts will be different instances of an account but don't explicitly write that constraint into your program. Always think about the behavior you're expecting from the program and whether that is explicit.
+The simple constraint is all it takes to close this loophole. While somewhat
+contrived, this example illustrates the odd behavior that can occur if you write
+your program under the assumption that two same-typed accounts will be different
+instances of an account but don't explicitly write that constraint into your
+program. Always think about the behavior you're expecting from the program and
+whether that is explicit.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the repository](https://github.com/Unboxed-Software/solana-duplicate-mutable-accounts/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the repository](https://github.com/Unboxed-Software/solana-duplicate-mutable-accounts/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that any instructions with two same-typed mutable accounts are properly constrained to avoid duplicates.
+Take some time to review at least one program and ensure that any instructions
+with two same-typed mutable accounts are properly constrained to avoid
+duplicates.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/duplicate-mutable-accounts.md
+++ b/developers/courses/solana-course/content/duplicate-mutable-accounts.md
@@ -1,9 +1,9 @@
 ---
 title: Duplicate Mutable Accounts
 objectives:
-- Explain the security risks associated with instructions that require two mutable accounts of the same type and how to avoid them
-- Implement a check for duplicate mutable accounts using long-form Rust
-- Implement a check for duplicate mutable accounts using Anchor constraints
+  - Explain the security risks associated with instructions that require two mutable accounts of the same type and how to avoid them
+  - Implement a check for duplicate mutable accounts using long-form Rust
+  - Implement a check for duplicate mutable accounts using Anchor constraints
 ---
 
 # TL;DR

--- a/developers/courses/solana-course/content/env-variables.md
+++ b/developers/courses/solana-course/content/env-variables.md
@@ -1,18 +1,18 @@
 ---
 title: Environment Variables in Solana Programs
 objectives:
-- Define program features in the `Cargo.toml` file
-- Use the Rust `cfg` attribute to conditionally compile code based on which features are or are not enabled
-- Use the Rust `cfg!` macro to conditionally compile code based on which features are or are not enabled
-- Create an admin-only instruction to set up a program account that can be used to store program configuration values
+  - Define program features in the `Cargo.toml` file
+  - Use the Rust `cfg` attribute to conditionally compile code based on which features are or are not enabled
+  - Use the Rust `cfg!` macro to conditionally compile code based on which features are or are not enabled
+  - Create an admin-only instruction to set up a program account that can be used to store program configuration values
 ---
 
 # TL;DR
 
--   There are no "out of the box" solutions for creating distinct environments in an on-chain program, but you can achieve something similar to environment variables if you get creative.
--   You can use the `cfg` attribute with **Rust features** (`#[cfg(feature = ...)]`) to run different code or provide different variable values based on the Rust feature provided. _This happens at compile-time and doesn't allow you to swap values after a program has been deployed_.
--   Similarly, you can use the `cfg!` **macro** to compile different code paths based on the features that are enabled.
--   Alternatively, you can achieve something similar to environment variables that can be modified after deployment by creating accounts and instructions that are only accessible by the program’s upgrade authority.
+- There are no "out of the box" solutions for creating distinct environments in an on-chain program, but you can achieve something similar to environment variables if you get creative.
+- You can use the `cfg` attribute with **Rust features** (`#[cfg(feature = ...)]`) to run different code or provide different variable values based on the Rust feature provided. _This happens at compile-time and doesn't allow you to swap values after a program has been deployed_.
+- Similarly, you can use the `cfg!` **macro** to compile different code paths based on the features that are enabled.
+- Alternatively, you can achieve something similar to environment variables that can be modified after deployment by creating accounts and instructions that are only accessible by the program’s upgrade authority.
 
 # Overview
 
@@ -315,7 +315,7 @@ Before we continue, take a few minutes to familiarize yourself with these files 
 
 Let's start by running the existing test.
 
-Make sure you use `yarn` or `npm install` to install the dependencies laid out in the `package.json` file. Then be sure to run `anchor keys list` to get the public key for your program printed to the console. This differs based on the keypair you have locally, so you need to update `lib.rs` and `Anchor.toml` to use *your* key.
+Make sure you use `yarn` or `npm install` to install the dependencies laid out in the `package.json` file. Then be sure to run `anchor keys list` to get the public key for your program printed to the console. This differs based on the keypair you have locally, so you need to update `lib.rs` and `Anchor.toml` to use _your_ key.
 
 Finally, run `anchor test` to start the test. It should fail with the following output:
 
@@ -323,11 +323,11 @@ Finally, run `anchor test` to start the test. It should fail with the following 
 Error: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: incorrect program id for instruction
 ```
 
-The reason for this error is that we're attempting to use the mainnet USDC mint address (as hard-coded in the `lib.rs` file of the program), but that mint doesn't exist in the local environment. 
+The reason for this error is that we're attempting to use the mainnet USDC mint address (as hard-coded in the `lib.rs` file of the program), but that mint doesn't exist in the local environment.
 
 ### 3. Adding a `local-testing` feature
 
-To fix this, we need a mint we can use locally *and* hard-code into the program. Since the local environment is reset often during testing, you'll need to store a keypair that you can use to recreate the same mint address every time.
+To fix this, we need a mint we can use locally _and_ hard-code into the program. Since the local environment is reset often during testing, you'll need to store a keypair that you can use to recreate the same mint address every time.
 
 Additionally, you don't want to have to change the hard-coded address between local and mainnet builds since that could introduce human error (and is just annoying). So we'll create a `local-testing` feature that, when enabled, will make the program use our local mint but otherwise use the production USDC mint.
 
@@ -383,7 +383,7 @@ Next, update the `config.ts` test file to create a mint using the generated keyp
 
 ```ts
 const mint = new anchor.web3.PublicKey(
-    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
 );
 ```
 
@@ -713,21 +713,19 @@ it("Initialize Program Config Account", async () => {
       authority: wallet.publicKey,
       systemProgram: anchor.web3.SystemProgram.programId,
     })
-    .rpc()
+    .rpc();
 
   assert.strictEqual(
     (
       await program.account.programConfig.fetch(programConfig)
     ).feeBasisPoints.toNumber(),
-    100
-  )
+    100,
+  );
   assert.strictEqual(
-    (
-      await program.account.programConfig.fetch(programConfig)
-    ).admin.toString(),
-    wallet.publicKey.toString()
-  )
-})
+    (await program.account.programConfig.fetch(programConfig)).admin.toString(),
+    wallet.publicKey.toString(),
+  );
+});
 ```
 
 The second test verifies that the payment instruction is working correctly, with the fee being sent to the fee destination and the remaining balance being transferred to the receiver. Here we update the existing test to include the `programConfig` account.
@@ -743,27 +741,27 @@ it("Payment completes successfully", async () => {
       receiverTokenAccount: receiverTokenAccount,
       sender: sender.publicKey,
     })
-    .transaction()
+    .transaction();
 
-  await anchor.web3.sendAndConfirmTransaction(connection, tx, [sender])
+  await anchor.web3.sendAndConfirmTransaction(connection, tx, [sender]);
 
   assert.strictEqual(
     (await connection.getTokenAccountBalance(senderTokenAccount)).value
       .uiAmount,
-    0
-  )
+    0,
+  );
 
   assert.strictEqual(
     (await connection.getTokenAccountBalance(feeDestination)).value.uiAmount,
-    100
-  )
+    100,
+  );
 
   assert.strictEqual(
     (await connection.getTokenAccountBalance(receiverTokenAccount)).value
       .uiAmount,
-    9900
-  )
-})
+    9900,
+  );
+});
 ```
 
 The third test attempts to update the fee on the program config account, which should be successful.
@@ -778,15 +776,15 @@ it("Update Program Config Account", async () => {
       feeDestination: feeDestination,
       newAdmin: sender.publicKey,
     })
-    .rpc()
+    .rpc();
 
   assert.strictEqual(
     (
       await program.account.programConfig.fetch(programConfig)
     ).feeBasisPoints.toNumber(),
-    200
-  )
-})
+    200,
+  );
+});
 ```
 
 The fourth test tries to update the fee on the program config account, where the admin is not the one stored on the program config account, and this should fail.
@@ -802,13 +800,13 @@ it("Update Program Config Account with unauthorized admin (expect fail)", async 
         feeDestination: feeDestination,
         newAdmin: sender.publicKey,
       })
-      .transaction()
+      .transaction();
 
-    await anchor.web3.sendAndConfirmTransaction(connection, tx, [sender])
+    await anchor.web3.sendAndConfirmTransaction(connection, tx, [sender]);
   } catch (err) {
-    expect(err)
+    expect(err);
   }
-})
+});
 ```
 
 Finally, run the test using the following command:
@@ -833,7 +831,7 @@ And that's it! You've made the program a lot easier to work with moving forward.
 
 # Challenge
 
-Now it's time for you to do some of this on your own. We mentioned being able to use the program's upgrade authority as the initial admin.  Go ahead and update the demo's `initialize_program_config` so that only the upgrade authority can call it rather than having a hardcoded `ADMIN`.
+Now it's time for you to do some of this on your own. We mentioned being able to use the program's upgrade authority as the initial admin. Go ahead and update the demo's `initialize_program_config` so that only the upgrade authority can call it rather than having a hardcoded `ADMIN`.
 
 Note that the `anchor test` command, when run on a local network, starts a new test validator using `solana-test-validator`. This test validator uses a non-upgradeable loader. The non-upgradeable loader makes it so the program's `program_data` account isn't initialized when the validator starts. You'll recall from the lesson that this account is how we access the upgrade authority from the program.
 

--- a/developers/courses/solana-course/content/env-variables.md
+++ b/developers/courses/solana-course/content/env-variables.md
@@ -2,34 +2,60 @@
 title: Environment Variables in Solana Programs
 objectives:
   - Define program features in the `Cargo.toml` file
-  - Use the Rust `cfg` attribute to conditionally compile code based on which features are or are not enabled
-  - Use the Rust `cfg!` macro to conditionally compile code based on which features are or are not enabled
-  - Create an admin-only instruction to set up a program account that can be used to store program configuration values
+  - Use the Rust `cfg` attribute to conditionally compile code based on which
+    features are or are not enabled
+  - Use the Rust `cfg!` macro to conditionally compile code based on which
+    features are or are not enabled
+  - Create an admin-only instruction to set up a program account that can be
+    used to store program configuration values
 ---
 
 # TL;DR
 
-- There are no "out of the box" solutions for creating distinct environments in an on-chain program, but you can achieve something similar to environment variables if you get creative.
-- You can use the `cfg` attribute with **Rust features** (`#[cfg(feature = ...)]`) to run different code or provide different variable values based on the Rust feature provided. _This happens at compile-time and doesn't allow you to swap values after a program has been deployed_.
-- Similarly, you can use the `cfg!` **macro** to compile different code paths based on the features that are enabled.
-- Alternatively, you can achieve something similar to environment variables that can be modified after deployment by creating accounts and instructions that are only accessible by the program’s upgrade authority.
+- There are no "out of the box" solutions for creating distinct environments in
+  an on-chain program, but you can achieve something similar to environment
+  variables if you get creative.
+- You can use the `cfg` attribute with **Rust features**
+  (`#[cfg(feature = ...)]`) to run different code or provide different variable
+  values based on the Rust feature provided. _This happens at compile-time and
+  doesn't allow you to swap values after a program has been deployed_.
+- Similarly, you can use the `cfg!` **macro** to compile different code paths
+  based on the features that are enabled.
+- Alternatively, you can achieve something similar to environment variables that
+  can be modified after deployment by creating accounts and instructions that
+  are only accessible by the program’s upgrade authority.
 
 # Overview
 
-One of the difficulties engineers face across all types of software development is that of writing testable code and creating distinct environments for local development, testing, production, etc.
+One of the difficulties engineers face across all types of software development
+is that of writing testable code and creating distinct environments for local
+development, testing, production, etc.
 
-This can be particularly difficult in Solana program development. For example, imagine creating an NFT staking program that rewards each staked NFT with 10 reward tokens per day. How do you test the ability to claim rewards when tests run in a few hundred milliseconds, not nearly long enough to earn rewards?
+This can be particularly difficult in Solana program development. For example,
+imagine creating an NFT staking program that rewards each staked NFT with 10
+reward tokens per day. How do you test the ability to claim rewards when tests
+run in a few hundred milliseconds, not nearly long enough to earn rewards?
 
-Traditional web development solves some of this with environment variables whose values can differ in each distinct "environment." Currently, there's no formal concept of environment variables in a Solana program. If there were, you could just make it so that rewards in your test environment are 10,000,000 tokens per day and it would be easier to test the ability to claim rewards.
+Traditional web development solves some of this with environment variables whose
+values can differ in each distinct "environment." Currently, there's no formal
+concept of environment variables in a Solana program. If there were, you could
+just make it so that rewards in your test environment are 10,000,000 tokens per
+day and it would be easier to test the ability to claim rewards.
 
-Fortunately, you can achieve similar functionality if you get creative. The best approach is probably a combination of two things:
+Fortunately, you can achieve similar functionality if you get creative. The best
+approach is probably a combination of two things:
 
-1. Rust feature flags that allow you to specify in your build command the "environment" of the build, coupled with code that adjusts specific values accordingly
-2. Program "admin-only" accounts and instructions that are only accessible by the program's upgrade authority
+1. Rust feature flags that allow you to specify in your build command the
+   "environment" of the build, coupled with code that adjusts specific values
+   accordingly
+2. Program "admin-only" accounts and instructions that are only accessible by
+   the program's upgrade authority
 
 ## Rust feature flags
 
-One of the simplest ways to create environments is to use Rust features. Features are defined in the `[features]` table of the program’s `Cargo.toml` file. You may define multiple features for different use cases.
+One of the simplest ways to create environments is to use Rust features.
+Features are defined in the `[features]` table of the program’s `Cargo.toml`
+file. You may define multiple features for different use cases.
 
 ```toml
 [features]
@@ -37,7 +63,9 @@ feature-one = []
 feature-two = []
 ```
 
-It's important to note that the above simply defines a feature. To enable a feature when testing your program, you can use the `--features` flag with the `anchor test` command.
+It's important to note that the above simply defines a feature. To enable a
+feature when testing your program, you can use the `--features` flag with the
+`anchor test` command.
 
 ```bash
 anchor test -- --features "feature-one"
@@ -51,9 +79,14 @@ anchor test -- --features "feature-one", "feature-two"
 
 ### Make code conditional using the `cfg` attribute
 
-With a feature defined, you can then use the `cfg` attribute within your code to conditionally compile code based on the whether or not a given feature is enabled. This allows you to include or exclude certain code from your program.
+With a feature defined, you can then use the `cfg` attribute within your code to
+conditionally compile code based on the whether or not a given feature is
+enabled. This allows you to include or exclude certain code from your program.
 
-The syntax for using the `cfg` attribute is like any other attribute macro: `#[cfg(feature=[FEATURE_HERE])]`. For example, the following code compiles the function `function_for_testing` when the `testing` feature is enabled and the `function_when_not_testing` otherwise:
+The syntax for using the `cfg` attribute is like any other attribute macro:
+`#[cfg(feature=[FEATURE_HERE])]`. For example, the following code compiles the
+function `function_for_testing` when the `testing` feature is enabled and the
+`function_when_not_testing` otherwise:
 
 ```rust
 #[cfg(feature = "testing")]
@@ -67,11 +100,19 @@ fn function_when_not_testing() {
 }
 ```
 
-This allows you to enable or disable certain functionality in your Anchor program at compile time by enabling or disabling the feature.
+This allows you to enable or disable certain functionality in your Anchor
+program at compile time by enabling or disabling the feature.
 
-It's not a stretch to imagine wanting to use this to create distinct "environments" for different program deployments. For example, not all tokens have deployments across both Mainnet and Devnet. So you might hard-code one token address for Mainnet deployments but hard-code a different address for Devnet and Localnet deployments. That way you can quickly switch between between different environments without requiring any changes to the code itself.
+It's not a stretch to imagine wanting to use this to create distinct
+"environments" for different program deployments. For example, not all tokens
+have deployments across both Mainnet and Devnet. So you might hard-code one
+token address for Mainnet deployments but hard-code a different address for
+Devnet and Localnet deployments. That way you can quickly switch between between
+different environments without requiring any changes to the code itself.
 
-The code below shows an example of an Anchor program that uses the `cfg` attribute to include different token addresses for local testing compared to other deployments:
+The code below shows an example of an Anchor program that uses the `cfg`
+attribute to include different token addresses for local testing compared to
+other deployments:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -119,15 +160,25 @@ pub struct Initialize<'info> {
 }
 ```
 
-In this example, the `cfg` attribute is used to conditionally compile two different implementations of the `constants` module. This allows the program to use different values for the `USDC_MINT_PUBKEY` constant depending on whether or not the `local-testing` feature is enabled.
+In this example, the `cfg` attribute is used to conditionally compile two
+different implementations of the `constants` module. This allows the program to
+use different values for the `USDC_MINT_PUBKEY` constant depending on whether or
+not the `local-testing` feature is enabled.
 
 ### Make code conditional using the `cfg!` macro
 
-Similar to the `cfg` attribute, the `cfg!` **macro** in Rust allows you to check the values of certain configuration flags at runtime. This can be useful if you want to execute different code paths depending on the values of certain configuration flags.
+Similar to the `cfg` attribute, the `cfg!` **macro** in Rust allows you to check
+the values of certain configuration flags at runtime. This can be useful if you
+want to execute different code paths depending on the values of certain
+configuration flags.
 
-You could use this to bypass or adjust the time-based constraints required in the NFT staking app we mentioned previously. When running a test, you can execute code that provides far higher staking rewards when compared to running a production build.
+You could use this to bypass or adjust the time-based constraints required in
+the NFT staking app we mentioned previously. When running a test, you can
+execute code that provides far higher staking rewards when compared to running a
+production build.
 
-To use the `cfg!` macro in an Anchor program, you simply add a `cfg!` macro call to the conditional statement in question:
+To use the `cfg!` macro in an Anchor program, you simply add a `cfg!` macro call
+to the conditional statement in question:
 
 ```rust
 #[program]
@@ -149,27 +200,45 @@ pub mod my_program {
 }
 ```
 
-In this example, the `test_function` uses the `cfg!` macro to check the value of the `local-testing` feature at runtime. If the `local-testing` feature is enabled, the first code path is executed. If the `local-testing` feature is not enabled, the second code path is executed instead.
+In this example, the `test_function` uses the `cfg!` macro to check the value of
+the `local-testing` feature at runtime. If the `local-testing` feature is
+enabled, the first code path is executed. If the `local-testing` feature is not
+enabled, the second code path is executed instead.
 
 ## Admin-only instructions
 
-Feature flags are great for adjusting values and code paths at compilation, but they don't help much if you end up needing to adjust something after you've already deployed your program.
+Feature flags are great for adjusting values and code paths at compilation, but
+they don't help much if you end up needing to adjust something after you've
+already deployed your program.
 
-For example, if your NFT staking program has to pivot and use a different rewards token, there'd be no way to update the program without redeploying. If only there were a way for program admins to update certain program values... Well, it's possible!
+For example, if your NFT staking program has to pivot and use a different
+rewards token, there'd be no way to update the program without redeploying. If
+only there were a way for program admins to update certain program values...
+Well, it's possible!
 
-First, you need to structure your program to store the values you anticipate changing in an account rather than hard-coding them into the program code.
+First, you need to structure your program to store the values you anticipate
+changing in an account rather than hard-coding them into the program code.
 
-Next, you need to ensure that this account can only be updated by some known program authority, or what we're calling an admin. That means any instructions that modify the data on this account need to have constraints limiting who can sign for the instruction. This sounds fairly straightforward in theory, but there is one main issues: how does the program know who is an authorized admin?
+Next, you need to ensure that this account can only be updated by some known
+program authority, or what we're calling an admin. That means any instructions
+that modify the data on this account need to have constraints limiting who can
+sign for the instruction. This sounds fairly straightforward in theory, but
+there is one main issues: how does the program know who is an authorized admin?
 
 Well, there are a few solutions, each with their own benefits and drawbacks:
 
-1. Hard-code an admin public key that can be used in the admin-only instruction constraints.
+1. Hard-code an admin public key that can be used in the admin-only instruction
+   constraints.
 2. Make the program's upgrade authority the admin.
-3. Store the admin in the config account and set the first admin in an `initialize` instruction.
+3. Store the admin in the config account and set the first admin in an
+   `initialize` instruction.
 
 ### Create the config account
 
-The first step is adding what we'll call a "config" account to your program. You can customize this to best suit your needs, but we suggest a single global PDA. In Anchor, that simply means creating an account struct and using a single seed to derive the account's address.
+The first step is adding what we'll call a "config" account to your program. You
+can customize this to best suit your needs, but we suggest a single global PDA.
+In Anchor, that simply means creating an account struct and using a single seed
+to derive the account's address.
 
 ```rust
 pub const SEED_PROGRAM_CONFIG: &[u8] = b"program_config";
@@ -181,15 +250,25 @@ pub struct ProgramConfig {
 }
 ```
 
-The example above shows a hypothetical config account for the NFT staking program example we've referenced throughout the lesson. It stores data representing the token that should be used for rewards and the amount of tokens to give out for each day of staking.
+The example above shows a hypothetical config account for the NFT staking
+program example we've referenced throughout the lesson. It stores data
+representing the token that should be used for rewards and the amount of tokens
+to give out for each day of staking.
 
-With the config account defined, simply ensure that the rest of your code references this account when using these values. That way, if the data in the account changes, the program adapts accordingly.
+With the config account defined, simply ensure that the rest of your code
+references this account when using these values. That way, if the data in the
+account changes, the program adapts accordingly.
 
 ### Constrain config updates to hard-coded admins
 
-You'll need a way to initialize and update the config account data. That means you need to have one or more instructions that only an admin can invoke. The simplest way to do this is to hard-code an admin's public key in your code and then add a simple signer check into your instruction's account validation comparing the signer to this public key.
+You'll need a way to initialize and update the config account data. That means
+you need to have one or more instructions that only an admin can invoke. The
+simplest way to do this is to hard-code an admin's public key in your code and
+then add a simple signer check into your instruction's account validation
+comparing the signer to this public key.
 
-In Anchor, constraining an `update_program_config` instruction to only be usable by a hard-coded admin might look like this:
+In Anchor, constraining an `update_program_config` instruction to only be usable
+by a hard-coded admin might look like this:
 
 ```rust
 #[program]
@@ -220,20 +299,36 @@ pub struct UpdateProgramConfig<'info> {
 }
 ```
 
-Before instruction logic even executes, a check will be performed to make sure the instruction's signer matches the hard-coded `ADMIN_PUBKEY`. Notice that the example above doesn't show the instruction that initializes the config account, but it should have similar constraints to ensure that an attacker can't initialize the account with unexpected values.
+Before instruction logic even executes, a check will be performed to make sure
+the instruction's signer matches the hard-coded `ADMIN_PUBKEY`. Notice that the
+example above doesn't show the instruction that initializes the config account,
+but it should have similar constraints to ensure that an attacker can't
+initialize the account with unexpected values.
 
-While this approach works, it also means keeping track of an admin wallet on top of keeping track of a program's upgrade authority. With a few more lines of code, you could simply restrict an instruction to only be callable by the upgrade authority. The only tricky part is getting a program's upgrade authority to compare against.
+While this approach works, it also means keeping track of an admin wallet on top
+of keeping track of a program's upgrade authority. With a few more lines of
+code, you could simply restrict an instruction to only be callable by the
+upgrade authority. The only tricky part is getting a program's upgrade authority
+to compare against.
 
 ### Constrain config updates to the program's upgrade authority
 
-Fortunately, every program has a program data account that translates to the Anchor `ProgramData` account type and has the `upgrade_authority_address` field. The program itself stores this account's address in its data in the field `programdata_address`.
+Fortunately, every program has a program data account that translates to the
+Anchor `ProgramData` account type and has the `upgrade_authority_address` field.
+The program itself stores this account's address in its data in the field
+`programdata_address`.
 
-So in addition to the two accounts required by the instruction in the hard-coded admin example, this instruction requires the `program` and the `program_data` accounts.
+So in addition to the two accounts required by the instruction in the hard-coded
+admin example, this instruction requires the `program` and the `program_data`
+accounts.
 
 The accounts then need the following constraints:
 
-1. A constraint on `program` ensuring that the provided `program_data` account matches the program's `programdata_address` field
-2. A constraint on the `program_data` account ensuring that the instruction's signer matches the `program_data` account's `upgrade_authority_address` field.
+1. A constraint on `program` ensuring that the provided `program_data` account
+   matches the program's `programdata_address` field
+2. A constraint on the `program_data` account ensuring that the instruction's
+   signer matches the `program_data` account's `upgrade_authority_address`
+   field.
 
 When completed, that looks like this:
 
@@ -252,13 +347,20 @@ pub struct UpdateProgramConfig<'info> {
 }
 ```
 
-Again, the example above doesn't show the instruction that initializes the config account, but it should have the same constraints to ensure that an attacker can't initialize the account with unexpected values.
+Again, the example above doesn't show the instruction that initializes the
+config account, but it should have the same constraints to ensure that an
+attacker can't initialize the account with unexpected values.
 
-If this is the first time you've heard about the program data account, it's worth reading through [this Notion doc](https://www.notion.so/29780c48794c47308d5f138074dd9838) about program deploys.
+If this is the first time you've heard about the program data account, it's
+worth reading through
+[this Notion doc](https://www.notion.so/29780c48794c47308d5f138074dd9838) about
+program deploys.
 
 ### Constrain config updates to a provided admin
 
-Both of the previous options are fairly secure but also inflexible. What if you want to update the admin to be someone else? For that, you can store the admin on the config account.
+Both of the previous options are fairly secure but also inflexible. What if you
+want to update the admin to be someone else? For that, you can store the admin
+on the config account.
 
 ```rust
 pub const SEED_PROGRAM_CONFIG: &[u8] = b"program_config";
@@ -271,7 +373,8 @@ pub struct ProgramConfig {
 }
 ```
 
-Then you can constrain your "update" instructions with a signer check matching against the config account's `admin` field.
+Then you can constrain your "update" instructions with a signer check matching
+against the config account's `admin` field.
 
 ```rust
 ...
@@ -287,51 +390,94 @@ pub struct UpdateProgramConfig<'info> {
 }
 ```
 
-There's one catch here: in the time between deploying a program and initializing the config account, _there is no admin_. Which means that the instruction for initializing the config account can't be constrained to only allow admins as callers. That means it could be called by an attacker looking to set themselves as the admin.
+There's one catch here: in the time between deploying a program and initializing
+the config account, _there is no admin_. Which means that the instruction for
+initializing the config account can't be constrained to only allow admins as
+callers. That means it could be called by an attacker looking to set themselves
+as the admin.
 
-While this sounds bad, it really just means that you shouldn't treat your program as "initialized" until you've initialized the config account yourself and verified that the admin listed on the account is who you expect. If your deploy script deploys and then immediately calls `initialize`, it's very unlikely that an attacker is even aware of your program's existence much less trying to make themselves the admin. If by some crazy stroke of bad luck someone "intercepts" your program, you can close the program with the upgrade authority and redeploy.
+While this sounds bad, it really just means that you shouldn't treat your
+program as "initialized" until you've initialized the config account yourself
+and verified that the admin listed on the account is who you expect. If your
+deploy script deploys and then immediately calls `initialize`, it's very
+unlikely that an attacker is even aware of your program's existence much less
+trying to make themselves the admin. If by some crazy stroke of bad luck someone
+"intercepts" your program, you can close the program with the upgrade authority
+and redeploy.
 
 # Demo
 
-Now let's go ahead and try this out together. For this demo, we'll be working with a simple program that enables USDC payments. The program collects a small fee for facilitating the transfer. Note that this is somewhat contrived since you can do direct transfers without an intermediary contract, but it simulates how some complex DeFi programs work.
+Now let's go ahead and try this out together. For this demo, we'll be working
+with a simple program that enables USDC payments. The program collects a small
+fee for facilitating the transfer. Note that this is somewhat contrived since
+you can do direct transfers without an intermediary contract, but it simulates
+how some complex DeFi programs work.
 
-We'll quickly learn while testing our program that it could benefit from the flexibility provided by an admin-controlled configuration account and some feature flags.
+We'll quickly learn while testing our program that it could benefit from the
+flexibility provided by an admin-controlled configuration account and some
+feature flags.
 
 ### 1. Starter
 
-Download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-admin-instructions/tree/starter). The code contains a program with a single instruction and a single test in the `tests` directory.
+Download the starter code from the `starter` branch
+of [this repository](https://github.com/Unboxed-Software/solana-admin-instructions/tree/starter).
+The code contains a program with a single instruction and a single test in the
+`tests` directory.
 
 Let's quickly walk through how the program works.
 
-The `lib.rs` file includes a constant for the USDC address and a single `payment` instruction. The `payment` instruction simply called the `payment_handler` function in the `instructions/payment.rs` file where the instruction logic is contained.
+The `lib.rs` file includes a constant for the USDC address and a single
+`payment` instruction. The `payment` instruction simply called the
+`payment_handler` function in the `instructions/payment.rs` file where the
+instruction logic is contained.
 
-The `instructions/payment.rs` file contains both the `payment_handler` function as well as the `Payment` account validation struct representing the accounts required by the `payment` instruction. The `payment_handler` function calculates a 1% fee from the payment amount, transfers the fee to a designated token account, and transfers the remaining amount to the payment recipient.
+The `instructions/payment.rs` file contains both the `payment_handler` function
+as well as the `Payment` account validation struct representing the accounts
+required by the `payment` instruction. The `payment_handler` function calculates
+a 1% fee from the payment amount, transfers the fee to a designated token
+account, and transfers the remaining amount to the payment recipient.
 
-Finally, the `tests` directory has a single test file, `config.ts` that simply invokes the `payment` instruction and asserts that the corresponding token account balances have been debited and credited accordingly.
+Finally, the `tests` directory has a single test file, `config.ts` that simply
+invokes the `payment` instruction and asserts that the corresponding token
+account balances have been debited and credited accordingly.
 
-Before we continue, take a few minutes to familiarize yourself with these files and their contents.
+Before we continue, take a few minutes to familiarize yourself with these files
+and their contents.
 
 ### 2. Run the existing test
 
 Let's start by running the existing test.
 
-Make sure you use `yarn` or `npm install` to install the dependencies laid out in the `package.json` file. Then be sure to run `anchor keys list` to get the public key for your program printed to the console. This differs based on the keypair you have locally, so you need to update `lib.rs` and `Anchor.toml` to use _your_ key.
+Make sure you use `yarn` or `npm install` to install the dependencies laid out
+in the `package.json` file. Then be sure to run `anchor keys list` to get the
+public key for your program printed to the console. This differs based on the
+keypair you have locally, so you need to update `lib.rs` and `Anchor.toml` to
+use _your_ key.
 
-Finally, run `anchor test` to start the test. It should fail with the following output:
+Finally, run `anchor test` to start the test. It should fail with the following
+output:
 
 ```
 Error: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: incorrect program id for instruction
 ```
 
-The reason for this error is that we're attempting to use the mainnet USDC mint address (as hard-coded in the `lib.rs` file of the program), but that mint doesn't exist in the local environment.
+The reason for this error is that we're attempting to use the mainnet USDC mint
+address (as hard-coded in the `lib.rs` file of the program), but that mint
+doesn't exist in the local environment.
 
 ### 3. Adding a `local-testing` feature
 
-To fix this, we need a mint we can use locally _and_ hard-code into the program. Since the local environment is reset often during testing, you'll need to store a keypair that you can use to recreate the same mint address every time.
+To fix this, we need a mint we can use locally _and_ hard-code into the program.
+Since the local environment is reset often during testing, you'll need to store
+a keypair that you can use to recreate the same mint address every time.
 
-Additionally, you don't want to have to change the hard-coded address between local and mainnet builds since that could introduce human error (and is just annoying). So we'll create a `local-testing` feature that, when enabled, will make the program use our local mint but otherwise use the production USDC mint.
+Additionally, you don't want to have to change the hard-coded address between
+local and mainnet builds since that could introduce human error (and is just
+annoying). So we'll create a `local-testing` feature that, when enabled, will
+make the program use our local mint but otherwise use the production USDC mint.
 
-Generate a new keypair by running `solana-keygen grind`. Run the following command to generate a keypair with a public key that begins with "env".
+Generate a new keypair by running `solana-keygen grind`. Run the following
+command to generate a keypair with a public key that begins with "env".
 
 ```
 solana-keygen grind --starts-with env:1
@@ -343,7 +489,12 @@ Once a keypair is found, you should see an output similar to the following:
 Wrote keypair to env9Y3szLdqMLU9rXpEGPqkjdvVn8YNHtxYNvCKXmHe.json
 ```
 
-The keypair is written to a file in your working directory. Now that we have a placeholder USDC address, let's modify the `lib.rs` file. Use the `cfg` attribute to define the `USDC_MINT_PUBKEY` constant depending on whether the `local-testing` feature is enabled or disabled. Remember to set the `USDC_MINT_PUBKEY` constant for `local-testing` with the one generated in the previous step rather than copying the one below.
+The keypair is written to a file in your working directory. Now that we have a
+placeholder USDC address, let's modify the `lib.rs` file. Use the `cfg`
+attribute to define the `USDC_MINT_PUBKEY` constant depending on whether the
+`local-testing` feature is enabled or disabled. Remember to set the
+`USDC_MINT_PUBKEY` constant for `local-testing` with the one generated in the
+previous step rather than copying the one below.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -371,7 +522,8 @@ pub mod config {
 }
 ```
 
-Next, add the `local-testing` feature to the `Cargo.toml` file located in `/programs`.
+Next, add the `local-testing` feature to the `Cargo.toml` file located in
+`/programs`.
 
 ```
 [features]
@@ -379,7 +531,8 @@ Next, add the `local-testing` feature to the `Cargo.toml` file located in `/prog
 local-testing = []
 ```
 
-Next, update the `config.ts` test file to create a mint using the generated keypair. Start by deleting the `mint` constant.
+Next, update the `config.ts` test file to create a mint using the generated
+keypair. Start by deleting the `mint` constant.
 
 ```ts
 const mint = new anchor.web3.PublicKey(
@@ -387,7 +540,9 @@ const mint = new anchor.web3.PublicKey(
 );
 ```
 
-Next, update the test to create a mint using the keypair, which will enable us to reuse the same mint address each time the tests are run. Remember to replace the file name with the one generated in the previous step.
+Next, update the test to create a mint using the keypair, which will enable us
+to reuse the same mint address each time the tests are run. Remember to replace
+the file name with the one generated in the previous step.
 
 ```ts
 let mint: anchor.web3.PublicKey
@@ -428,18 +583,27 @@ config
 1 passing (3s)
 ```
 
-Boom. Just like that, you've used features to run two different code paths for different environments.
+Boom. Just like that, you've used features to run two different code paths for
+different environments.
 
 ### 4. Program Config
 
-Features are great for setting different values at compilation, but what if you wanted to be able to dynamically update the fee percentage used by the program? Let's make that possible by creating a Program Config account that allows us to update the fee without upgrading the program.
+Features are great for setting different values at compilation, but what if you
+wanted to be able to dynamically update the fee percentage used by the program?
+Let's make that possible by creating a Program Config account that allows us to
+update the fee without upgrading the program.
 
 To begin, let's first update the `lib.rs` file to:
 
-1. Include a `SEED_PROGRAM_CONFIG` constant, which will be used to generate the PDA for the program config account.
-2. Include an `ADMIN` constant, which will be used as a constraint when initializing the program config account. Run the `solana address` command to get your address to use as the constant's value.
+1. Include a `SEED_PROGRAM_CONFIG` constant, which will be used to generate the
+   PDA for the program config account.
+2. Include an `ADMIN` constant, which will be used as a constraint when
+   initializing the program config account. Run the `solana address` command to
+   get your address to use as the constant's value.
 3. Include a `state` module that we'll implement shortly.
-4. Include the `initialize_program_config` and `update_program_config` instructions and calls to their "handlers," both of which we'll implement in another step.
+4. Include the `initialize_program_config` and `update_program_config`
+   instructions and calls to their "handlers," both of which we'll implement in
+   another step.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -486,9 +650,12 @@ pub mod config {
 
 ### 5. Program Config State
 
-Next, let's define the structure for the `ProgramConfig` state. This account will store the admin, the token account where fees are sent, and the fee rate. We'll also specify the number of bytes required to store this structure.
+Next, let's define the structure for the `ProgramConfig` state. This account
+will store the admin, the token account where fees are sent, and the fee rate.
+We'll also specify the number of bytes required to store this structure.
 
-Create a new file called `state.rs` in the `/src` directory and add the following code.
+Create a new file called `state.rs` in the `/src` directory and add the
+following code.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -507,11 +674,16 @@ impl ProgramConfig {
 
 ### 6. Add Initialize Program Config Account Instruction
 
-Now let's create the instruction logic for initializing the program config account. It should only be callable by a transaction signed by the `ADMIN` key and should set all the properties on the `ProgramConfig` account.
+Now let's create the instruction logic for initializing the program config
+account. It should only be callable by a transaction signed by the `ADMIN` key
+and should set all the properties on the `ProgramConfig` account.
 
-Create a folder called `program_config` at the path `/src/instructions/program_config`. This folder will store all instructions related to the program config account.
+Create a folder called `program_config` at the path
+`/src/instructions/program_config`. This folder will store all instructions
+related to the program config account.
 
-Within the `program_config` folder, create a file called `initialize_program_config.rs` and add the following code.
+Within the `program_config` folder, create a file called
+`initialize_program_config.rs` and add the following code.
 
 ```rust
 use crate::state::ProgramConfig;
@@ -542,9 +714,12 @@ pub fn initialize_program_config_handler(ctx: Context<InitializeProgramConfig>) 
 
 ### 7. Add Update Program Config Fee Instruction
 
-Next, implement the instruction logic for updating the config account. The instruction should require that the signer match the `admin` stored in the `program_config` account.
+Next, implement the instruction logic for updating the config account. The
+instruction should require that the signer match the `admin` stored in the
+`program_config` account.
 
-Within the `program_config` folder, create a file called `update_program_config.rs` and add the following code.
+Within the `program_config` folder, create a file called
+`update_program_config.rs` and add the following code.
 
 ```rust
 use crate::state::ProgramConfig;
@@ -581,7 +756,10 @@ pub fn update_program_config_handler(
 
 ### 8. Add mod.rs and update instructions.rs
 
-Next, let's expose the instruction handlers we created so that the call from `lib.rs` doesn't show an error. Start by adding a file `mod.rs` in the `program_config` folder. Add the code below to make the two modules, `initialize_program_config` and `update_program_config` accessible.
+Next, let's expose the instruction handlers we created so that the call from
+`lib.rs` doesn't show an error. Start by adding a file `mod.rs` in the
+`program_config` folder. Add the code below to make the two modules,
+`initialize_program_config` and `update_program_config` accessible.
 
 ```rust
 mod initialize_program_config;
@@ -591,7 +769,8 @@ mod update_program_config;
 pub use update_program_config::*;
 ```
 
-Now, update `instructions.rs` at the path `/src/instructions.rs`. Add the code below to make the two modules, `program_config` and `payment` accessible.
+Now, update `instructions.rs` at the path `/src/instructions.rs`. Add the code
+below to make the two modules, `program_config` and `payment` accessible.
 
 ```rust
 mod program_config;
@@ -603,7 +782,10 @@ pub use payment::*;
 
 ### 9. Update Payment Instruction
 
-Lastly, let's update the payment instruction to check that the `fee_destination` account in the instruction matches the `fee_destination` stored in the program config account. Then update the instruction's fee calculation to be based on the `fee_basis_point` stored in the program config account.
+Lastly, let's update the payment instruction to check that the `fee_destination`
+account in the instruction matches the `fee_destination` stored in the program
+config account. Then update the instruction's fee calculation to be based on the
+`fee_basis_point` stored in the program config account.
 
 ```rust
 use crate::state::ProgramConfig;
@@ -682,7 +864,9 @@ pub fn payment_handler(ctx: Context<Payment>, amount: u64) -> Result<()> {
 
 ### 10. Test
 
-Now that we're done implementing our new program configuration struct and instructions, let's move on to testing our updated program. To begin, add the PDA for the program config account to the test file.
+Now that we're done implementing our new program configuration struct and
+instructions, let's move on to testing our updated program. To begin, add the
+PDA for the program config account to the test file.
 
 ```ts
 describe("config", () => {
@@ -701,7 +885,9 @@ Next, update the test file with three more tests testing that:
 3. The config account can be updated successfully by the admin
 4. The config account cannot be updated by another other than the admin
 
-The first test initializes the program config account and verifies that the correct fee is set and that the correct admin is stored on the program config account.
+The first test initializes the program config account and verifies that the
+correct fee is set and that the correct admin is stored on the program config
+account.
 
 ```typescript
 it("Initialize Program Config Account", async () => {
@@ -728,7 +914,10 @@ it("Initialize Program Config Account", async () => {
 });
 ```
 
-The second test verifies that the payment instruction is working correctly, with the fee being sent to the fee destination and the remaining balance being transferred to the receiver. Here we update the existing test to include the `programConfig` account.
+The second test verifies that the payment instruction is working correctly, with
+the fee being sent to the fee destination and the remaining balance being
+transferred to the receiver. Here we update the existing test to include the
+`programConfig` account.
 
 ```typescript
 it("Payment completes successfully", async () => {
@@ -764,7 +953,8 @@ it("Payment completes successfully", async () => {
 });
 ```
 
-The third test attempts to update the fee on the program config account, which should be successful.
+The third test attempts to update the fee on the program config account, which
+should be successful.
 
 ```typescript
 it("Update Program Config Account", async () => {
@@ -787,7 +977,8 @@ it("Update Program Config Account", async () => {
 });
 ```
 
-The fourth test tries to update the fee on the program config account, where the admin is not the one stored on the program config account, and this should fail.
+The fourth test tries to update the fee on the program config account, where the
+admin is not the one stored on the program config account, and this should fail.
 
 ```typescript
 it("Update Program Config Account with unauthorized admin (expect fail)", async () => {
@@ -827,15 +1018,29 @@ config
 4 passing (8s)
 ```
 
-And that's it! You've made the program a lot easier to work with moving forward. If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-admin-instructions/tree/solution).
+And that's it! You've made the program a lot easier to work with moving forward.
+If you want to take a look at the final solution code you can find it on
+the `solution` branch
+of [the same repository](https://github.com/Unboxed-Software/solana-admin-instructions/tree/solution).
 
 # Challenge
 
-Now it's time for you to do some of this on your own. We mentioned being able to use the program's upgrade authority as the initial admin. Go ahead and update the demo's `initialize_program_config` so that only the upgrade authority can call it rather than having a hardcoded `ADMIN`.
+Now it's time for you to do some of this on your own. We mentioned being able to
+use the program's upgrade authority as the initial admin. Go ahead and update
+the demo's `initialize_program_config` so that only the upgrade authority can
+call it rather than having a hardcoded `ADMIN`.
 
-Note that the `anchor test` command, when run on a local network, starts a new test validator using `solana-test-validator`. This test validator uses a non-upgradeable loader. The non-upgradeable loader makes it so the program's `program_data` account isn't initialized when the validator starts. You'll recall from the lesson that this account is how we access the upgrade authority from the program.
+Note that the `anchor test` command, when run on a local network, starts a new
+test validator using `solana-test-validator`. This test validator uses a
+non-upgradeable loader. The non-upgradeable loader makes it so the program's
+`program_data` account isn't initialized when the validator starts. You'll
+recall from the lesson that this account is how we access the upgrade authority
+from the program.
 
-To work around this, you can add a `deploy` function to the test file that runs the deploy command for the program with an upgradeable loader. To use it, run `anchor test --skip-deploy`, and call the `deploy` function within the test to run the deploy command after the test validator has started.
+To work around this, you can add a `deploy` function to the test file that runs
+the deploy command for the program with an upgradeable loader. To use it, run
+`anchor test --skip-deploy`, and call the `deploy` function within the test to
+run the deploy command after the test validator has started.
 
 ```typescript
 import { execSync } from "child_process"
@@ -861,4 +1066,7 @@ For example, the command to run the test with features would look like this:
 anchor test --skip-deploy -- --features "local-testing"
 ```
 
-Try doing this on your own, but if you get stuck, feel free to reference the `challenge` branch of [the same repository](https://github.com/Unboxed-Software/solana-admin-instructions/tree/challenge) to see one possible solution.
+Try doing this on your own, but if you get stuck, feel free to reference the
+`challenge` branch of
+[the same repository](https://github.com/Unboxed-Software/solana-admin-instructions/tree/challenge)
+to see one possible solution.

--- a/developers/courses/solana-course/content/getting-started.md
+++ b/developers/courses/solana-course/content/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Course Guide
 objectives:
-- explain how this Solana course is structured
+  - explain how this Solana course is structured
 ---
 
 ## How is this course structured?
@@ -11,15 +11,17 @@ Glad you asked. Each lesson starts by listing the lesson objectives. These are s
 In addition to listing objectives, each lesson provides a brief TL;DR so that you can glance through, get a sense of what the lesson covers, and decide if the lesson is for you or not.
 
 If you decide to continue your journey, you'll then encounter three sections:
-- **Overview** - the overview contains explanatory text, examples, and code snippets. You are *not* expected to code along with any of the examples shown here. The goal is to simply read through and get initial exposure to the lesson topics.
-- **Demo** - the demo is a tutorial-style project. You *absolutely should* code along with this section. This is your second exposure to the content as well as your first opportunity to dive in and *do the thing*.
+
+- **Overview** - the overview contains explanatory text, examples, and code snippets. You are _not_ expected to code along with any of the examples shown here. The goal is to simply read through and get initial exposure to the lesson topics.
+- **Demo** - the demo is a tutorial-style project. You _absolutely should_ code along with this section. This is your second exposure to the content as well as your first opportunity to dive in and _do the thing_.
 - **Challenge** - the challenge contains a similar project to the demo only instead of walking you through it, the lesson leaves just a few simple prompts that you should then take and implement independently.
 
-This structure leans into a pedagogical technique call IWY loops. IWY stands for "I do, We do, You do." Each step along the way increases your exposure to the topic *and* reduces the amount of handholding you're given.
+This structure leans into a pedagogical technique call IWY loops. IWY stands for "I do, We do, You do." Each step along the way increases your exposure to the topic _and_ reduces the amount of handholding you're given.
 
 ## How do I use it effectively?
 
 Again, glad you asked. The lesson structure is pretty great, but everyone comes into this with different backgrounds and aptitudes that can't be taken into account by static text. With that in mind, here are three recommendations for how to get the most out of the course:
+
 1. **Be brutally honest with yourself** - this may sound a little vague, but being honest with yourself about how well you understand a certain topic is essential to mastering it. It's really easy to read a thing and think "yeah, yeah I get it," only to realize later that you actually didn't. Be honest with yourself while going through each lesson. Please don't hesitate to repeat sections if you need to or do outside research when the lesson phrasing doesn't quite work for you.
 2. **Do every demo and challenge** - this supports the first point. It's pretty tough to lie to yourself about how well you know something when you make yourself try to do it. Do every demo and every challenge to test where you're at and repeat them as needed. We provide solution code for everything, but be sure to use it as a helpful resource rather than a crutch.
 3. **Go above and beyond** - sounds cliche, I know, but don't just stop at what the demo and challenges ask you to do. Get creative! Take the projects and make them your own. Build past them. The more you practice the better you get.

--- a/developers/courses/solana-course/content/getting-started.md
+++ b/developers/courses/solana-course/content/getting-started.md
@@ -6,24 +6,52 @@ objectives:
 
 ## How is this course structured?
 
-Glad you asked. Each lesson starts by listing the lesson objectives. These are short statements that indicate what you'll be learning throughout the lesson.
+Glad you asked. Each lesson starts by listing the lesson objectives. These are
+short statements that indicate what you'll be learning throughout the lesson.
 
-In addition to listing objectives, each lesson provides a brief TL;DR so that you can glance through, get a sense of what the lesson covers, and decide if the lesson is for you or not.
+In addition to listing objectives, each lesson provides a brief TL;DR so that
+you can glance through, get a sense of what the lesson covers, and decide if the
+lesson is for you or not.
 
 If you decide to continue your journey, you'll then encounter three sections:
 
-- **Overview** - the overview contains explanatory text, examples, and code snippets. You are _not_ expected to code along with any of the examples shown here. The goal is to simply read through and get initial exposure to the lesson topics.
-- **Demo** - the demo is a tutorial-style project. You _absolutely should_ code along with this section. This is your second exposure to the content as well as your first opportunity to dive in and _do the thing_.
-- **Challenge** - the challenge contains a similar project to the demo only instead of walking you through it, the lesson leaves just a few simple prompts that you should then take and implement independently.
+- **Overview** - the overview contains explanatory text, examples, and code
+  snippets. You are _not_ expected to code along with any of the examples shown
+  here. The goal is to simply read through and get initial exposure to the
+  lesson topics.
+- **Demo** - the demo is a tutorial-style project. You _absolutely should_ code
+  along with this section. This is your second exposure to the content as well
+  as your first opportunity to dive in and _do the thing_.
+- **Challenge** - the challenge contains a similar project to the demo only
+  instead of walking you through it, the lesson leaves just a few simple prompts
+  that you should then take and implement independently.
 
-This structure leans into a pedagogical technique call IWY loops. IWY stands for "I do, We do, You do." Each step along the way increases your exposure to the topic _and_ reduces the amount of handholding you're given.
+This structure leans into a pedagogical technique call IWY loops. IWY stands for
+"I do, We do, You do." Each step along the way increases your exposure to the
+topic _and_ reduces the amount of handholding you're given.
 
 ## How do I use it effectively?
 
-Again, glad you asked. The lesson structure is pretty great, but everyone comes into this with different backgrounds and aptitudes that can't be taken into account by static text. With that in mind, here are three recommendations for how to get the most out of the course:
+Again, glad you asked. The lesson structure is pretty great, but everyone comes
+into this with different backgrounds and aptitudes that can't be taken into
+account by static text. With that in mind, here are three recommendations for
+how to get the most out of the course:
 
-1. **Be brutally honest with yourself** - this may sound a little vague, but being honest with yourself about how well you understand a certain topic is essential to mastering it. It's really easy to read a thing and think "yeah, yeah I get it," only to realize later that you actually didn't. Be honest with yourself while going through each lesson. Please don't hesitate to repeat sections if you need to or do outside research when the lesson phrasing doesn't quite work for you.
-2. **Do every demo and challenge** - this supports the first point. It's pretty tough to lie to yourself about how well you know something when you make yourself try to do it. Do every demo and every challenge to test where you're at and repeat them as needed. We provide solution code for everything, but be sure to use it as a helpful resource rather than a crutch.
-3. **Go above and beyond** - sounds cliche, I know, but don't just stop at what the demo and challenges ask you to do. Get creative! Take the projects and make them your own. Build past them. The more you practice the better you get.
+1. **Be brutally honest with yourself** - this may sound a little vague, but
+   being honest with yourself about how well you understand a certain topic is
+   essential to mastering it. It's really easy to read a thing and think "yeah,
+   yeah I get it," only to realize later that you actually didn't. Be honest
+   with yourself while going through each lesson. Please don't hesitate to
+   repeat sections if you need to or do outside research when the lesson
+   phrasing doesn't quite work for you.
+2. **Do every demo and challenge** - this supports the first point. It's pretty
+   tough to lie to yourself about how well you know something when you make
+   yourself try to do it. Do every demo and every challenge to test where you're
+   at and repeat them as needed. We provide solution code for everything, but be
+   sure to use it as a helpful resource rather than a crutch.
+3. **Go above and beyond** - sounds cliche, I know, but don't just stop at what
+   the demo and challenges ask you to do. Get creative! Take the projects and
+   make them your own. Build past them. The more you practice the better you
+   get.
 
 Alright, that's it for my pep talk. Get after it!

--- a/developers/courses/solana-course/content/hello-world-program.md
+++ b/developers/courses/solana-course/content/hello-world-program.md
@@ -11,39 +11,60 @@ objectives:
 
 # TL;DR
 
-- **Programs** on Solana are a particular type of account that stores and executes instruction logic
+- **Programs** on Solana are a particular type of account that stores and
+  executes instruction logic
 - Solana programs have a single **entry point** to process instructions
-- A program processes an instruction using the **program_id**, list of **accounts**, and **instruction_data** included with the instruction
+- A program processes an instruction using the **program_id**, list of
+  **accounts**, and **instruction_data** included with the instruction
 
 # Overview
 
-Solana's ability to run arbitrary executable code is part of what makes it so powerful. Solana programs, similar to "smart contracts" in other blockchain environments, are quite literally the backbone of the Solana ecosystem. And the collection of programs grows daily as developers and creators dream up and deploy new programs.
+Solana's ability to run arbitrary executable code is part of what makes it so
+powerful. Solana programs, similar to "smart contracts" in other blockchain
+environments, are quite literally the backbone of the Solana ecosystem. And the
+collection of programs grows daily as developers and creators dream up and
+deploy new programs.
 
-This lesson will give you a basic introduction to writing and deploying a Solana program using the Rust programming language. To avoid the distraction of setting up a local development environment, we'll be using a browser-based IDE called Solana Playground.
+This lesson will give you a basic introduction to writing and deploying a Solana
+program using the Rust programming language. To avoid the distraction of setting
+up a local development environment, we'll be using a browser-based IDE called
+Solana Playground.
 
 ## Rust Basics
 
-Before we dive into the building our "Hello, world!" program, let’s first go over some Rust basics. If you want to dig deeper into Rust, have a look at the [Rust language book](https://doc.rust-lang.org/book/ch00-00-introduction.html).
+Before we dive into the building our "Hello, world!" program, let’s first go
+over some Rust basics. If you want to dig deeper into Rust, have a look at
+the [Rust language book](https://doc.rust-lang.org/book/ch00-00-introduction.html).
 
 ### Module System
 
-Rust organizes code using what is collectively referred to as the “module system”.
+Rust organizes code using what is collectively referred to as the “module
+system”.
 
 This includes:
 
-- **Modules** - A module separates code into logical units to provide isolated namespaces for organization, scope, and privacy of paths
-- **Crates** - A crate is either a library or an executable program. The source code for a crate is usually subdivided into multiple modules.
-- **Packages** - A package contains a collection of crates as well as a manifest file for specifying metadata and dependencies between packages
+- **Modules** - A module separates code into logical units to provide isolated
+  namespaces for organization, scope, and privacy of paths
+- **Crates** - A crate is either a library or an executable program. The source
+  code for a crate is usually subdivided into multiple modules.
+- **Packages** - A package contains a collection of crates as well as a manifest
+  file for specifying metadata and dependencies between packages
 
 Throughout this lesson, we’ll focus on using crates and modules.
 
 ### Paths and scope
 
-Crates in Rust contain modules that define functionality which can be shared with multiple projects. If we want to access an item within a module, then we need to know its "path" (like when we're navigating a filesystem).
+Crates in Rust contain modules that define functionality which can be shared
+with multiple projects. If we want to access an item within a module, then we
+need to know its "path" (like when we're navigating a filesystem).
 
-Think of the crate structure as a tree where the crate is the base and modules are branches, each of which can have submodules or items that are additional branches.
+Think of the crate structure as a tree where the crate is the base and modules
+are branches, each of which can have submodules or items that are additional
+branches.
 
-The path to a particular module or item is the name of each step from the crate to that module where each is separated by `::`. As an example, let's look at the following structure:
+The path to a particular module or item is the name of each step from the crate
+to that module where each is separated by `::`. As an example, let's look at the
+following structure:
 
 1. The base crate is `solana_program`
 2. `solana_program` contains a module named `account_info`
@@ -51,9 +72,14 @@ The path to a particular module or item is the name of each step from the crate 
 
 The path to `AccountInfo` would be `solana_program::account_info::AccountInfo`.
 
-Absent of any other keywords, we would need to reference this entire path to use `AccountInfo` in our code.
+Absent of any other keywords, we would need to reference this entire path to use
+`AccountInfo` in our code.
 
-However, with the [`use`](https://doc.rust-lang.org/stable/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html) keyword we can bring an item into scope so that it can be reused throughout a file without specifying the full path each time. It's common to see a series of `use` commands at the top of a Rust file.
+However, with the
+[`use`](https://doc.rust-lang.org/stable/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html)
+keyword we can bring an item into scope so that it can be reused throughout a
+file without specifying the full path each time. It's common to see a series of
+`use` commands at the top of a Rust file.
 
 ```rust
 use solana_program::account_info::AccountInfo
@@ -61,27 +87,45 @@ use solana_program::account_info::AccountInfo
 
 ### Declaring Functions in Rust
 
-We define a function in Rust by using the `fn` keyword followed by a function name and a set of parentheses.
+We define a function in Rust by using the `fn` keyword followed by a function
+name and a set of parentheses.
 
 ```rust
 fn process_instruction()
 ```
 
-We can then add arguments to our function by including variable names and specifying its corresponding data type within the parentheses.
+We can then add arguments to our function by including variable names and
+specifying its corresponding data type within the parentheses.
 
-Rust is known as a ”statically typed” language and every value in Rust is of a certain ”data type”. This meaning that Rust must know the types of all variables at compile time. In cases when multiple types are possible, we must add a type annotation to our variables.
+Rust is known as a ”statically typed” language and every value in Rust is of a
+certain ”data type”. This meaning that Rust must know the types of all variables
+at compile time. In cases when multiple types are possible, we must add a type
+annotation to our variables.
 
-In the example below, we create a function named `process_instruction` that requires the following arguments:
+In the example below, we create a function named `process_instruction` that
+requires the following arguments:
 
 - `program_id` - required to be type `&Pubkey`
 - `accounts` - required to be type `&[AccountInfo]`
 - `instruction_data` - required to be type `&[u8]`
 
-Note the `&` in front of the type for each argument listed in the `process_instruction` function. In Rust, `&` represents a ”reference” to another variable. This allows you to refer to some value without taking ownership of it. The “reference” is guaranteed to point to a valid value of a particular type. The action of creating a reference in Rust is called “borrowing”.
+Note the `&` in front of the type for each argument listed in the
+`process_instruction` function. In Rust, `&` represents a ”reference” to another
+variable. This allows you to refer to some value without taking ownership of it.
+The “reference” is guaranteed to point to a valid value of a particular type.
+The action of creating a reference in Rust is called “borrowing”.
 
-In this example, when the `process_instruction` function is called, a user must pass in values for the required arguments. The `process_instruction` function then references the values passed in by the user, and guarantees that each value is the correct data type specified in the `process_instruction` function.
+In this example, when the `process_instruction` function is called, a user must
+pass in values for the required arguments. The `process_instruction` function
+then references the values passed in by the user, and guarantees that each value
+is the correct data type specified in the `process_instruction` function.
 
-Additionally, note the brackets `[]` around `&[AccountInfo]` and `&[u8]`. This means that the `accounts` and `instruction_data` arguments expect “slices” of types `AccountInfo` and `u8`, respectively. A “slice” is similar to an array (collection of objects of the same type), except the length is not known at compile time. In other words, the `accounts` and `instruction_data` arguments expect inputs of unknown length.
+Additionally, note the brackets `[]` around `&[AccountInfo]` and `&[u8]`. This
+means that the `accounts` and `instruction_data` arguments expect “slices” of
+types `AccountInfo` and `u8`, respectively. A “slice” is similar to an array
+(collection of objects of the same type), except the length is not known at
+compile time. In other words, the `accounts` and `instruction_data` arguments
+expect inputs of unknown length.
 
 ```rust
 fn process_instruction(
@@ -91,9 +135,11 @@ fn process_instruction(
 )
 ```
 
-We can then have our functions return values by declaring the return type using an arrow `->` after the function.
+We can then have our functions return values by declaring the return type using
+an arrow `->` after the function.
 
-In the example below, the `process_instruction` function will now return a value of type `ProgramResult`. We will go over this in the next section.
+In the example below, the `process_instruction` function will now return a value
+of type `ProgramResult`. We will go over this in the next section.
 
 ```rust
 fn process_instruction(
@@ -105,9 +151,17 @@ fn process_instruction(
 
 ### Result enum
 
-`Result` is a standard library type that represents two discrete outcomes: success (`Ok`) or failure (`Err`). We'll talk more about enums in a future lesson, but you'll see `Ok` used later in this lesson so it's important to cover the basics.
+`Result` is a standard library type that represents two discrete outcomes:
+success (`Ok`) or failure (`Err`). We'll talk more about enums in a future
+lesson, but you'll see `Ok` used later in this lesson so it's important to cover
+the basics.
 
-When you use `Ok` or `Err`, you must include a value, the type of which is determined by the context of the code. For example, a function that requires a return value of type `Result<String, i64>` is saying that the function can either return `Ok` with an embedded string value or `Err` with an embedded integer. In this example, the integer is an error code that can be used to appropriately handle the error.
+When you use `Ok` or `Err`, you must include a value, the type of which is
+determined by the context of the code. For example, a function that requires a
+return value of type `Result<String, i64>` is saying that the function can
+either return `Ok` with an embedded string value or `Err` with an embedded
+integer. In this example, the integer is an error code that can be used to
+appropriately handle the error.
 
 To return a success case with a string value, you would do the following:
 
@@ -123,13 +177,21 @@ Err(404);
 
 ## Solana Programs
 
-Recall that all data stored on the Solana network are contained in what are referred to as accounts. Each account has its own unique address which is used to identify and access the account data. Solana programs are just a particular type of Solana account that store and execute instructions.
+Recall that all data stored on the Solana network are contained in what are
+referred to as accounts. Each account has its own unique address which is used
+to identify and access the account data. Solana programs are just a particular
+type of Solana account that store and execute instructions.
 
 ### Solana Program Crate
 
-To write Solana programs with Rust, we use the `solana_program` library crate. The `solana_program` crate acts as a standard library for Solana programs. This standard library contains the modules and macros that we'll use to develop our Solana programs. If you want to dig deeper `solana_program` crate, have a look [here](https://docs.rs/solana-program/latest/solana_program/index.html).
+To write Solana programs with Rust, we use the `solana_program` library crate.
+The `solana_program` crate acts as a standard library for Solana programs. This
+standard library contains the modules and macros that we'll use to develop our
+Solana programs. If you want to dig deeper `solana_program` crate, have a look
+[here](https://docs.rs/solana-program/latest/solana_program/index.html).
 
-For a basic program we will need to bring into scope the following items from the `solana_program` crate:
+For a basic program we will need to bring into scope the following items from
+the `solana_program` crate:
 
 ```rust
 use solana_program::{
@@ -141,17 +203,22 @@ use solana_program::{
 };
 ```
 
-- `AccountInfo` - a struct within the `account_info` module that allows us to access account information
+- `AccountInfo` - a struct within the `account_info` module that allows us to
+  access account information
 - `entrypoint` - a macro that declares the entry point of the program
-- `ProgramResult` - a type within the `entrypoint` module that returns either a `Result` or `ProgramError`
-- `Pubkey` - a struct within the `pubkey` module that allows us to access addresses as a public key
+- `ProgramResult` - a type within the `entrypoint` module that returns either
+  a `Result` or `ProgramError`
+- `Pubkey` - a struct within the `pubkey` module that allows us to access
+  addresses as a public key
 - `msg` - a macro that allows us to print messages to the program log
 
 ### Solana Program Entry Point
 
-Solana programs require a single entry point to process program instructions. The entry point is declared using the `entrypoint!` macro.
+Solana programs require a single entry point to process program instructions.
+The entry point is declared using the `entrypoint!` macro.
 
-The entry point to a Solana program requires a `process_instruction` function with the following arguments:
+The entry point to a Solana program requires a `process_instruction` function
+with the following arguments:
 
 - `program_id` - the address of the account where the program is stored
 - `accounts` - the list of accounts required to process the instruction
@@ -167,27 +234,44 @@ fn process_instruction(
 ) -> ProgramResult;
 ```
 
-Recall that Solana program accounts only store the logic to process instructions. This means program accounts are "read-only" and “stateless”. The “state” (the set of data) that a program requires in order to process an instruction is stored in data accounts (separate from the program account).
+Recall that Solana program accounts only store the logic to process
+instructions. This means program accounts are "read-only" and “stateless”. The
+“state” (the set of data) that a program requires in order to process an
+instruction is stored in data accounts (separate from the program account).
 
-In order to process an instruction, the data accounts that an instruction requires must be explicitly passed into the program through the `accounts` argument. Any additional inputs must be passed in through the `instruction_data` argument.
+In order to process an instruction, the data accounts that an instruction
+requires must be explicitly passed into the program through
+the `accounts` argument. Any additional inputs must be passed in through
+the `instruction_data` argument.
 
-Following program execution, the program must return a value of type `ProgramResult`. This type is a `Result` where the embedded value of a success case is `()` and the embedded value of a failure case is `ProgramError`. `()` is effectively an empty value and `ProgramError` is an error type defined in the `solana_program` crate.
+Following program execution, the program must return a value of type
+`ProgramResult`. This type is a `Result` where the embedded value of a success
+case is `()` and the embedded value of a failure case is `ProgramError`. `()` is
+effectively an empty value and `ProgramError` is an error type defined in the
+`solana_program` crate.
 
-...and there you have it - you now know all the things you need for the foundations of creating a Solana program using Rust. Let’s practice what we’ve learned so far!
+...and there you have it - you now know all the things you need for the
+foundations of creating a Solana program using Rust. Let’s practice what we’ve
+learned so far!
 
 # Demo
 
-We're going to build a "Hello, World!" program using Solana Playground. Solana Playground is a tool that allows you to write and deploy Solana programs from the browser.
+We're going to build a "Hello, World!" program using Solana Playground. Solana
+Playground is a tool that allows you to write and deploy Solana programs from
+the browser.
 
 ### 1. Setup
 
-Click [here](https://beta.solpg.io/) to open Solana Playground. Next, go ahead and delete everything in the default `lib.rs` file and create a Playground wallet.
+Click [here](https://beta.solpg.io/) to open Solana Playground. Next, go ahead
+and delete everything in the default `lib.rs` file and create a Playground
+wallet.
 
 ![Gif Solana Playground Create Wallet](../assets/hello-world-create-wallet.gif)
 
 ### 2. Solana Program Crate
 
-First, let's bring into scope everything we’ll need from the `solana_program` crate.
+First, let's bring into scope everything we’ll need from the `solana_program`
+crate.
 
 ```rust
 use solana_program::{
@@ -199,7 +283,9 @@ use solana_program::{
 };
 ```
 
-Next, let's set up the entry point to our program using the `entrypoint!` macro and create the `process_instruction` function. The `msg!` macro then allows us to print “Hello, world!” to the program log when the program is invoked.
+Next, let's set up the entry point to our program using the `entrypoint!` macro
+and create the `process_instruction` function. The `msg!` macro then allows us
+to print “Hello, world!” to the program log when the program is invoked.
 
 ### 3. Entry Point
 
@@ -249,11 +335,18 @@ Now let's build and deploy our program using Solana Playground.
 
 ### 5. Invoke Program
 
-Finally, let's invoke our program from the client side. Download the code [here](https://github.com/Unboxed-Software/solana-hello-world-client).
+Finally, let's invoke our program from the client side. Download the code
+[here](https://github.com/Unboxed-Software/solana-hello-world-client).
 
-The focus of this lesson is to build our Solana program, so we’ve gone ahead and provided the client code to invoke our “Hello, world!” program. The code provided includes a `sayHello` helper function that builds and submits our transaction. We then call `sayHello` in the main function and print a Solana Explorer URL to view our transaction details in the browser.
+The focus of this lesson is to build our Solana program, so we’ve gone ahead and
+provided the client code to invoke our “Hello, world!” program. The code
+provided includes a `sayHello` helper function that builds and submits our
+transaction. We then call `sayHello` in the main function and print a Solana
+Explorer URL to view our transaction details in the browser.
 
-Open the `index.ts` file you should see a variable named `programId`. Go ahead and update this with the program ID of the “Hello, world!" program you just deployed using Solana Playground.
+Open the `index.ts` file you should see a variable named `programId`. Go ahead
+and update this with the program ID of the “Hello, world!" program you just
+deployed using Solana Playground.
 
 ```tsx
 let programId = new web3.PublicKey("<YOUR_PROGRAM_ID>");
@@ -272,7 +365,8 @@ Now, go ahead and run `npm start`. This command will:
 3. Invoke the “Hello, world!” program
 4. Output the transaction URL to view on Solana Explorer
 
-Copy the transaction URL printed in the console into your browser. Scroll down to see “Hello, world!” under Program Instruction Logs.
+Copy the transaction URL printed in the console into your browser. Scroll down
+to see “Hello, world!” under Program Instruction Logs.
 
 ![Screenshot Solana Explorer Program Log](../assets/hello-world-program-log.png)
 
@@ -280,10 +374,16 @@ Congratulations, you’ve just successfully built and deployed a Solana program!
 
 # Challenge
 
-Now it’s your turn to build something independently. Because we're starting with very simple programs, yours will look almost identical to what we just created. It's useful to try and get to the point where you can write it from scratch without referencing prior code, so try not to copy and paste here.
+Now it’s your turn to build something independently. Because we're starting with
+very simple programs, yours will look almost identical to what we just created.
+It's useful to try and get to the point where you can write it from scratch
+without referencing prior code, so try not to copy and paste here.
 
-1. Write a new program that uses the `msg!` macro to print your own message to the program log.
+1. Write a new program that uses the `msg!` macro to print your own message to
+   the program log.
 2. Build and deploy your program like we did in the demo.
-3. Invoke your newly deployed program and use Solana Explorer to check that your message was printed in the program log.
+3. Invoke your newly deployed program and use Solana Explorer to check that your
+   message was printed in the program log.
 
-As always, get creative with these challenges and take them beyond the basic instructions if you want - and have fun!
+As always, get creative with these challenges and take them beyond the basic
+instructions if you want - and have fun!

--- a/developers/courses/solana-course/content/hello-world-program.md
+++ b/developers/courses/solana-course/content/hello-world-program.md
@@ -1,12 +1,12 @@
 ---
 title: Hello World
 objectives:
-- Use the Rust module system
-- Define a function in Rust
-- Explain the `Result` type
-- Explain the entry point to a Solana program
-- Build and deploy a basic Solana program
-- Submit a transaction to invoke our “Hello, world!” program
+  - Use the Rust module system
+  - Define a function in Rust
+  - Explain the `Result` type
+  - Explain the entry point to a Solana program
+  - Build and deploy a basic Solana program
+  - Submit a transaction to invoke our “Hello, world!” program
 ---
 
 # TL;DR
@@ -266,6 +266,7 @@ You can locate the program ID on Solana Playground referencing the image below.
 Next, install the Node modules with `npm i`.
 
 Now, go ahead and run `npm start`. This command will:
+
 1. Generate a new keypair and create a `.env` file if one does not already exist
 2. Airdrop devnet SOL
 3. Invoke the “Hello, world!” program

--- a/developers/courses/solana-course/content/interact-with-wallets.md
+++ b/developers/courses/solana-course/content/interact-with-wallets.md
@@ -1,10 +1,10 @@
 ---
 title: Interact With Wallets
 objectives:
-- Explain Wallets
-- Install Phantom extension
-- Set Phantom wallet to [Devnet](https://api.devnet.solana.com/)
-- Use wallet-adapter to have users sign transactions
+  - Explain Wallets
+  - Install Phantom extension
+  - Set Phantom wallet to [Devnet](https://api.devnet.solana.com/)
+  - Use wallet-adapter to have users sign transactions
 ---
 
 # TL;DR
@@ -72,24 +72,27 @@ npm install @solana/wallet-adapter-base \
 For these to work properly, any use of `useWallet` and `useConnection` should be wrapped in `WalletProvider` and `ConnectionProvider`. One of the best ways to ensure this is to wrap your entire app in `ConnectionProvider` and `WalletProvider`:
 
 ```tsx
-import { NextPage } from 'next'
-import { FC, ReactNode } from "react"
-import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
-import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom'
-import * as web3 from '@solana/web3.js'
+import { NextPage } from "next";
+import { FC, ReactNode } from "react";
+import {
+  ConnectionProvider,
+  WalletProvider,
+} from "@solana/wallet-adapter-react";
+import { PhantomWalletAdapter } from "@solana/wallet-adapter-phantom";
+import * as web3 from "@solana/web3.js";
 
-export const Home: NextPage = (props) => {
-    const endpoint = web3.clusterApiUrl('devnet')
-    const wallet = new PhantomWalletAdapter()
+export const Home: NextPage = props => {
+  const endpoint = web3.clusterApiUrl("devnet");
+  const wallet = new PhantomWalletAdapter();
 
-    return (
-        <ConnectionProvider endpoint={endpoint}>
-            <WalletProvider wallets={[wallet]}>
-                <p>Put the rest of your app here</p>
-            </WalletProvider>
-        </ConnectionProvider>
-    )
-}
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={[wallet]}>
+        <p>Put the rest of your app here</p>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+};
 ```
 
 Note that `ConnectionProvider` requires an `endpoint` property and that `WalletProvider` requires a `wallets` property. We’re continuing to use the endpoint for the Devnet cluster, and for now we’re only using the `PhantomWalletAdapter` for `wallets`.
@@ -105,30 +108,36 @@ While you could do this in a `useEffect` hook, you’ll usually want to provide 
 You can create custom components for this, or you can leverage components provided by `@solana/wallet-adapter-react-ui`. The simplest way to provide extensive options is to use `WalletModalProvider` and `WalletMultiButton`:
 
 ```tsx
-import { NextPage } from 'next'
-import { FC, ReactNode } from "react"
-import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
-import { WalletModalProvider, WalletMultiButton } from '@solana/wallet-adapter-react-ui';
-import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom'
-import * as web3 from '@solana/web3.js'
+import { NextPage } from "next";
+import { FC, ReactNode } from "react";
+import {
+  ConnectionProvider,
+  WalletProvider,
+} from "@solana/wallet-adapter-react";
+import {
+  WalletModalProvider,
+  WalletMultiButton,
+} from "@solana/wallet-adapter-react-ui";
+import { PhantomWalletAdapter } from "@solana/wallet-adapter-phantom";
+import * as web3 from "@solana/web3.js";
 
-const Home: NextPage = (props) => {
-    const endpoint = web3.clusterApiUrl('devnet')
-    const wallet = new PhantomWalletAdapter()
+const Home: NextPage = props => {
+  const endpoint = web3.clusterApiUrl("devnet");
+  const wallet = new PhantomWalletAdapter();
 
-    return (
-        <ConnectionProvider endpoint={endpoint}>
-            <WalletProvider wallets={[wallet]}>
-                <WalletModalProvider>
-                    <WalletMultiButton />
-                    <p>Put the rest of your app here</p>
-                </WalletModalProvider>
-            </WalletProvider>
-        </ConnectionProvider>
-    )
-}
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={[wallet]}>
+        <WalletModalProvider>
+          <WalletMultiButton />
+          <p>Put the rest of your app here</p>
+        </WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+};
 
-export default Home
+export default Home;
 ```
 
 The `WalletModalProvider` adds functionality for presenting a modal screen for users to select which wallet they’d like to use. The `WalletMultiButton` changes behavior to match the connection status:
@@ -154,29 +163,31 @@ You can also use more granular components if you need more specific functionalit
 Once your site is connected to a wallet, `useConnection` will retrieve a `Connection` object and `useWallet` will get the `WalletContextState`. `WalletContextState` has a property `publicKey` that is `null` when not connected to a wallet and has the public key of the user’s account when a wallet is connected. With a public key and a connection, you can fetch account info and more.
 
 ```tsx
-import { useConnection, useWallet } from '@solana/wallet-adapter-react'
-import { LAMPORTS_PER_SOL } from '@solana/web3.js'
-import { FC, useEffect, useState } from 'react'
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+import { LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { FC, useEffect, useState } from "react";
 
 export const BalanceDisplay: FC = () => {
-    const [balance, setBalance] = useState(0)
-    const { connection } = useConnection()
-    const { publicKey } = useWallet()
+  const [balance, setBalance] = useState(0);
+  const { connection } = useConnection();
+  const { publicKey } = useWallet();
 
-    useEffect(() => {
-        if (!connection || !publicKey) { return }
+  useEffect(() => {
+    if (!connection || !publicKey) {
+      return;
+    }
 
-        connection.getAccountInfo(publicKey).then(info => {
-            setBalance(info.lamports)
-        })
-    }, [connection, publicKey])
+    connection.getAccountInfo(publicKey).then(info => {
+      setBalance(info.lamports);
+    });
+  }, [connection, publicKey]);
 
-    return (
-        <div>
-            <p>{publicKey ? `Balance: ${balance / LAMPORTS_PER_SOL} SOL` : ''}</p>
-        </div>
-    )
-}
+  return (
+    <div>
+      <p>{publicKey ? `Balance: ${balance / LAMPORTS_PER_SOL} SOL` : ""}</p>
+    </div>
+  );
+};
 ```
 
 ### Send Transactions
@@ -184,26 +195,26 @@ export const BalanceDisplay: FC = () => {
 `WalletContextState` also provides a `sendTransaction` function that you can use to submit transactions for approval.
 
 ```tsx
-const { publicKey, sendTransaction } = useWallet()
-const { connection } = useConnection()
+const { publicKey, sendTransaction } = useWallet();
+const { connection } = useConnection();
 
 const sendSol = event => {
-    event.preventDefault()
+  event.preventDefault();
 
-    const transaction = new web3.Transaction()
-    const recipientPubKey = new web3.PublicKey(event.target.recipient.value)
+  const transaction = new web3.Transaction();
+  const recipientPubKey = new web3.PublicKey(event.target.recipient.value);
 
-    const sendSolInstruction = web3.SystemProgram.transfer({
-        fromPubkey: publicKey,
-        toPubkey: recipientPubKey,
-        lamports: LAMPORTS_PER_SOL * 0.1
-    })
+  const sendSolInstruction = web3.SystemProgram.transfer({
+    fromPubkey: publicKey,
+    toPubkey: recipientPubKey,
+    lamports: LAMPORTS_PER_SOL * 0.1,
+  });
 
-    transaction.add(sendSolInstruction);
-    sendTransaction(transaction, connection).then(sig => {
-        console.log(sig)
-    })
-}
+  transaction.add(sendSolInstruction);
+  sendTransaction(transaction, connection).then(sig => {
+    console.log(sig);
+  });
+};
 ```
 
 When this function is called, the connected wallet will display the transaction for the user’s approval. If approved, then the transaction will be sent.
@@ -250,24 +261,24 @@ export default WalletContextProvider
 To properly connect to the user’s wallet, we’ll need a `ConnectionProvider`, `WalletProvider` and `WalletModalProvider`. Start by importing these components from `@solana/wallet-adapter-react` and `@solana/wallet-adapter-react-ui`. Then add them to the `WalletContextProvider` component. Note that `ConnectionProvider` requires an `endpoint` parameter and `WalletProvider` requires an array of `wallets`. For now, just use an empty string and an empty array, respectively.
 
 ```tsx
-import { FC, ReactNode } from 'react'
-import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
-import { WalletModalProvider } from "@solana/wallet-adapter-react-ui"
+import { FC, ReactNode } from "react";
+import {
+  ConnectionProvider,
+  WalletProvider,
+} from "@solana/wallet-adapter-react";
+import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 
 const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  return (
+    <ConnectionProvider endpoint={""}>
+      <WalletProvider wallets={[]}>
+        <WalletModalProvider>{children}</WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+};
 
-    return (
-        <ConnectionProvider endpoint={''}>
-            <WalletProvider wallets={[]}>
-                <WalletModalProvider>
-                    { children }
-                </WalletModalProvider>
-            </WalletProvider>
-        </ConnectionProvider>
-    )
-}
-
-export default WalletContextProvider
+export default WalletContextProvider;
 ```
 
 The last things we need are an actual endpoint for `ConnectionProvider` and the supported wallets for `WalletProvider`.
@@ -279,29 +290,30 @@ After importing these libraries, create a constant `endpoint` that uses the `clu
 To complete this component, add `require('@solana/wallet-adapter-react-ui/styles.css');` below your imports to ensure proper styling and behavior of the Wallet Adapter library components.
 
 ```tsx
-import { FC, ReactNode } from 'react'
-import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
-import { WalletModalProvider } from "@solana/wallet-adapter-react-ui"
-import * as web3 from '@solana/web3.js'
-import * as walletAdapterWallets from '@solana/wallet-adapter-wallets'
-require('@solana/wallet-adapter-react-ui/styles.css')
+import { FC, ReactNode } from "react";
+import {
+  ConnectionProvider,
+  WalletProvider,
+} from "@solana/wallet-adapter-react";
+import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
+import * as web3 from "@solana/web3.js";
+import * as walletAdapterWallets from "@solana/wallet-adapter-wallets";
+require("@solana/wallet-adapter-react-ui/styles.css");
 
 const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
-    const endpoint = web3.clusterApiUrl('devnet')
-    const wallets = [new walletAdapterWallets.PhantomWalletAdapter()]
+  const endpoint = web3.clusterApiUrl("devnet");
+  const wallets = [new walletAdapterWallets.PhantomWalletAdapter()];
 
-    return (
-        <ConnectionProvider endpoint={endpoint}>
-            <WalletProvider wallets={wallets}>
-                <WalletModalProvider>
-                    { children }
-                </WalletModalProvider>
-            </WalletProvider>
-        </ConnectionProvider>
-    )
-}
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets}>
+        <WalletModalProvider>{children}</WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+};
 
-export default WalletContextProvider
+export default WalletContextProvider;
 ```
 
 ### 4. Add wallet multi-button
@@ -311,54 +323,50 @@ Next let’s set up the Connect button. The current button is just a placeholder
 Before we add the “multi-button,” we need to wrap the app in the `WalletContextProvider`. Do this by importing it in `index.tsx` and adding it after the closing `</Head>` tag:
 
 ```tsx
-import { NextPage } from 'next'
-import styles from '../styles/Home.module.css'
-import WalletContextProvider from '../components/WalletContextProvider'
-import { AppBar } from '../components/AppBar'
-import Head from 'next/head'
-import { PingButton } from '../components/PingButton'
+import { NextPage } from "next";
+import styles from "../styles/Home.module.css";
+import WalletContextProvider from "../components/WalletContextProvider";
+import { AppBar } from "../components/AppBar";
+import Head from "next/head";
+import { PingButton } from "../components/PingButton";
 
-const Home: NextPage = (props) => {
-
-    return (
-        <div className={styles.App}>
-            <Head>
-                <title>Wallet-Adapter Example</title>
-                <meta
-                    name="description"
-                    content="Wallet-Adapter Example"
-                />
-            </Head>
-            <WalletContextProvider>
-                <AppBar />
-                <div className={styles.AppBody}>
-                    <PingButton/>
-                </div>
-            </WalletContextProvider >
+const Home: NextPage = props => {
+  return (
+    <div className={styles.App}>
+      <Head>
+        <title>Wallet-Adapter Example</title>
+        <meta name="description" content="Wallet-Adapter Example" />
+      </Head>
+      <WalletContextProvider>
+        <AppBar />
+        <div className={styles.AppBody}>
+          <PingButton />
         </div>
-    );
-}
+      </WalletContextProvider>
+    </div>
+  );
+};
 
-export default Home
+export default Home;
 ```
 
 If you run the app, everything should still look the same since the current button on the top right is still just a placeholder. To remedy this, open `AppBar.tsx` and replace `<button>Connect</button>` with `<WalletMultiButton/>`. You’ll need to import `WalletMultiButton` from `@solana/wallet-adapter-react-ui`.
 
 ```tsx
-import { FC } from 'react'
-import styles from '../styles/Home.module.css'
-import Image from 'next/image'
-import { WalletMultiButton } from '@solana/wallet-adapter-react-ui'
+import { FC } from "react";
+import styles from "../styles/Home.module.css";
+import Image from "next/image";
+import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
 
 export const AppBar: FC = () => {
-    return (
-        <div className={styles.AppHeader}>
-            <Image src="/solanaLogo.png" height={30} width={200} />
-            <span>Wallet-Adapter Example</span>
-            <WalletMultiButton/>
-        </div>
-    )
-}
+  return (
+    <div className={styles.AppHeader}>
+      <Image src="/solanaLogo.png" height={30} width={200} />
+      <span>Wallet-Adapter Example</span>
+      <WalletMultiButton />
+    </div>
+  );
+};
 ```
 
 At this point, you should be able to run the app and interact with the multi-button at the top-right of the screen. It should now read, "Select Wallet." If you have the Phantom extension and are signed in, you should be able to connect your Phantom wallet to the site using this new button.
@@ -372,47 +380,46 @@ Start by opening the `PingButton.tsx` file. We’re going to replace the `consol
 First, we need a connection, the wallet’s public key, and Wallet-Adapter’s `sendTransaction` function. To get this, we need to import `useConnection` and `useWallet` from `@solana/wallet-adapter-react`. While we’re here, let’s also import `@solana/web3.js` since we’ll need it to create our transaction.
 
 ```tsx
-import { useConnection, useWallet } from '@solana/wallet-adapter-react'
-import * as web3 from '@solana/web3.js'
-import { FC, useState } from 'react'
-import styles from '../styles/PingButton.module.css'
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+import * as web3 from "@solana/web3.js";
+import { FC, useState } from "react";
+import styles from "../styles/PingButton.module.css";
 
 export const PingButton: FC = () => {
+  const onClick = () => {
+    console.log("Ping!");
+  };
 
-	const onClick = () => {
-		console.log('Ping!')
-	}
-
-	return (
-		<div className={styles.buttonContainer} onClick={onClick}>
-			<button className={styles.button}>Ping!</button>
-		</div>
-	)
-}
+  return (
+    <div className={styles.buttonContainer} onClick={onClick}>
+      <button className={styles.button}>Ping!</button>
+    </div>
+  );
+};
 ```
 
 Now use the `useConnection` hook to create a `connection` constant and the `useWallet` hook to create `publicKey` and `sendTransaction` constants.
 
 ```tsx
-import { useConnection, useWallet } from '@solana/wallet-adapter-react'
-import * as web3 from '@solana/web3.js'
-import { FC, useState } from 'react'
-import styles from '../styles/PingButton.module.css'
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+import * as web3 from "@solana/web3.js";
+import { FC, useState } from "react";
+import styles from "../styles/PingButton.module.css";
 
 export const PingButton: FC = () => {
-    const { connection } = useConnection();
-    const { publicKey, sendTransaction } = useWallet();
+  const { connection } = useConnection();
+  const { publicKey, sendTransaction } = useWallet();
 
-    const onClick = () => {
-        console.log('Ping!')
-    }
+  const onClick = () => {
+    console.log("Ping!");
+  };
 
-    return (
-        <div className={styles.buttonContainer} onClick={onClick}>
-            <button className={styles.button}>Ping!</button>
-        </div>
-    )
-}
+  return (
+    <div className={styles.buttonContainer} onClick={onClick}>
+      <button className={styles.button}>Ping!</button>
+    </div>
+  );
+};
 ```
 
 With that, we can fill in the body of `onClick`.
@@ -429,28 +436,30 @@ Finally, call `sendTransaction`.
 
 ```tsx
 const onClick = () => {
-    if (!connection || !publicKey) { return }
+  if (!connection || !publicKey) {
+    return;
+  }
 
-    const programId = new web3.PublicKey(PROGRAM_ID)
-    const programDataAccount = new web3.PublicKey(DATA_ACCOUNT_PUBKEY)
-    const transaction = new web3.Transaction()
+  const programId = new web3.PublicKey(PROGRAM_ID);
+  const programDataAccount = new web3.PublicKey(DATA_ACCOUNT_PUBKEY);
+  const transaction = new web3.Transaction();
 
-    const instruction = new web3.TransactionInstruction({
-        keys: [
-            {
-                pubkey: programDataAccount,
-                isSigner: false,
-                isWritable: true
-            },
-        ],
-        programId
-    });
+  const instruction = new web3.TransactionInstruction({
+    keys: [
+      {
+        pubkey: programDataAccount,
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    programId,
+  });
 
-    transaction.add(instruction)
-    sendTransaction(transaction, connection).then(sig => {
-        console.log(sig)
-    })
-}
+  transaction.add(instruction);
+  sendTransaction(transaction, connection).then(sig => {
+    console.log(sig);
+  });
+};
 ```
 
 And that’s it! If you refresh the page, connect your wallet, and click the ping button, Phantom should present you with a popup for confirming the transaction.

--- a/developers/courses/solana-course/content/interact-with-wallets.md
+++ b/developers/courses/solana-course/content/interact-with-wallets.md
@@ -12,46 +12,81 @@ objectives:
 - **Wallets** store your secret key and handle secure transaction signing
 - **Hardware wallets** store your secret key on a separate device
 - **Software wallets** use your computer for secure storage
-- Software wallets are often **browser extensions** that facilitate connecting to websites
-- Solana’s **Wallet-Adapter library** simplifies the support of wallet browser extensions, allowing you to build websites that can request a user’s wallet address and propose transactions for them to sign
+- Software wallets are often **browser extensions** that facilitate connecting
+  to websites
+- Solana’s **Wallet-Adapter library** simplifies the support of wallet browser
+  extensions, allowing you to build websites that can request a user’s wallet
+  address and propose transactions for them to sign
 
 # Overview
 
 ## Wallets
 
-In the previous two lessons we discussed keypairs. Keypairs are used to locate accounts and sign transactions. While the public key of a keypair is perfectly safe to share, the secret key should always be kept in a secure location. If a user’s secret key is exposed, then a malicious actor could drain their account of all assets and execute transactions with the authority of that user.
+In the previous two lessons we discussed keypairs. Keypairs are used to locate
+accounts and sign transactions. While the public key of a keypair is perfectly
+safe to share, the secret key should always be kept in a secure location. If a
+user’s secret key is exposed, then a malicious actor could drain their account
+of all assets and execute transactions with the authority of that user.
 
-A “wallet” refers to anything that stores a secret key in order to keep it secure. These secure storage options can generally be described as either “hardware” or “software” wallets. Hardware wallets are storage devices that are separate from your computer. Software wallets are application you can install on your existing device(s).
+A “wallet” refers to anything that stores a secret key in order to keep it
+secure. These secure storage options can generally be described as either
+“hardware” or “software” wallets. Hardware wallets are storage devices that are
+separate from your computer. Software wallets are application you can install on
+your existing device(s).
 
-Software wallets often come in the form of a browser extension. This makes it possible for websites to interact easily with the wallet. Such interactions are usually limited to:
+Software wallets often come in the form of a browser extension. This makes it
+possible for websites to interact easily with the wallet. Such interactions are
+usually limited to:
 
 1. Seeing the wallet’s public key (address)
 2. Submitting transactions for a user's approval
 3. Sending an approved transaction to the network
 
-Once a transaction is submitted, the end user can “confirm” the transaction and send it to the network with their “signature.”
+Once a transaction is submitted, the end user can “confirm” the transaction and
+send it to the network with their “signature.”
 
-Signing transactions requires using your secret key. By letting a site submit a transaction to your wallet and having the wallet handle the signing, you ensure that you never expose your secret key to the website. Instead, you only share the secret key with the wallet application.
+Signing transactions requires using your secret key. By letting a site submit a
+transaction to your wallet and having the wallet handle the signing, you ensure
+that you never expose your secret key to the website. Instead, you only share
+the secret key with the wallet application.
 
-Unless you’re creating a wallet application yourself, your code should never need to ask a user for their secret key. Instead, you can ask users to connect to your site using a reputable wallet.
+Unless you’re creating a wallet application yourself, your code should never
+need to ask a user for their secret key. Instead, you can ask users to connect
+to your site using a reputable wallet.
 
 ## Phantom Wallet
 
-One of the most widely used software wallets in the Solana ecosystem is [Phantom](https://phantom.app). Phantom supports a few of the most popular browsers and has a mobile app for connecting on the go. You’ll likely want your decentralized applications to support multiple wallets, but this course will focus on Phantom.
+One of the most widely used software wallets in the Solana ecosystem is
+[Phantom](https://phantom.app). Phantom supports a few of the most popular
+browsers and has a mobile app for connecting on the go. You’ll likely want your
+decentralized applications to support multiple wallets, but this course will
+focus on Phantom.
 
 ## Solana’s Wallet-Adapter
 
-Solana’s Wallet-Adapter is a suite of libraries you can use to simplify the process of supporting wallet browser extensions.
+Solana’s Wallet-Adapter is a suite of libraries you can use to simplify the
+process of supporting wallet browser extensions.
 
-Solana’s Wallet-Adapter comprises multiple modular packages. The core functionality is found in `@solana/wallet-adapter-base` and `@solana/wallet-adapter-react`.
+Solana’s Wallet-Adapter comprises multiple modular packages. The core
+functionality is found in `@solana/wallet-adapter-base` and
+`@solana/wallet-adapter-react`.
 
-There are also packages that provide components for common UI frameworks. In this lesson and throughout this course, we’ll be using components from `@solana/wallet-adapter-react-ui`.
+There are also packages that provide components for common UI frameworks. In
+this lesson and throughout this course, we’ll be using components from
+`@solana/wallet-adapter-react-ui`.
 
-Finally, there are packages that are adapters for specific wallets, including Phantom. You can use `@solana/wallet-adapter-wallets` to include all of the supported wallets, or you can choose a specific wallet package like `@solana/wallet-adapter-phantom`.
+Finally, there are packages that are adapters for specific wallets, including
+Phantom. You can use `@solana/wallet-adapter-wallets` to include all of the
+supported wallets, or you can choose a specific wallet package like
+`@solana/wallet-adapter-phantom`.
 
 ### Install Wallet-Adapter Libraries
 
-When adding wallet support to an existing react app, you start by installing the appropriate packages. You’ll need `@solana/wallet-adapter-base`, `@solana/wallet-adapter-react`, the package(s) for the wallet(s) you want to support, and `@solana/wallet-adapter-react-ui` if you plan to use the provided react components, e.g.
+When adding wallet support to an existing react app, you start by installing the
+appropriate packages. You’ll need `@solana/wallet-adapter-base`,
+`@solana/wallet-adapter-react`, the package(s) for the wallet(s) you want to
+support, and `@solana/wallet-adapter-react-ui` if you plan to use the provided
+react components, e.g.
 
 ```
 npm install @solana/wallet-adapter-base \
@@ -62,14 +97,18 @@ npm install @solana/wallet-adapter-base \
 
 ### Connect To Wallets
 
-`@solana/wallet-adapter-react` allows us to persist and access wallet connection states through hooks and context providers, namely:
+`@solana/wallet-adapter-react` allows us to persist and access wallet connection
+states through hooks and context providers, namely:
 
 - `useWallet`
 - `WalletProvider`
 - `useConnection`
 - `ConnectionProvider`
 
-For these to work properly, any use of `useWallet` and `useConnection` should be wrapped in `WalletProvider` and `ConnectionProvider`. One of the best ways to ensure this is to wrap your entire app in `ConnectionProvider` and `WalletProvider`:
+For these to work properly, any use of `useWallet` and `useConnection` should be
+wrapped in `WalletProvider` and `ConnectionProvider`. One of the best ways to
+ensure this is to wrap your entire app in `ConnectionProvider` and
+`WalletProvider`:
 
 ```tsx
 import { NextPage } from "next";
@@ -95,17 +134,27 @@ export const Home: NextPage = props => {
 };
 ```
 
-Note that `ConnectionProvider` requires an `endpoint` property and that `WalletProvider` requires a `wallets` property. We’re continuing to use the endpoint for the Devnet cluster, and for now we’re only using the `PhantomWalletAdapter` for `wallets`.
+Note that `ConnectionProvider` requires an `endpoint` property and that
+`WalletProvider` requires a `wallets` property. We’re continuing to use the
+endpoint for the Devnet cluster, and for now we’re only using the
+`PhantomWalletAdapter` for `wallets`.
 
-At this point you can connect with `wallet.connect()`, which will effectively instruct the wallet to prompt the user for permission to view their public key and request approval for transactions.
+At this point you can connect with `wallet.connect()`, which will effectively
+instruct the wallet to prompt the user for permission to view their public key
+and request approval for transactions.
 
 ![Screenshot of wallet connection prompt](../assets/wallet-connect-prompt.png)
 
-While you could do this in a `useEffect` hook, you’ll usually want to provide more sophisticated functionality. For example, you may want users to be able to choose from a list of supported wallets, or disconnect after they’ve already connected.
+While you could do this in a `useEffect` hook, you’ll usually want to provide
+more sophisticated functionality. For example, you may want users to be able to
+choose from a list of supported wallets, or disconnect after they’ve already
+connected.
 
 ### `@solana/wallet-adapter-react-ui`
 
-You can create custom components for this, or you can leverage components provided by `@solana/wallet-adapter-react-ui`. The simplest way to provide extensive options is to use `WalletModalProvider` and `WalletMultiButton`:
+You can create custom components for this, or you can leverage components
+provided by `@solana/wallet-adapter-react-ui`. The simplest way to provide
+extensive options is to use `WalletModalProvider` and `WalletMultiButton`:
 
 ```tsx
 import { NextPage } from "next";
@@ -140,7 +189,9 @@ const Home: NextPage = props => {
 export default Home;
 ```
 
-The `WalletModalProvider` adds functionality for presenting a modal screen for users to select which wallet they’d like to use. The `WalletMultiButton` changes behavior to match the connection status:
+The `WalletModalProvider` adds functionality for presenting a modal screen for
+users to select which wallet they’d like to use. The `WalletMultiButton` changes
+behavior to match the connection status:
 
 ![Screenshot of multi button select wallet option](../assets/multi-button-select-wallet.png)
 
@@ -150,7 +201,8 @@ The `WalletModalProvider` adds functionality for presenting a modal screen for u
 
 ![Screenshot of multi button connected state](../assets/multi-button-connected.png)
 
-You can also use more granular components if you need more specific functionality:
+You can also use more granular components if you need more specific
+functionality:
 
 - `WalletConnectButton`
 - `WalletModal`
@@ -160,7 +212,12 @@ You can also use more granular components if you need more specific functionalit
 
 ### Access Account Info
 
-Once your site is connected to a wallet, `useConnection` will retrieve a `Connection` object and `useWallet` will get the `WalletContextState`. `WalletContextState` has a property `publicKey` that is `null` when not connected to a wallet and has the public key of the user’s account when a wallet is connected. With a public key and a connection, you can fetch account info and more.
+Once your site is connected to a wallet, `useConnection` will retrieve a
+`Connection` object and `useWallet` will get the `WalletContextState`.
+`WalletContextState` has a property `publicKey` that is `null` when not
+connected to a wallet and has the public key of the user’s account when a wallet
+is connected. With a public key and a connection, you can fetch account info and
+more.
 
 ```tsx
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
@@ -192,7 +249,8 @@ export const BalanceDisplay: FC = () => {
 
 ### Send Transactions
 
-`WalletContextState` also provides a `sendTransaction` function that you can use to submit transactions for approval.
+`WalletContextState` also provides a `sendTransaction` function that you can use
+to submit transactions for approval.
 
 ```tsx
 const { publicKey, sendTransaction } = useWallet();
@@ -217,31 +275,47 @@ const sendSol = event => {
 };
 ```
 
-When this function is called, the connected wallet will display the transaction for the user’s approval. If approved, then the transaction will be sent.
+When this function is called, the connected wallet will display the transaction
+for the user’s approval. If approved, then the transaction will be sent.
 
 ![Screenshot of wallet transaction approval prompt](../assets/wallet-transaction-approval-prompt.png)
 
 # Demo
 
-Let’s take the Ping program from last lesson and build a frontend that lets users approve a transaction that pings the program. As a reminder, the program’s public key is `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa` and the public key for the data account is `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
+Let’s take the Ping program from last lesson and build a frontend that lets
+users approve a transaction that pings the program. As a reminder, the program’s
+public key is `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa` and the public key
+for the data account is `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
 
 ![Screenshot of Solana Ping App](../assets/solana-ping-app.png)
 
 ### 1. Download the Phantom browser extension and set it to Devnet
 
-If you don’t already have it, download the [Phantom browser extension](https://phantom.app/download). At the time of writing, it supports Chrome, Brave, Firefox, and Edge browsers, so you’ll also need to have one of those browsers installed. Follow Phantom’s instructions for creating a new account and a new wallet.
+If you don’t already have it, download the
+[Phantom browser extension](https://phantom.app/download). At the time of
+writing, it supports Chrome, Brave, Firefox, and Edge browsers, so you’ll also
+need to have one of those browsers installed. Follow Phantom’s instructions for
+creating a new account and a new wallet.
 
-Once you have a wallet, click the settings gear on the bottom right in the Phantom UI. Scroll down and click on the line item “Change Network” and select “Devnet.” This ensures that Phantom will be connected to the same network we’ll be using in this demo.
+Once you have a wallet, click the settings gear on the bottom right in the
+Phantom UI. Scroll down and click on the line item “Change Network” and select
+“Devnet.” This ensures that Phantom will be connected to the same network we’ll
+be using in this demo.
 
 ### 2. Download the starter code
 
-Download the starter code for this project [here](https://github.com/Unboxed-Software/solana-ping-frontend/tree/starter). This project is a simple Next.js application. It’s mostly empty except for the `AppBar` component. We’ll build the rest throughout this demo.
+Download the starter code for this project
+[here](https://github.com/Unboxed-Software/solana-ping-frontend/tree/starter).
+This project is a simple Next.js application. It’s mostly empty except for the
+`AppBar` component. We’ll build the rest throughout this demo.
 
 You can see its current state with the command `npm run dev` in the console.
 
 ### 3. Wrap the app in context providers
 
-To start, we’re going to create a new component to contain the various Wallet-Adapter providers that we’ll be using. Create a new file inside the `components` folder called `WalletContextProvider.tsx`.
+To start, we’re going to create a new component to contain the various
+Wallet-Adapter providers that we’ll be using. Create a new file inside the
+`components` folder called `WalletContextProvider.tsx`.
 
 Let’s start with some of the boilerplate for a functional component:
 
@@ -258,7 +332,13 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
 export default WalletContextProvider
 ```
 
-To properly connect to the user’s wallet, we’ll need a `ConnectionProvider`, `WalletProvider` and `WalletModalProvider`. Start by importing these components from `@solana/wallet-adapter-react` and `@solana/wallet-adapter-react-ui`. Then add them to the `WalletContextProvider` component. Note that `ConnectionProvider` requires an `endpoint` parameter and `WalletProvider` requires an array of `wallets`. For now, just use an empty string and an empty array, respectively.
+To properly connect to the user’s wallet, we’ll need a `ConnectionProvider`,
+`WalletProvider` and `WalletModalProvider`. Start by importing these components
+from `@solana/wallet-adapter-react` and `@solana/wallet-adapter-react-ui`. Then
+add them to the `WalletContextProvider` component. Note that
+`ConnectionProvider` requires an `endpoint` parameter and `WalletProvider`
+requires an array of `wallets`. For now, just use an empty string and an empty
+array, respectively.
 
 ```tsx
 import { FC, ReactNode } from "react";
@@ -281,13 +361,23 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
 export default WalletContextProvider;
 ```
 
-The last things we need are an actual endpoint for `ConnectionProvider` and the supported wallets for `WalletProvider`.
+The last things we need are an actual endpoint for `ConnectionProvider` and the
+supported wallets for `WalletProvider`.
 
-For the endpoint, we’ll use the same `clusterApiUrl` function from the `@solana/web3.js` library that we’ve used before so you’ll need to import it. For the array of wallets you’ll also need to import the `@solana/wallet-adapter-wallets` library.
+For the endpoint, we’ll use the same `clusterApiUrl` function from the
+`@solana/web3.js` library that we’ve used before so you’ll need to import it.
+For the array of wallets you’ll also need to import the
+`@solana/wallet-adapter-wallets` library.
 
-After importing these libraries, create a constant `endpoint` that uses the `clusterApiUrl` function to get the url for Devnet. Then create a constant `wallets` and set it to an array that contains a newly constructed `PhantomWalletAdapter`. Finally, replace the empty string and empty array in `ConnectionProvider` and `WalletProvider`, respectively.
+After importing these libraries, create a constant `endpoint` that uses the
+`clusterApiUrl` function to get the url for Devnet. Then create a constant
+`wallets` and set it to an array that contains a newly constructed
+`PhantomWalletAdapter`. Finally, replace the empty string and empty array in
+`ConnectionProvider` and `WalletProvider`, respectively.
 
-To complete this component, add `require('@solana/wallet-adapter-react-ui/styles.css');` below your imports to ensure proper styling and behavior of the Wallet Adapter library components.
+To complete this component, add
+`require('@solana/wallet-adapter-react-ui/styles.css');` below your imports to
+ensure proper styling and behavior of the Wallet Adapter library components.
 
 ```tsx
 import { FC, ReactNode } from "react";
@@ -318,9 +408,16 @@ export default WalletContextProvider;
 
 ### 4. Add wallet multi-button
 
-Next let’s set up the Connect button. The current button is just a placeholder because rather than using a standard button or creating a custom component, we’ll be using Wallet-Adapter’s “multi-button.” This button interfaces with the providers we set up in `WalletContextProvider` and let’s users choose a wallet, connect to a wallet, and disconnect from a wallet. If you ever need more custom functionality, you can create a custom component to handle this.
+Next let’s set up the Connect button. The current button is just a placeholder
+because rather than using a standard button or creating a custom component,
+we’ll be using Wallet-Adapter’s “multi-button.” This button interfaces with the
+providers we set up in `WalletContextProvider` and let’s users choose a wallet,
+connect to a wallet, and disconnect from a wallet. If you ever need more custom
+functionality, you can create a custom component to handle this.
 
-Before we add the “multi-button,” we need to wrap the app in the `WalletContextProvider`. Do this by importing it in `index.tsx` and adding it after the closing `</Head>` tag:
+Before we add the “multi-button,” we need to wrap the app in the
+`WalletContextProvider`. Do this by importing it in `index.tsx` and adding it
+after the closing `</Head>` tag:
 
 ```tsx
 import { NextPage } from "next";
@@ -350,7 +447,11 @@ const Home: NextPage = props => {
 export default Home;
 ```
 
-If you run the app, everything should still look the same since the current button on the top right is still just a placeholder. To remedy this, open `AppBar.tsx` and replace `<button>Connect</button>` with `<WalletMultiButton/>`. You’ll need to import `WalletMultiButton` from `@solana/wallet-adapter-react-ui`.
+If you run the app, everything should still look the same since the current
+button on the top right is still just a placeholder. To remedy this, open
+`AppBar.tsx` and replace `<button>Connect</button>` with `<WalletMultiButton/>`.
+You’ll need to import `WalletMultiButton` from
+`@solana/wallet-adapter-react-ui`.
 
 ```tsx
 import { FC } from "react";
@@ -369,15 +470,24 @@ export const AppBar: FC = () => {
 };
 ```
 
-At this point, you should be able to run the app and interact with the multi-button at the top-right of the screen. It should now read, "Select Wallet." If you have the Phantom extension and are signed in, you should be able to connect your Phantom wallet to the site using this new button.
+At this point, you should be able to run the app and interact with the
+multi-button at the top-right of the screen. It should now read, "Select
+Wallet." If you have the Phantom extension and are signed in, you should be able
+to connect your Phantom wallet to the site using this new button.
 
 ### 5. Create button to ping program
 
-Now that our app can connect to the Phantom wallet, let’s make the “Ping!” button actually do something.
+Now that our app can connect to the Phantom wallet, let’s make the “Ping!”
+button actually do something.
 
-Start by opening the `PingButton.tsx` file. We’re going to replace the `console.log` inside of `onClick` with code that will create a transaction and submit it to the Phantom extension for the end user’s approval.
+Start by opening the `PingButton.tsx` file. We’re going to replace the
+`console.log` inside of `onClick` with code that will create a transaction and
+submit it to the Phantom extension for the end user’s approval.
 
-First, we need a connection, the wallet’s public key, and Wallet-Adapter’s `sendTransaction` function. To get this, we need to import `useConnection` and `useWallet` from `@solana/wallet-adapter-react`. While we’re here, let’s also import `@solana/web3.js` since we’ll need it to create our transaction.
+First, we need a connection, the wallet’s public key, and Wallet-Adapter’s
+`sendTransaction` function. To get this, we need to import `useConnection` and
+`useWallet` from `@solana/wallet-adapter-react`. While we’re here, let’s also
+import `@solana/web3.js` since we’ll need it to create our transaction.
 
 ```tsx
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
@@ -398,7 +508,8 @@ export const PingButton: FC = () => {
 };
 ```
 
-Now use the `useConnection` hook to create a `connection` constant and the `useWallet` hook to create `publicKey` and `sendTransaction` constants.
+Now use the `useConnection` hook to create a `connection` constant and the
+`useWallet` hook to create `publicKey` and `sendTransaction` constants.
 
 ```tsx
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
@@ -424,11 +535,15 @@ export const PingButton: FC = () => {
 
 With that, we can fill in the body of `onClick`.
 
-First, check that both `connection` and `publicKey` exist (if either does not then the user’s wallet isn’t connected yet).
+First, check that both `connection` and `publicKey` exist (if either does not
+then the user’s wallet isn’t connected yet).
 
-Next, construct two instances of `PublicKey`, one for the program ID `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa` and one for the data account `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
+Next, construct two instances of `PublicKey`, one for the program ID
+`ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa` and one for the data account
+`Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
 
-Next, construct a `Transaction`, then a new `TransactionInstruction` that includes the data account as a writable key.
+Next, construct a `Transaction`, then a new `TransactionInstruction` that
+includes the data account as a writable key.
 
 Next, add the instruction to the transaction.
 
@@ -462,23 +577,36 @@ const onClick = () => {
 };
 ```
 
-And that’s it! If you refresh the page, connect your wallet, and click the ping button, Phantom should present you with a popup for confirming the transaction.
+And that’s it! If you refresh the page, connect your wallet, and click the ping
+button, Phantom should present you with a popup for confirming the transaction.
 
 ### 6. Add some polish around the edges
 
-There’s a lot you could do to make the user experience here even better. For example, you could change the UI to only show you the Ping button when a wallet is connected and display some other prompt otherwise. You could link to the transaction on Solana Explorer after a user confirms a transaction so they can easily go look at the transaction details. The more you experiment with it, the more comfortable you’ll get, so get creative!
+There’s a lot you could do to make the user experience here even better. For
+example, you could change the UI to only show you the Ping button when a wallet
+is connected and display some other prompt otherwise. You could link to the
+transaction on Solana Explorer after a user confirms a transaction so they can
+easily go look at the transaction details. The more you experiment with it, the
+more comfortable you’ll get, so get creative!
 
-If you need to spend some time looking at the full source code from this demo to understand all of this in context, check that out [here](https://github.com/Unboxed-Software/solana-ping-frontend).
+If you need to spend some time looking at the full source code from this demo to
+understand all of this in context, check that out
+[here](https://github.com/Unboxed-Software/solana-ping-frontend).
 
 # Challenge
 
-Now it’s your turn to build something independently. Create an application that lets a user connect their Phantom wallet and send SOL to another account.
+Now it’s your turn to build something independently. Create an application that
+lets a user connect their Phantom wallet and send SOL to another account.
 
 ![Screenshot of Send Sol App](../assets/solana-send-sol-app.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/starter).
+1. You can build this from scratch or you can download the starter code
+   [here](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/starter).
 2. Wrap the starter application in the appropriate context providers.
-3. In the form component, set up the transaction and send it to the user’s wallet for approval.
-4. Get creative with the user experience. Add a link to let the user view the transaction on Solana Explorer or something else that seems cool to you!
+3. In the form component, set up the transaction and send it to the user’s
+   wallet for approval.
+4. Get creative with the user experience. Add a link to let the user view the
+   transaction on Solana Explorer or something else that seems cool to you!
 
-If you get really stumped, feel free to check out the solution code [here](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/main).
+If you get really stumped, feel free to check out the solution code
+[here](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/main).

--- a/developers/courses/solana-course/content/intro-to-anchor-frontend.md
+++ b/developers/courses/solana-course/content/intro-to-anchor-frontend.md
@@ -11,15 +11,26 @@ objectives:
 
 # TL;DR
 
-- An **IDL** is a file representing the structure of a Solana program. Programs written and built using Anchor automatically generate a corresponding IDL. IDL stands for Interface Description Language.
-- `@project-serum/anchor` is a Typescript client that includes everything you’ll need to interact with Anchor programs
-- An **Anchor `Provider`** object combines a `connection` to a cluster and a specified `wallet` to enable transaction signing
-- An **Anchor `Program`** object provides a custom API to interact with a specific program. You create a `Program` instance using a program's IDL and `Provider`.
-- The **Anchor `MethodsBuilder`** provides a simple interface through `Program` for building instructions and transactions
+- An **IDL** is a file representing the structure of a Solana program. Programs
+  written and built using Anchor automatically generate a corresponding IDL. IDL
+  stands for Interface Description Language.
+- `@project-serum/anchor` is a Typescript client that includes everything you’ll
+  need to interact with Anchor programs
+- An **Anchor `Provider`** object combines a `connection` to a cluster and a
+  specified `wallet` to enable transaction signing
+- An **Anchor `Program`** object provides a custom API to interact with a
+  specific program. You create a `Program` instance using a program's IDL and
+  `Provider`.
+- The **Anchor `MethodsBuilder`** provides a simple interface through `Program`
+  for building instructions and transactions
 
 # Overview
 
-Anchor simplifies the process of interacting with Solana programs from the client by providing an Interface Description Language (IDL) file that reflects the structure of a program. Using the IDL in conjunction with Anchor's Typescript library (`@project-serum/anchor`) provides a simplified format for building instructions and transactions.
+Anchor simplifies the process of interacting with Solana programs from the
+client by providing an Interface Description Language (IDL) file that reflects
+the structure of a program. Using the IDL in conjunction with Anchor's
+Typescript library (`@project-serum/anchor`) provides a simplified format for
+building instructions and transactions.
 
 ```tsx
 // sends transaction
@@ -30,11 +41,16 @@ await program.methods
   .rpc();
 ```
 
-This works from any Typescript client, whether it's a frontend or integration tests. In this lesson we'll go over how to use `@project-serum/anchor` to simplify your client-side program interaction.
+This works from any Typescript client, whether it's a frontend or integration
+tests. In this lesson we'll go over how to use `@project-serum/anchor` to
+simplify your client-side program interaction.
 
 ## Anchor client-side structure
 
-Let's start by going over the basic structure of Anchor's Typescript library. The primary object you'll be using is the `Program` object. A `Program` instance represents a specific Solana program and provides a custom API for reading and writing to the program.
+Let's start by going over the basic structure of Anchor's Typescript library.
+The primary object you'll be using is the `Program` object. A `Program` instance
+represents a specific Solana program and provides a custom API for reading and
+writing to the program.
 
 To create an instance of `Program`, you'll need the following:
 
@@ -46,15 +62,23 @@ To create an instance of `Program`, you'll need the following:
 
 ![Anchor structure](../assets/anchor-client-structure.png)
 
-The above image shows how each of these pieces are combined to create a `Program` instance. We'll go over each of them individually to get a better idea of how everything ties together.
+The above image shows how each of these pieces are combined to create a
+`Program` instance. We'll go over each of them individually to get a better idea
+of how everything ties together.
 
 ### Interface Description Language (IDL)
 
-When you build an Anchor program, Anchor generates both a JSON and Typescript file representing your program's IDL. The IDL represents the structure of the program and can be used by a client to infer how to interact with a specific program.
+When you build an Anchor program, Anchor generates both a JSON and Typescript
+file representing your program's IDL. The IDL represents the structure of the
+program and can be used by a client to infer how to interact with a specific
+program.
 
-While it isn't automatic, you can also generate an IDL from a native Solana program using tools like [shank](https://github.com/metaplex-foundation/shank) by Metaplex.
+While it isn't automatic, you can also generate an IDL from a native Solana
+program using tools like [shank](https://github.com/metaplex-foundation/shank)
+by Metaplex.
 
-To get an idea of the information an IDL provides, here is the IDL for the counter program you built previously:
+To get an idea of the information an IDL provides, here is the IDL for the
+counter program you built previously:
 
 ```json
 {
@@ -91,9 +115,12 @@ To get an idea of the information an IDL provides, here is the IDL for the count
 }
 ```
 
-Inspecting the IDL, you can see that this program contains two instructions (`initialize` and `increment`).
+Inspecting the IDL, you can see that this program contains two instructions
+(`initialize` and `increment`).
 
-Notice that in addition to specifying the instructions, it species the accounts and inputs for each instruction. The `initialize` instruction requires three accounts:
+Notice that in addition to specifying the instructions, it species the accounts
+and inputs for each instruction. The `initialize` instruction requires three
+accounts:
 
 1. `counter` - the new account being initialized in the instruction
 2. `user` - the payer for the transaction and initialization
@@ -104,13 +131,22 @@ And the `increment` instruction requires two accounts:
 1. `counter` - an existing account to increment the count field
 2. `user` - the payer from the transaction
 
-Looking at the IDL, you can see that in both instructions the `user` is required as a signer because the `isSigner` flag is marked as `true`. Additionally, neither instructions require any additional instruction data since the `args` section is blank for both.
+Looking at the IDL, you can see that in both instructions the `user` is required
+as a signer because the `isSigner` flag is marked as `true`. Additionally,
+neither instructions require any additional instruction data since the `args`
+section is blank for both.
 
-Looking further down at the `accounts` section, you can see that the program contains one account type named `Counter` with a single `count` field of type `u64`.
+Looking further down at the `accounts` section, you can see that the program
+contains one account type named `Counter` with a single `count` field of type
+`u64`.
 
-Although the IDL does not provide the implementation details for each instruction, we can get a basic idea of how the on-chain program expects instructions to be constructed and see the structure of the program accounts.
+Although the IDL does not provide the implementation details for each
+instruction, we can get a basic idea of how the on-chain program expects
+instructions to be constructed and see the structure of the program accounts.
 
-Regardless of how you get it, you _need_ an IDL file to interact with a program using the `@project-serum/anchor` package. To use the IDL, you'll need to include the IDL file in your project and then import the file.
+Regardless of how you get it, you _need_ an IDL file to interact with a program
+using the `@project-serum/anchor` package. To use the IDL, you'll need to
+include the IDL file in your project and then import the file.
 
 ```tsx
 import idl from "./idl.json";
@@ -118,14 +154,20 @@ import idl from "./idl.json";
 
 ### Provider
 
-Before you can create a `Program` object using the IDL, you first need to create an Anchor `Provider` object.
+Before you can create a `Program` object using the IDL, you first need to create
+an Anchor `Provider` object.
 
 The `Provider` object combines two things:
 
-- `Connection` - the connection to a Solana cluster (i.e. localhost, devnet, mainnet)
+- `Connection` - the connection to a Solana cluster (i.e. localhost, devnet,
+  mainnet)
 - `Wallet` - a specified address used to pay for and sign transactions
 
-The `Provider` is then able to send transactions to the Solana blockchain on behalf of a `Wallet` by including the wallet’s signature to outgoing transactions. When using a frontend with a Solana wallet provider, all outgoing transactions must still be approved by the user via their wallet browser extension.
+The `Provider` is then able to send transactions to the Solana blockchain on
+behalf of a `Wallet` by including the wallet’s signature to outgoing
+transactions. When using a frontend with a Solana wallet provider, all outgoing
+transactions must still be approved by the user via their wallet browser
+extension.
 
 Setting up the `Wallet` and `Connection` would look something like this:
 
@@ -136,9 +178,13 @@ const { connection } = useConnection();
 const wallet = useAnchorWallet();
 ```
 
-To set up the connection, you can use the `useConnection` hook from `@solana/wallet-adapter-react` to get the `Connection` to a Solana cluster.
+To set up the connection, you can use the `useConnection` hook from
+`@solana/wallet-adapter-react` to get the `Connection` to a Solana cluster.
 
-Note that the `Wallet` object provided by the `useWallet` hook from `@solana/wallet-adapter-react` is not compatible with the `Wallet` object that the Anchor `Provider` expects. However, `@solana/wallet-adapter-react` also provides a `useAnchorWallet` hook.
+Note that the `Wallet` object provided by the `useWallet` hook from
+`@solana/wallet-adapter-react` is not compatible with the `Wallet` object that
+the Anchor `Provider` expects. However, `@solana/wallet-adapter-react` also
+provides a `useAnchorWallet` hook.
 
 For comparison, here is the `AnchorWallet` from `useAnchorWallet`:
 
@@ -177,17 +223,22 @@ export interface WalletContextState {
 }
 ```
 
-The `WalletContextState` provides much more functionality compared to the `AnchorWallet`, but the `AnchorWallet` is required to set up the `Provider` object.
+The `WalletContextState` provides much more functionality compared to the
+`AnchorWallet`, but the `AnchorWallet` is required to set up the `Provider`
+object.
 
-To create the `Provider` object you use `AnchorProvider` from `@project-serum/anchor`.
+To create the `Provider` object you use `AnchorProvider` from
+`@project-serum/anchor`.
 
 The `AnchorProvider` constructor takes three parameters:
 
 - `connection` - the `Connection` to the Solana cluster
 - `wallet` - the `Wallet` object
-- `opts` - optional parameter that specifies the confirmation options, using a default setting if one is not provided
+- `opts` - optional parameter that specifies the confirmation options, using a
+  default setting if one is not provided
 
-Once you’ve create the `Provider` object, you then set it as the default provider using `setProvider`.
+Once you’ve create the `Provider` object, you then set it as the default
+provider using `setProvider`.
 
 ```tsx
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
@@ -201,17 +252,29 @@ setProvider(provider);
 
 ### Program
 
-Once you have the IDL and a provider, you can create an instance of `Program`. The constructor requires three parameters:
+Once you have the IDL and a provider, you can create an instance of `Program`.
+The constructor requires three parameters:
 
 - `idl` - the IDL as type `Idl`
 - `programId` - the on-chain address of the program as a `string` or `PublicKey`
 - `Provider` - the provider discussed in the previous section
 
-The `Program` object creates a custom API you can use to interact with a Solana program. This API is the one stop shop for all things related to communicating with on-chain programs. Among other things, you can send transactions, fetch deserialized accounts, decode instruction data, subscribe to account changes, and listen to events. You can learn more about the `Program` class [here](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
+The `Program` object creates a custom API you can use to interact with a Solana
+program. This API is the one stop shop for all things related to communicating
+with on-chain programs. Among other things, you can send transactions, fetch
+deserialized accounts, decode instruction data, subscribe to account changes,
+and listen to events. You can learn more about the `Program` class
+[here](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
-To create the `Program` object, first import `Program` and `Idl` from `@project-serum/anchor`. `Idl` is a type you can used when working with Typescript.
+To create the `Program` object, first import `Program` and `Idl` from
+`@project-serum/anchor`. `Idl` is a type you can used when working with
+Typescript.
 
-Next, specify the `programId` of the program. We have to explicitly state the `programId` since there can be multiple programs with the same IDL structure (i.e. if the same program is deployed multiple times using different addresses). When creating the `Program` object, the default `Provider` is used if one is not explicitly specified.
+Next, specify the `programId` of the program. We have to explicitly state the
+`programId` since there can be multiple programs with the same IDL structure
+(i.e. if the same program is deployed multiple times using different addresses).
+When creating the `Program` object, the default `Provider` is used if one is not
+explicitly specified.
 
 All together, the final setup looks something like this:
 
@@ -237,9 +300,14 @@ const program = new Program(idl as Idl, programId);
 
 ## Anchor `MethodsBuilder`
 
-Once the `Program` object is set up, you can use the Anchor Methods Builder to build instructions and transactions related to the program. The `MethodsBuilder` uses the IDL to provide a simplified format for building transactions that invoke program instructions.
+Once the `Program` object is set up, you can use the Anchor Methods Builder to
+build instructions and transactions related to the program. The `MethodsBuilder`
+uses the IDL to provide a simplified format for building transactions that
+invoke program instructions.
 
-Note that the camel case naming convention is used when interacting with a program from the client, compared to the snake case naming convention used when the writing the program in rust.
+Note that the camel case naming convention is used when interacting with a
+program from the client, compared to the snake case naming convention used when
+the writing the program in rust.
 
 The basic `MethodsBuilder` format looks like this:
 
@@ -254,15 +322,27 @@ await program.methods
 
 Going step by step, you:
 
-1. Call `methods` on `program` - this is the builder API for creating instruction calls related to the program's IDL
-2. Call the instruction name as `.instructionName(instructionDataInputs)` - simply call the instruction using dot syntax and the instruction's name, passing in any instruction arguments as comma-separated values
-3. Call `accounts` - using dot syntax, call `.accounts`, passing in an object with each account the instruction expects based on the IDL
-4. Optionally call `signers` - using dot syntax, call `.signers`, passing in an array of additional signers required by the instruction
-5. Call `rpc` - this method creates and sends a signed transaction with the specified instruction and returns a `TransactionSignature`. When using `.rpc`, the `Wallet` from the `Provider` is automatically included as a signer and does not have to be listed explicitly.
+1. Call `methods` on `program` - this is the builder API for creating
+   instruction calls related to the program's IDL
+2. Call the instruction name as `.instructionName(instructionDataInputs)` -
+   simply call the instruction using dot syntax and the instruction's name,
+   passing in any instruction arguments as comma-separated values
+3. Call `accounts` - using dot syntax, call `.accounts`, passing in an object
+   with each account the instruction expects based on the IDL
+4. Optionally call `signers` - using dot syntax, call `.signers`, passing in an
+   array of additional signers required by the instruction
+5. Call `rpc` - this method creates and sends a signed transaction with the
+   specified instruction and returns a `TransactionSignature`. When using
+   `.rpc`, the `Wallet` from the `Provider` is automatically included as a
+   signer and does not have to be listed explicitly.
 
-Note that if no additional signers are required by the instruction other than the `Wallet` specified with the `Provider`, the `.signer([])` line can be excluded.
+Note that if no additional signers are required by the instruction other than
+the `Wallet` specified with the `Provider`, the `.signer([])` line can be
+excluded.
 
-You can also build the transaction directly by changing `.rpc()` to `.transaction()`. This builds a `Transaction` object using the instruction specified.
+You can also build the transaction directly by changing `.rpc()` to
+`.transaction()`. This builds a `Transaction` object using the instruction
+specified.
 
 ```tsx
 // creates transaction
@@ -274,7 +354,9 @@ const transaction = await program.methods
 await sendTransaction(transaction, connection);
 ```
 
-Similarly, you can use the same format to build an instruction using `.instruction()` and then manually add the instructions to a new transaction. This builds a `TransactionInstruction` object using the instruction specified.
+Similarly, you can use the same format to build an instruction using
+`.instruction()` and then manually add the instructions to a new transaction.
+This builds a `TransactionInstruction` object using the instruction specified.
 
 ```tsx
 // creates first instruction
@@ -296,21 +378,35 @@ const transaction = new Transaction().add(instructionOne, instructionTwo);
 await sendTransaction(transaction, connection);
 ```
 
-In summary, the Anchor `MethodsBuilder` provides a simplified and more flexible way to interact with on-chain programs. You can build an instruction, a transaction, or build and send a transaction using basically the same format without having to manually serialize or deserialize the accounts or instruction data.
+In summary, the Anchor `MethodsBuilder` provides a simplified and more flexible
+way to interact with on-chain programs. You can build an instruction, a
+transaction, or build and send a transaction using basically the same format
+without having to manually serialize or deserialize the accounts or instruction
+data.
 
 ## Fetch program accounts
 
-The `Program` object also allows you to easily fetch and filter program accounts. Simply call `account` on `program` and then specify the name of the account type as reflected on the IDL. Anchor then deserializes and returns all accounts as specified.
+The `Program` object also allows you to easily fetch and filter program
+accounts. Simply call `account` on `program` and then specify the name of the
+account type as reflected on the IDL. Anchor then deserializes and returns all
+accounts as specified.
 
-The example below shows how you can fetch all existing `counter` accounts for the Counter program.
+The example below shows how you can fetch all existing `counter` accounts for
+the Counter program.
 
 ```tsx
 const accounts = await program.account.counter.all();
 ```
 
-You can also apply a filter by using `memcmp` and then specifying an `offset` and the `bytes` to filter for.
+You can also apply a filter by using `memcmp` and then specifying an `offset`
+and the `bytes` to filter for.
 
-The example below fetches all `counter` accounts with a `count` of 0. Note that the `offset` of 8 is for the 8 byte discriminator Anchor uses to identify account types. The 9th byte is where the `count` field begins. You can refer to the IDL to see that the next byte stores the `count` field of type `u64`. Anchor then filters for and returns all accounts with matching bytes in the same position.
+The example below fetches all `counter` accounts with a `count` of 0. Note that
+the `offset` of 8 is for the 8 byte discriminator Anchor uses to identify
+account types. The 9th byte is where the `count` field begins. You can refer to
+the IDL to see that the next byte stores the `count` field of type `u64`. Anchor
+then filters for and returns all accounts with matching bytes in the same
+position.
 
 ```tsx
 const accounts = await program.account.counter.all([
@@ -323,7 +419,8 @@ const accounts = await program.account.counter.all([
 ]);
 ```
 
-Alternatively, you can also get the deserialized account data for a specific account using `fetch` if you know the address of the account you're looking for.
+Alternatively, you can also get the deserialized account data for a specific
+account using `fetch` if you know the address of the account you're looking for.
 
 ```tsx
 const account = await program.account.counter.fetch(ACCOUNT_ADDRESS);
@@ -340,22 +437,36 @@ const accounts = await program.account.counter.fetchMultiple([
 
 # Demo
 
-Let’s practice this together by building a frontend for the Counter program from last lesson. As a reminder, the Counter program has two instructions:
+Let’s practice this together by building a frontend for the Counter program from
+last lesson. As a reminder, the Counter program has two instructions:
 
 - `initialize` - initializes a new `Counter` account and sets the `count` to `0`
 - `increment` - increments the `count` on an existing `Counter` account
 
 ### 1. Download the starter code
 
-Download the starter code for this project [here](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/starter). Once you have the starter code, take a look around. Install the dependencies with `npm install` and then run the app with `npm run dev`.
+Download the starter code for this
+project [here](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/starter).
+Once you have the starter code, take a look around. Install the dependencies
+with `npm install` and then run the app with `npm run dev`.
 
-This project is a simple Next.js application. It includes the `WalletContextProvider` we created in the [Wallets lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/interact-with-wallets.md), the `idl.json` file for the Counter program, and the `Initialize` and `Increment` components we’ll be building throughout this demo. The `programId` of the program we’ll be invoking is also included in the starter code.
+This project is a simple Next.js application. It includes the
+`WalletContextProvider` we created in the
+[Wallets lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/interact-with-wallets.md),
+the `idl.json` file for the Counter program, and the `Initialize` and
+`Increment` components we’ll be building throughout this demo. The `programId`
+of the program we’ll be invoking is also included in the starter code.
 
 ### 2. `Initialize`
 
-To begin, let’s complete the setup to create the `Program` object in `Initialize.tsx` component.
+To begin, let’s complete the setup to create the `Program` object in
+`Initialize.tsx` component.
 
-Remember, we’ll need an instance of `Program` to use the Anchor `MethodsBuilder` to invoke the instructions on our program. For that, we'll need an Anchor wallet and a connection, which we can get from the `useAnchorWallet` and `useConnection` hooks. Let's also create a `useState` to capture the program instance.
+Remember, we’ll need an instance of `Program` to use the Anchor `MethodsBuilder`
+to invoke the instructions on our program. For that, we'll need an Anchor wallet
+and a connection, which we can get from the `useAnchorWallet` and
+`useConnection` hooks. Let's also create a `useState` to capture the program
+instance.
 
 ```tsx
 export const Initialize: FC<Props> = ({ setCounter }) => {
@@ -368,9 +479,13 @@ export const Initialize: FC<Props> = ({ setCounter }) => {
 }
 ```
 
-With that, we can work on creating the actual `Program` instance. Let's do this in a `useEffect`.
+With that, we can work on creating the actual `Program` instance. Let's do this
+in a `useEffect`.
 
-First we need to either get the default provider if it already exists, or create it if it doesn't. We can do that by calling `getProvider` inside a try/catch block. If an error is thrown, that means there is no default provider and we need to create one.
+First we need to either get the default provider if it already exists, or create
+it if it doesn't. We can do that by calling `getProvider` inside a try/catch
+block. If an error is thrown, that means there is no default provider and we
+need to create one.
 
 Once we have a provider, we can construct a `Program` instance.
 
@@ -390,13 +505,21 @@ useEffect(() => {
 }, []);
 ```
 
-Now that we've finished the Anchor setup, we can actually invoke the program's `initialize` instruction. We'll do this inside the `onClick` function.
+Now that we've finished the Anchor setup, we can actually invoke the program's
+`initialize` instruction. We'll do this inside the `onClick` function.
 
-First, we’ll need to generate a new `Keypair` for the new `Counter` account since we are initializing an account for the first time.
+First, we’ll need to generate a new `Keypair` for the new `Counter` account
+since we are initializing an account for the first time.
 
-Then we can use the Anchor `MethodsBuilder` to create and send a new transaction. Remember, Anchor can infer some of the accounts required, like the `user` and `systemAccount` accounts. However, it can't infer the `counter` account because we generate that dynamically, so you'll need to add it with `.accounts`. You'll also need to add that keypair as a sign with `.signers`. Lastly, you can use `.rpc()` to submit the transaction to the user's wallet.
+Then we can use the Anchor `MethodsBuilder` to create and send a new
+transaction. Remember, Anchor can infer some of the accounts required, like the
+`user` and `systemAccount` accounts. However, it can't infer the `counter`
+account because we generate that dynamically, so you'll need to add it with
+`.accounts`. You'll also need to add that keypair as a sign with `.signers`.
+Lastly, you can use `.rpc()` to submit the transaction to the user's wallet.
 
-Once the transaction goes through, call `setUrl` with the explorer URL and then call `setCounter`, passing in the counter account.
+Once the transaction goes through, call `setUrl` with the explorer URL and then
+call `setCounter`, passing in the counter account.
 
 ```tsx
 const onClick = async () => {
@@ -417,7 +540,9 @@ const onClick = async () => {
 
 ### 3. `Increment`
 
-Next, let’s move on the the `Increment.tsx` component. Just as before, complete the setup to create the `Program` object. In addition to calling `setProgram`, the `useEffect` should call `refreshCount`.
+Next, let’s move on the the `Increment.tsx` component. Just as before, complete
+the setup to create the `Program` object. In addition to calling `setProgram`,
+the `useEffect` should call `refreshCount`.
 
 Add the following code for the initial set up:
 
@@ -446,7 +571,9 @@ export const Increment: FC<Props> = ({ counter, setTransactionUrl }) => {
 }
 ```
 
-Next, let’s use the Anchor `MethodsBuilder` to build a new instruction to invoke the `increment` instruction. Again, Anchor can infer the `user` account from the wallet so we only need to include the `counter` account.
+Next, let’s use the Anchor `MethodsBuilder` to build a new instruction to invoke
+the `increment` instruction. Again, Anchor can infer the `user` account from the
+wallet so we only need to include the `counter` account.
 
 ```tsx
 const onClick = async () => {
@@ -464,11 +591,15 @@ const onClick = async () => {
 
 ### 5. Display the correct count
 
-Now that we can initialize the counter program and increment the count, we need to get our UI to show the count stored in the counter account.
+Now that we can initialize the counter program and increment the count, we need
+to get our UI to show the count stored in the counter account.
 
-We'll show how to observe account changes in a future lesson, but for now we just have a button that calls `refreshCount` so you can click it to show the new count after each `increment` invocation.
+We'll show how to observe account changes in a future lesson, but for now we
+just have a button that calls `refreshCount` so you can click it to show the new
+count after each `increment` invocation.
 
-Inside `refreshCount`, let's use `program` to fetch the counter account, then use `setCount` to set the count to the number stored on the program:
+Inside `refreshCount`, let's use `program` to fetch the counter account, then
+use `setCount` to set the count to the number stored on the program:
 
 ```tsx
 const refreshCount = async program => {
@@ -481,13 +612,17 @@ Super simple with Anchor!
 
 ### 5. Test the frontend
 
-At this point, everything should work! You can test the frontend by running `npm run dev`.
+At this point, everything should work! You can test the frontend by running
+`npm run dev`.
 
 1. Connect your wallet and you should see the `Initialize Counter` button
 2. Click the `Initialize Counter` button, and then approve the transaction
-3. You should then see a link at the bottom of the screen to Solana Explorer for the `initialize` transaction. The `Increment Counter` button, `Refresh Count` button, and the count should also all appear.
+3. You should then see a link at the bottom of the screen to Solana Explorer for
+   the `initialize` transaction. The `Increment Counter` button, `Refresh Count`
+   button, and the count should also all appear.
 4. Click the `Increment Counter` button, and then approve the transaction
-5. Wait a few seconds and click `Refresh Count`. The count should increment on the screen.
+5. Wait a few seconds and click `Refresh Count`. The count should increment on
+   the screen.
 
 ![Gif of Anchor Frontend Demo](../assets/anchor-frontend-demo.gif)
 
@@ -497,13 +632,19 @@ Feel free to click the links to inspect the program logs from each transaction!
 
 ![Screenshot of Increment Program Log](../assets/anchor-frontend-increment.png)
 
-Congratulations, you now know how to set up a frontend to invoke a Solana program using an Anchor IDL.
+Congratulations, you now know how to set up a frontend to invoke a Solana
+program using an Anchor IDL.
 
-If you need more time with this project to feel comfortable with these concepts, feel free to have a look at the [solution code on the `solution-increment` branch](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/solution-increment) before continuing.
+If you need more time with this project to feel comfortable with these concepts,
+feel free to have a look at
+the [solution code on the `solution-increment` branch](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/solution-increment) before
+continuing.
 
 # Challenge
 
-Now it’s your turn to build something independently. Building on top of what we’ve done in the demo, try to create a new component in the frontend that implements a button to decrements the counter.
+Now it’s your turn to build something independently. Building on top of what
+we’ve done in the demo, try to create a new component in the frontend that
+implements a button to decrements the counter.
 
 Before building the component in the frontend, you’ll first need to:
 
@@ -511,6 +652,9 @@ Before building the component in the frontend, you’ll first need to:
 2. Update the IDL file in the frontend with the one from your new program
 3. Update the `programId` with the one from your new program
 
-If you need some help, feel free to reference this program [here](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-decrement).
+If you need some help, feel free to reference this program
+[here](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-decrement).
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/solution-decrement).
+Try to do this independently if you can! But if you get stuck, feel free to
+reference
+the [solution code](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/solution-decrement).

--- a/developers/courses/solana-course/content/intro-to-anchor-frontend.md
+++ b/developers/courses/solana-course/content/intro-to-anchor-frontend.md
@@ -1,12 +1,12 @@
 ---
 title: Intro to client-side Anchor development
 objectives:
-- Use an IDL to interact with a Solana program from the client
-- Explain an Anchor `Provider` object
-- Explain an Anchor `Program` object
-- Use the Anchor `MethodsBuilder` to build instructions and transactions
-- Use Anchor to fetch accounts
-- Set up a frontend to invoke instructions using Anchor and an IDL
+  - Use an IDL to interact with a Solana program from the client
+  - Explain an Anchor `Provider` object
+  - Explain an Anchor `Program` object
+  - Use the Anchor `MethodsBuilder` to build instructions and transactions
+  - Use Anchor to fetch accounts
+  - Set up a frontend to invoke instructions using Anchor and an IDL
 ---
 
 # TL;DR
@@ -27,7 +27,7 @@ await program.methods
   .instructionName(instructionDataInputs)
   .accounts({})
   .signers([])
-  .rpc()
+  .rpc();
 ```
 
 This works from any Typescript client, whether it's a frontend or integration tests. In this lesson we'll go over how to use `@project-serum/anchor` to simplify your client-side program interaction.
@@ -52,7 +52,7 @@ The above image shows how each of these pieces are combined to create a `Program
 
 When you build an Anchor program, Anchor generates both a JSON and Typescript file representing your program's IDL. The IDL represents the structure of the program and can be used by a client to infer how to interact with a specific program.
 
-While it isn't automatic, you can also generate an IDL from a native Solana program using tools like [shank](https://github.com/metaplex-foundation/shank) by Metaplex. 
+While it isn't automatic, you can also generate an IDL from a native Solana program using tools like [shank](https://github.com/metaplex-foundation/shank) by Metaplex.
 
 To get an idea of the information an IDL provides, here is the IDL for the counter program you built previously:
 
@@ -110,10 +110,10 @@ Looking further down at the `accounts` section, you can see that the program con
 
 Although the IDL does not provide the implementation details for each instruction, we can get a basic idea of how the on-chain program expects instructions to be constructed and see the structure of the program accounts.
 
-Regardless of how you get it, you *need* an IDL file to interact with a program using the `@project-serum/anchor` package. To use the IDL, you'll need to include the IDL file in your project and then import the file.
+Regardless of how you get it, you _need_ an IDL file to interact with a program using the `@project-serum/anchor` package. To use the IDL, you'll need to include the IDL file in your project and then import the file.
 
 ```tsx
-import idl from "./idl.json"
+import idl from "./idl.json";
 ```
 
 ### Provider
@@ -130,10 +130,10 @@ The `Provider` is then able to send transactions to the Solana blockchain on beh
 Setting up the `Wallet` and `Connection` would look something like this:
 
 ```tsx
-import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
+import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
 
-const { connection } = useConnection()
-const wallet = useAnchorWallet()
+const { connection } = useConnection();
+const wallet = useAnchorWallet();
 ```
 
 To set up the connection, you can use the `useConnection` hook from `@solana/wallet-adapter-react` to get the `Connection` to a Solana cluster.
@@ -144,9 +144,9 @@ For comparison, here is the `AnchorWallet` from `useAnchorWallet`:
 
 ```tsx
 export interface AnchorWallet {
-  publicKey: PublicKey
-  signTransaction(transaction: Transaction): Promise<Transaction>
-  signAllTransactions(transactions: Transaction[]): Promise<Transaction[]>
+  publicKey: PublicKey;
+  signTransaction(transaction: Transaction): Promise<Transaction>;
+  signAllTransactions(transactions: Transaction[]): Promise<Transaction[]>;
 }
 ```
 
@@ -154,26 +154,26 @@ And the `WalletContextState` from `useWallet`:
 
 ```tsx
 export interface WalletContextState {
-  autoConnect: boolean
-  wallets: Wallet[]
-  wallet: Wallet | null
-  publicKey: PublicKey | null
-  connecting: boolean
-  connected: boolean
-  disconnecting: boolean
-  select(walletName: WalletName): void
-  connect(): Promise<void>
-  disconnect(): Promise<void>
+  autoConnect: boolean;
+  wallets: Wallet[];
+  wallet: Wallet | null;
+  publicKey: PublicKey | null;
+  connecting: boolean;
+  connected: boolean;
+  disconnecting: boolean;
+  select(walletName: WalletName): void;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
   sendTransaction(
     transaction: Transaction,
     connection: Connection,
-    options?: SendTransactionOptions
-  ): Promise<TransactionSignature>
-  signTransaction: SignerWalletAdapterProps["signTransaction"] | undefined
+    options?: SendTransactionOptions,
+  ): Promise<TransactionSignature>;
+  signTransaction: SignerWalletAdapterProps["signTransaction"] | undefined;
   signAllTransactions:
     | SignerWalletAdapterProps["signAllTransactions"]
-    | undefined
-  signMessage: MessageSignerWalletAdapterProps["signMessage"] | undefined
+    | undefined;
+  signMessage: MessageSignerWalletAdapterProps["signMessage"] | undefined;
 }
 ```
 
@@ -190,13 +190,13 @@ The `AnchorProvider` constructor takes three parameters:
 Once you’ve create the `Provider` object, you then set it as the default provider using `setProvider`.
 
 ```tsx
-import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
-import { AnchorProvider, setProvider } from "@project-serum/anchor"
+import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
+import { AnchorProvider, setProvider } from "@project-serum/anchor";
 
-const { connection } = useConnection()
-const wallet = useAnchorWallet()
-const provider = new AnchorProvider(connection, wallet, {})
-setProvider(provider)
+const { connection } = useConnection();
+const wallet = useAnchorWallet();
+const provider = new AnchorProvider(connection, wallet, {});
+setProvider(provider);
 ```
 
 ### Program
@@ -216,23 +216,23 @@ Next, specify the `programId` of the program. We have to explicitly state the `p
 All together, the final setup looks something like this:
 
 ```tsx
-import idl from "./idl.json"
-import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
+import idl from "./idl.json";
+import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
 import {
   Program,
   Idl,
   AnchorProvider,
   setProvider,
-} from "@project-serum/anchor"
+} from "@project-serum/anchor";
 
-const { connection } = useConnection()
-const wallet = useAnchorWallet()
+const { connection } = useConnection();
+const wallet = useAnchorWallet();
 
-const provider = new AnchorProvider(connection, wallet, {})
-setProvider(provider)
+const provider = new AnchorProvider(connection, wallet, {});
+setProvider(provider);
 
-const programId = new PublicKey("JPLockxtkngHkaQT5AuRYow3HyUv5qWzmhwsCPd653n")
-const program = new Program(idl as Idl, programId)
+const programId = new PublicKey("JPLockxtkngHkaQT5AuRYow3HyUv5qWzmhwsCPd653n");
+const program = new Program(idl as Idl, programId);
 ```
 
 ## Anchor `MethodsBuilder`
@@ -249,7 +249,7 @@ await program.methods
   .instructionName(instructionDataInputs)
   .accounts({})
   .signers([])
-  .rpc()
+  .rpc();
 ```
 
 Going step by step, you:
@@ -269,9 +269,9 @@ You can also build the transaction directly by changing `.rpc()` to `.transactio
 const transaction = await program.methods
   .instructionName(instructionDataInputs)
   .accounts({})
-  .transaction()
+  .transaction();
 
-await sendTransaction(transaction, connection)
+await sendTransaction(transaction, connection);
 ```
 
 Similarly, you can use the same format to build an instruction using `.instruction()` and then manually add the instructions to a new transaction. This builds a `TransactionInstruction` object using the instruction specified.
@@ -281,19 +281,19 @@ Similarly, you can use the same format to build an instruction using `.instructi
 const instructionOne = await program.methods
   .instructionOneName(instructionOneDataInputs)
   .accounts({})
-  .instruction()
+  .instruction();
 
 // creates second instruction
 const instructionTwo = await program.methods
   .instructionTwoName(instructionTwoDataInputs)
   .accounts({})
-  .instruction()
+  .instruction();
 
 // add both instruction to one transaction
-const transaction = new Transaction().add(instructionOne, instructionTwo)
+const transaction = new Transaction().add(instructionOne, instructionTwo);
 
 // send transaction
-await sendTransaction(transaction, connection)
+await sendTransaction(transaction, connection);
 ```
 
 In summary, the Anchor `MethodsBuilder` provides a simplified and more flexible way to interact with on-chain programs. You can build an instruction, a transaction, or build and send a transaction using basically the same format without having to manually serialize or deserialize the accounts or instruction data.
@@ -305,34 +305,37 @@ The `Program` object also allows you to easily fetch and filter program accounts
 The example below shows how you can fetch all existing `counter` accounts for the Counter program.
 
 ```tsx
-const accounts = await program.account.counter.all()
+const accounts = await program.account.counter.all();
 ```
 
-You can also apply a filter by using `memcmp` and then specifying an `offset` and the `bytes` to filter for. 
+You can also apply a filter by using `memcmp` and then specifying an `offset` and the `bytes` to filter for.
 
 The example below fetches all `counter` accounts with a `count` of 0. Note that the `offset` of 8 is for the 8 byte discriminator Anchor uses to identify account types. The 9th byte is where the `count` field begins. You can refer to the IDL to see that the next byte stores the `count` field of type `u64`. Anchor then filters for and returns all accounts with matching bytes in the same position.
 
 ```tsx
 const accounts = await program.account.counter.all([
-    {
-        memcmp: {
-            offset: 8,
-            bytes: bs58.encode((new BN(0, 'le')).toArray()),
-        },
+  {
+    memcmp: {
+      offset: 8,
+      bytes: bs58.encode(new BN(0, "le").toArray()),
     },
-])
+  },
+]);
 ```
 
-Alternatively, you can also get the deserialized account data for a specific account using `fetch` if you know the address of the account you're looking for. 
+Alternatively, you can also get the deserialized account data for a specific account using `fetch` if you know the address of the account you're looking for.
 
 ```tsx
-const account = await program.account.counter.fetch(ACCOUNT_ADDRESS)
+const account = await program.account.counter.fetch(ACCOUNT_ADDRESS);
 ```
 
 Similarly, you can fetch for multiple accounts using `fetchMultiple`.
 
 ```tsx
-const accounts = await program.account.counter.fetchMultiple([ACCOUNT_ADDRESS_ONE, ACCOUNT_ADDRESS_TWO])
+const accounts = await program.account.counter.fetchMultiple([
+  ACCOUNT_ADDRESS_ONE,
+  ACCOUNT_ADDRESS_TWO,
+]);
 ```
 
 # Demo
@@ -373,18 +376,18 @@ Once we have a provider, we can construct a `Program` instance.
 
 ```tsx
 useEffect(() => {
-  let provider: anchor.Provider
+  let provider: anchor.Provider;
 
   try {
-    provider = anchor.getProvider()
+    provider = anchor.getProvider();
   } catch {
-    provider = new anchor.AnchorProvider(connection, wallet, {})
-    anchor.setProvider(provider)
+    provider = new anchor.AnchorProvider(connection, wallet, {});
+    anchor.setProvider(provider);
   }
 
-  const program = new anchor.Program(idl as anchor.Idl, PROGRAM_ID)
-  setProgram(program)
-}, [])
+  const program = new anchor.Program(idl as anchor.Idl, PROGRAM_ID);
+  setProgram(program);
+}, []);
 ```
 
 Now that we've finished the Anchor setup, we can actually invoke the program's `initialize` instruction. We'll do this inside the `onClick` function.
@@ -405,11 +408,11 @@ const onClick = async () => {
       systemAccount: anchor.web3.SystemProgram.programId,
     })
     .signers([newAccount])
-    .rpc()
+    .rpc();
 
-    setTransactionUrl(`https://explorer.solana.com/tx/${sig}?cluster=devnet`)
-    setCounter(newAccount.publicKey)
-}
+  setTransactionUrl(`https://explorer.solana.com/tx/${sig}?cluster=devnet`);
+  setCounter(newAccount.publicKey);
+};
 ```
 
 ### 3. `Increment`
@@ -453,10 +456,10 @@ const onClick = async () => {
       counter: counter,
       user: wallet.publicKey,
     })
-    .rpc()
+    .rpc();
 
-  setTransactionUrl(`https://explorer.solana.com/tx/${sig}?cluster=devnet`)
-}
+  setTransactionUrl(`https://explorer.solana.com/tx/${sig}?cluster=devnet`);
+};
 ```
 
 ### 5. Display the correct count
@@ -468,10 +471,10 @@ We'll show how to observe account changes in a future lesson, but for now we jus
 Inside `refreshCount`, let's use `program` to fetch the counter account, then use `setCount` to set the count to the number stored on the program:
 
 ```tsx
-const refreshCount = async (program) => {
-  const counterAccount = await program.account.counter.fetch(counter)
-  setCount(counterAccount.count.toNumber())
-}
+const refreshCount = async program => {
+  const counterAccount = await program.account.counter.fetch(counter);
+  setCount(counterAccount.count.toNumber());
+};
 ```
 
 Super simple with Anchor!

--- a/developers/courses/solana-course/content/intro-to-anchor.md
+++ b/developers/courses/solana-course/content/intro-to-anchor.md
@@ -1,9 +1,9 @@
 ---
 title: Intro to Anchor development
 objectives:
-- Use the Anchor framework to build a basic program
-- Describe the basic structure of an Anchor program
-- Explain how to implement basic account validation and security checks with Anchor
+  - Use the Anchor framework to build a basic program
+  - Describe the basic structure of an Anchor program
+  - Explain how to implement basic account validation and security checks with Anchor
 ---
 
 # TL;DR
@@ -83,7 +83,6 @@ pub struct Context<'a, 'b, 'c, 'info, T> {
 - The program ID (`ctx.program_id`) of the executing program
 - The remaining accounts (`ctx.remaining_accounts`). The `remaining_accounts` is a vector that contains all accounts that were passed into the instruction but are not declared in the `Accounts` struct.
 - The bumps for any PDA accounts in the `Accounts` struct (`ctx.bumps`)
-
 
 ## Define instruction accounts
 
@@ -199,7 +198,7 @@ account_info.executable == true
 
 The `#[account(..)]` attribute macro is used to apply constraints to accounts. We'll go over a few constraint examples in this and future lessons, but at some point be sure to look at the full [list of possible constraints](https://docs.rs/anchor-lang/latest/anchor_lang/derive.Accounts.html).
 
-Recall again the `account_name` field from the `InstructionAccounts` example. 
+Recall again the `account_name` field from the `InstructionAccounts` example.
 
 ```rust
 #[account(init, payer = user, space = 8 + 8)]
@@ -507,24 +506,24 @@ Run `anchor build` to build the program.
 Anchor tests are typically Typescript integration tests that use the mocha test framework. We'll learn more about testing later, but for now navigate to `anchor-counter.ts` and replace the default test code with the following:
 
 ```ts
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
-import { expect } from "chai"
-import { AnchorCounter } from "../target/types/anchor_counter"
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { expect } from "chai";
+import { AnchorCounter } from "../target/types/anchor_counter";
 
 describe("anchor-counter", () => {
   // Configure the client to use the local cluster.
-  const provider = anchor.AnchorProvider.env()
-  anchor.setProvider(provider)
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
 
-  const program = anchor.workspace.AnchorCounter as Program<AnchorCounter>
+  const program = anchor.workspace.AnchorCounter as Program<AnchorCounter>;
 
-  const counter = anchor.web3.Keypair.generate()
+  const counter = anchor.web3.Keypair.generate();
 
-  it("Is initialized!", async () => {})
+  it("Is initialized!", async () => {});
 
-  it("Incremented the count", async () => {})
-})
+  it("Incremented the count", async () => {});
+});
 ```
 
 The above code generates a new keypair for the `counter` account we'll be initializing and creates placeholders for a test of each instruction.
@@ -538,11 +537,11 @@ it("Is initialized!", async () => {
     .initialize()
     .accounts({ counter: counter.publicKey })
     .signers([counter])
-    .rpc()
+    .rpc();
 
-  const account = await program.account.counter.fetch(counter.publicKey)
-  expect(account.count.toNumber() === 0)
-})
+  const account = await program.account.counter.fetch(counter.publicKey);
+  expect(account.count.toNumber() === 0);
+});
 ```
 
 Next, create the second test for the `increment` instruction:
@@ -552,11 +551,11 @@ it("Incremented the count", async () => {
   const tx = await program.methods
     .increment()
     .accounts({ counter: counter.publicKey, user: provider.wallet.publicKey })
-    .rpc()
+    .rpc();
 
-  const account = await program.account.counter.fetch(counter.publicKey)
-  expect(account.count.toNumber() === 1)
-})
+  const account = await program.account.counter.fetch(counter.publicKey);
+  expect(account.count.toNumber() === 1);
+});
 ```
 
 Lastly, run `anchor test` and you should see the following output:

--- a/developers/courses/solana-course/content/intro-to-anchor.md
+++ b/developers/courses/solana-course/content/intro-to-anchor.md
@@ -3,35 +3,52 @@ title: Intro to Anchor development
 objectives:
   - Use the Anchor framework to build a basic program
   - Describe the basic structure of an Anchor program
-  - Explain how to implement basic account validation and security checks with Anchor
+  - Explain how to implement basic account validation and security checks with
+    Anchor
 ---
 
 # TL;DR
 
 - **Anchor** is a framework for building Solana programs
-- **Anchor macros** speed up the process of building Solana programs by abstracting away a significant amount of boilerplate code
-- Anchor allows you to build **secure programs** more easily by performing certain security checks, requiring account validation, and providing a simple way to implement additional checks.
+- **Anchor macros** speed up the process of building Solana programs by
+  abstracting away a significant amount of boilerplate code
+- Anchor allows you to build **secure programs** more easily by performing
+  certain security checks, requiring account validation, and providing a simple
+  way to implement additional checks.
 
 # Overview
 
 ## What is Anchor?
 
-Anchor is a development framework that makes writing Solana programs easier, faster, and more secure. It's the "go to" framework for Solana development for very good reason. It makes it easier to organize and reason about your code, implements common security checks automatically, and abstracts away a significant amount of boilerplate associated with writing a Solana program.
+Anchor is a development framework that makes writing Solana programs easier,
+faster, and more secure. It's the "go to" framework for Solana development for
+very good reason. It makes it easier to organize and reason about your code,
+implements common security checks automatically, and abstracts away a
+significant amount of boilerplate associated with writing a Solana program.
 
 ## Anchor program structure
 
-Anchor uses macros and traits to generate boilerplate Rust code for you. These provide a clear structure to your program so you can more easily reason about your code. The main high level macros and attributes are:
+Anchor uses macros and traits to generate boilerplate Rust code for you. These
+provide a clear structure to your program so you can more easily reason about
+your code. The main high level macros and attributes are:
 
 - `declare_id` - a macro for declaring the program’s on-chain address
-- `#[program]` - an attribute macro used to denote the module containing the program’s instruction logic
-- `Accounts` - a trait applied to structs representing the list of accounts required for an instruction
-- `#[account]` - an attribute macro used to define custom account types for the program
+- `#[program]` - an attribute macro used to denote the module containing the
+  program’s instruction logic
+- `Accounts` - a trait applied to structs representing the list of accounts
+  required for an instruction
+- `#[account]` - an attribute macro used to define custom account types for the
+  program
 
 Let's talk about each of them before putting all the pieces together.
 
 ## Declare your program ID
 
-The `declare_id` macro is used to specify the on-chain address of the program (i.e. the `programId`). When you build an Anchor program for the first time, the framework will generate a new keypair. This becomes the default keypair used to deploy the program unless specified otherwise. The corresponding public key should be used as the `programId` specified in the `declare_id!` macro.
+The `declare_id` macro is used to specify the on-chain address of the program
+(i.e. the `programId`). When you build an Anchor program for the first time, the
+framework will generate a new keypair. This becomes the default keypair used to
+deploy the program unless specified otherwise. The corresponding public key
+should be used as the `programId` specified in the `declare_id!` macro.
 
 ```rust
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
@@ -39,11 +56,17 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 ## Define instruction logic
 
-The `#[program]` attribute macro defines the module containing all of your program's instructions. This is where you implement the business logic for each instruction in your program.
+The `#[program]` attribute macro defines the module containing all of your
+program's instructions. This is where you implement the business logic for each
+instruction in your program.
 
-Each public function in the module with the `#[program]` attribute will be treated as a separate instruction.
+Each public function in the module with the `#[program]` attribute will be
+treated as a separate instruction.
 
-Each instruction function requires a parameter of type `Context` and can optionally include additional function parameters representing instruction data. Anchor will automatically handle instruction data deserialization so that you can work with instruction data as Rust types.
+Each instruction function requires a parameter of type `Context` and can
+optionally include additional function parameters representing instruction data.
+Anchor will automatically handle instruction data deserialization so that you
+can work with instruction data as Rust types.
 
 ```rust
 #[program]
@@ -59,7 +82,8 @@ mod program_module_name {
 
 ### Instruction `Context`
 
-The `Context` type exposes instruction metadata and accounts to your instruction logic.
+The `Context` type exposes instruction metadata and accounts to your instruction
+logic.
 
 ```rust
 pub struct Context<'a, 'b, 'c, 'info, T> {
@@ -77,22 +101,39 @@ pub struct Context<'a, 'b, 'c, 'info, T> {
 }
 ```
 
-`Context` is a generic type where `T` defines the list of accounts an instruction requires. When you use `Context`, you specify the concrete type of `T` as a struct that adopts the `Accounts` trait (e.g. `Context<AddMovieReviewAccounts>`). Through this context argument the instruction can then access:
+`Context` is a generic type where `T` defines the list of accounts an
+instruction requires. When you use `Context`, you specify the concrete type of
+`T` as a struct that adopts the `Accounts` trait (e.g.
+`Context<AddMovieReviewAccounts>`). Through this context argument the
+instruction can then access:
 
 - The accounts passed into the instruction (`ctx.accounts`)
 - The program ID (`ctx.program_id`) of the executing program
-- The remaining accounts (`ctx.remaining_accounts`). The `remaining_accounts` is a vector that contains all accounts that were passed into the instruction but are not declared in the `Accounts` struct.
+- The remaining accounts (`ctx.remaining_accounts`). The `remaining_accounts` is
+  a vector that contains all accounts that were passed into the instruction but
+  are not declared in the `Accounts` struct.
 - The bumps for any PDA accounts in the `Accounts` struct (`ctx.bumps`)
 
 ## Define instruction accounts
 
-The `Accounts` trait defines a data structure of validated accounts. Structs adopting this trait define the list of accounts required for a given instruction. These accounts are then exposed through an instruction's `Context` so that manual account iteration and deserialization is no longer necessary.
+The `Accounts` trait defines a data structure of validated accounts. Structs
+adopting this trait define the list of accounts required for a given
+instruction. These accounts are then exposed through an instruction's `Context`
+so that manual account iteration and deserialization is no longer necessary.
 
-You typically apply the `Accounts` trait through the `derive` macro (e.g. `#[derive(Accounts)]`). This implements an `Accounts` deserializer on the given struct and removes the need to deserialize each account manually.
+You typically apply the `Accounts` trait through the `derive` macro (e.g.
+`#[derive(Accounts)]`). This implements an `Accounts` deserializer on the given
+struct and removes the need to deserialize each account manually.
 
-Implementations of the `Accounts` trait are responsible for performing all requisite constraint checks to ensure the accounts meet conditions required for the program to run securely. Constraints are provided for each field using the `#account(..)` attribute (more on that shortly).
+Implementations of the `Accounts` trait are responsible for performing all
+requisite constraint checks to ensure the accounts meet conditions required for
+the program to run securely. Constraints are provided for each field using the
+`#account(..)` attribute (more on that shortly).
 
-For example, `instruction_one` requires a `Context` argument of type `InstructionAccounts`. The `#[derive(Accounts)]` macro is used to implement the `InstructionAccounts` struct which includes three accounts: `account_name`, `user`, and `system_program`.
+For example, `instruction_one` requires a `Context` argument of type
+`InstructionAccounts`. The `#[derive(Accounts)]` macro is used to implement the
+`InstructionAccounts` struct which includes three accounts: `account_name`,
+`user`, and `system_program`.
 
 ```rust
 #[program]
@@ -117,20 +158,29 @@ pub struct InstructionAccounts {
 
 When `instruction_one` is invoked, the program:
 
-- Checks that the accounts passed into the instruction match the account types specified in the `InstructionAccounts` struct
+- Checks that the accounts passed into the instruction match the account types
+  specified in the `InstructionAccounts` struct
 - Checks the accounts against any additional constraints specified
 
-If any accounts passed into `instruction_one` fail the account validation or security checks specified in the `InstructionAccounts` struct, then the instruction fails before even reaching the program logic.
+If any accounts passed into `instruction_one` fail the account validation or
+security checks specified in the `InstructionAccounts` struct, then the
+instruction fails before even reaching the program logic.
 
 ## Account validation
 
-You may have noticed in the previous example that one of the accounts in `InstructionAccounts` was of type `Account`, one was of type `Signer`, and one was of type `Program`.
+You may have noticed in the previous example that one of the accounts in
+`InstructionAccounts` was of type `Account`, one was of type `Signer`, and one
+was of type `Program`.
 
-Anchor provides a number of account types that can be used to represent accounts. Each type implements different account validation. We’ll go over a few of the common types you may encounter, but be sure to look through the [full list of account types](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/index.html).
+Anchor provides a number of account types that can be used to represent
+accounts. Each type implements different account validation. We’ll go over a few
+of the common types you may encounter, but be sure to look through the
+[full list of account types](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/index.html).
 
 ### `Account`
 
-`Account` is a wrapper around `AccountInfo` that verifies program ownership and deserializes the underlying data into a Rust type.
+`Account` is a wrapper around `AccountInfo` that verifies program ownership and
+deserializes the underlying data into a Rust type.
 
 ```rust
 // Deserializes this info
@@ -146,7 +196,8 @@ pub struct AccountInfo<'a> {
 }
 ```
 
-Recall the previous example where `InstructionAccounts` had a field `account_name`:
+Recall the previous example where `InstructionAccounts` had a field
+`account_name`:
 
 ```rust
 pub account_name: Account<'info, AccountStruct>
@@ -155,9 +206,12 @@ pub account_name: Account<'info, AccountStruct>
 The `Account` wrapper here does the following:
 
 - Deserializes the account `data` in the format of type `AccountStruct`
-- Checks that the program owner of the account matches the program owner specified for the `AccountStruct` type.
+- Checks that the program owner of the account matches the program owner
+  specified for the `AccountStruct` type.
 
-When the account type specified in the `Account` wrapper is defined within the same crate using the `#[account]` attribute macro, the program ownership check is against the `programId` defined in the `declare_id!` macro.
+When the account type specified in the `Account` wrapper is defined within the
+same crate using the `#[account]` attribute macro, the program ownership check
+is against the `programId` defined in the `declare_id!` macro.
 
 The following are the checks performed:
 
@@ -169,9 +223,12 @@ Account.info.owner == T::owner()
 
 ### `Signer`
 
-The `Signer` type validates that the given account signed the transaction. No other ownership or type checks are done. You should only use the `Signer` when the underlying account data is not required in the instruction.
+The `Signer` type validates that the given account signed the transaction. No
+other ownership or type checks are done. You should only use the `Signer` when
+the underlying account data is not required in the instruction.
 
-For the `user` account in the previous example, the `Signer` type specifies that the `user` account must be a signer of the instruction.
+For the `user` account in the previous example, the `Signer` type specifies that
+the `user` account must be a signer of the instruction.
 
 The following check is performed for you:
 
@@ -184,7 +241,10 @@ Signer.info.is_signer == true
 
 The `Program` type validates that the account is a certain program.
 
-For the `system_program` account in the previous example, the `Program` type is used to specify the program should be the system program. Anchor provides a `System` type which includes the `programId` of the system program to check against.
+For the `system_program` account in the previous example, the `Program` type is
+used to specify the program should be the system program. Anchor provides a
+`System` type which includes the `programId` of the system program to check
+against.
 
 The following checks are performed for you:
 
@@ -196,7 +256,10 @@ account_info.executable == true
 
 ## Add constraints with `#[account(..)]`
 
-The `#[account(..)]` attribute macro is used to apply constraints to accounts. We'll go over a few constraint examples in this and future lessons, but at some point be sure to look at the full [list of possible constraints](https://docs.rs/anchor-lang/latest/anchor_lang/derive.Accounts.html).
+The `#[account(..)]` attribute macro is used to apply constraints to accounts.
+We'll go over a few constraint examples in this and future lessons, but at some
+point be sure to look at the full
+[list of possible constraints](https://docs.rs/anchor-lang/latest/anchor_lang/derive.Accounts.html).
 
 Recall again the `account_name` field from the `InstructionAccounts` example.
 
@@ -207,24 +270,35 @@ pub account_name: Account<'info, AccountStruct>,
 pub user: Signer<'info>,
 ```
 
-Notice that the `#[account(..)]` attribute contains three comma-separated values:
+Notice that the `#[account(..)]` attribute contains three comma-separated
+values:
 
-- `init` - creates the account via a CPI to the system program and initializes it (sets its account discriminator)
-- `payer` - specifies the payer for the account initialization to be the `user` account defined in the struct
-- `space`- specifies that the space allocated for the account should be `8 + 8` bytes. The first 8 bytes is for a discriminator that Anchor automatically adds to identify the account type. The next 8 bytes allocates space for the data stored on the account as defined in the `AccountStruct` type.
+- `init` - creates the account via a CPI to the system program and initializes
+  it (sets its account discriminator)
+- `payer` - specifies the payer for the account initialization to be the `user`
+  account defined in the struct
+- `space`- specifies that the space allocated for the account should be `8 + 8`
+  bytes. The first 8 bytes is for a discriminator that Anchor automatically adds
+  to identify the account type. The next 8 bytes allocates space for the data
+  stored on the account as defined in the `AccountStruct` type.
 
-For `user` we use the `#[account(..)]` attribute to specify that the given account is mutable. The `user` account must be marked as mutable because lamports will be deducted from the account to pay for the initialization of `account_name`.
+For `user` we use the `#[account(..)]` attribute to specify that the given
+account is mutable. The `user` account must be marked as mutable because
+lamports will be deducted from the account to pay for the initialization of
+`account_name`.
 
 ```rust
 #[account(mut)]
 pub user: Signer<'info>,
 ```
 
-Note that the `init` constraint placed on `account_name` automatically includes a `mut` constraint so that both `account_name` and `user` are mutable accounts.
+Note that the `init` constraint placed on `account_name` automatically includes
+a `mut` constraint so that both `account_name` and `user` are mutable accounts.
 
 ## `#[account]`
 
-The `#[account]` attribute is applied to structs representing the data structure of a Solana account. It implements the following traits:
+The `#[account]` attribute is applied to structs representing the data structure
+of a Solana account. It implements the following traits:
 
 - `AccountSerialize`
 - `AccountDeserialize`
@@ -234,15 +308,28 @@ The `#[account]` attribute is applied to structs representing the data structure
 - `Discriminator`
 - `Owner`
 
-You can read more about the details of each trait [here](https://docs.rs/anchor-lang/latest/anchor_lang/attr.account.html). However, mostly what you need to know is that the `#[account]` attribute enables serialization and deserialization, and implements the discriminator and owner traits for an account.
+You can read more about the details of each trait
+[here](https://docs.rs/anchor-lang/latest/anchor_lang/attr.account.html).
+However, mostly what you need to know is that the `#[account]` attribute enables
+serialization and deserialization, and implements the discriminator and owner
+traits for an account.
 
-The discriminator is an 8 byte unique identifier for an account type derived from the first 8 bytes of the SHA256 hash of the account type's name. When implementing account serialization traits, the first 8 bytes are reserved for the account discriminator.
+The discriminator is an 8 byte unique identifier for an account type derived
+from the first 8 bytes of the SHA256 hash of the account type's name. When
+implementing account serialization traits, the first 8 bytes are reserved for
+the account discriminator.
 
-As a result, any calls to `AccountDeserialize`’s `try_deserialize` will check this discriminator. If it doesn’t match, an invalid account was given, and the account deserialization will exit with an error.
+As a result, any calls to `AccountDeserialize`’s `try_deserialize` will check
+this discriminator. If it doesn’t match, an invalid account was given, and the
+account deserialization will exit with an error.
 
-The `#[account]` attribute also implements the `Owner` trait for a struct using the `programId` declared by `declareId` of the crate `#[account]` is used in. In other words, all accounts initialized using an account type defined using the `#[account]` attribute within the program are also owned by the program.
+The `#[account]` attribute also implements the `Owner` trait for a struct using
+the `programId` declared by `declareId` of the crate `#[account]` is used in. In
+other words, all accounts initialized using an account type defined using the
+`#[account]` attribute within the program are also owned by the program.
 
-As an example, let's look at `AccountStruct` used by the `account_name` of `InstructionAccounts`
+As an example, let's look at `AccountStruct` used by the `account_name` of
+`InstructionAccounts`
 
 ```rust
 #[derive(Accounts)]
@@ -258,7 +345,8 @@ pub struct AccountStruct {
 }
 ```
 
-The `#[account]` attribute ensures that it can be used as an account in `InstructionAccounts`.
+The `#[account]` attribute ensures that it can be used as an account in
+`InstructionAccounts`.
 
 When the `account_name` account is initialized:
 
@@ -268,10 +356,12 @@ When the `account_name` account is initialized:
 
 ## Bring it all together
 
-When you combine all of these Anchor types you end up with a complete program. Below is an example of a basic Anchor program with a single instruction that:
+When you combine all of these Anchor types you end up with a complete program.
+Below is an example of a basic Anchor program with a single instruction that:
 
 - Initializes a new account
-- Updates the data field on the account with the instruction data passed into the instruction
+- Updates the data field on the account with the instruction data passed into
+  the instruction
 
 ```rust
 // Use this import to gain access to common anchor features
@@ -312,7 +402,8 @@ You are now ready to build your own Solana program using the Anchor framework!
 
 # Demo
 
-Before we begin, install Anchor by following the steps [here](https://www.anchor-lang.com/docs/installation).
+Before we begin, install Anchor by following the steps
+[here](https://www.anchor-lang.com/docs/installation).
 
 For this demo we'll create a simple counter program with two instructions:
 
@@ -358,7 +449,8 @@ And also update `Anchor.toml`
 anchor_counter = "BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr"
 ```
 
-Finally, delete the default code in `lib.rs` until all that is left is the following:
+Finally, delete the default code in `lib.rs` until all that is left is the
+following:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -374,7 +466,10 @@ pub mod anchor_counter {
 
 ### 2. Add the `initialize` instruction
 
-First, let’s implement the `initialize` instruction within `#[program]`. This instruction requires a `Context` of type `Initialize` and takes no additional instruction data. In the instruction logic, we are simply setting the `counter` account’s `count` field to `0`.
+First, let’s implement the `initialize` instruction within `#[program]`. This
+instruction requires a `Context` of type `Initialize` and takes no additional
+instruction data. In the instruction logic, we are simply setting the `counter`
+account’s `count` field to `0`.
 
 ```rust
 pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
@@ -388,11 +483,14 @@ pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
 
 ### 3. Implement `Context` type `Initialize`
 
-Next, using the `#[derive(Accounts)]` macro, let’s implement the `Initialize` type that lists and validates the accounts used by the `initialize` instruction. It'll need the following accounts:
+Next, using the `#[derive(Accounts)]` macro, let’s implement the `Initialize`
+type that lists and validates the accounts used by the `initialize` instruction.
+It'll need the following accounts:
 
 - `counter` - the counter account initialized in the instruction
 - `user` - payer for the initialization
-- `system_program` - the system program is required for the initialization of any new accounts
+- `system_program` - the system program is required for the initialization of
+  any new accounts
 
 ```rust
 #[derive(Accounts)]
@@ -407,7 +505,12 @@ pub struct Initialize<'info> {
 
 ### 4. Implement `Counter`
 
-Next, use the `#[account]` attribute to define a new `Counter` account type. The `Counter` struct defines one `count` field of type `u64`. This means that we can expect any new accounts initialized as a `Counter` type to have a matching data structure. The `#[account]` attribute also automatically sets the discriminator for a new account and sets the owner of the account as the `programId` from the `declare_id!` macro.
+Next, use the `#[account]` attribute to define a new `Counter` account type. The
+`Counter` struct defines one `count` field of type `u64`. This means that we can
+expect any new accounts initialized as a `Counter` type to have a matching data
+structure. The `#[account]` attribute also automatically sets the discriminator
+for a new account and sets the owner of the account as the `programId` from the
+`declare_id!` macro.
 
 ```rust
 #[account]
@@ -418,7 +521,11 @@ pub struct Counter {
 
 ### 5. Add `increment` instruction
 
-Within `#[program]`, let’s implement an `increment` instruction to increment the `count` once a `counter` account is initialized by the first instruction. This instruction requires a `Context` of type `Update` (implemented in the next step) and takes no additional instruction data. In the instruction logic, we are simply incrementing an existing `counter` account’s `count` field by `1`.
+Within `#[program]`, let’s implement an `increment` instruction to increment the
+`count` once a `counter` account is initialized by the first instruction. This
+instruction requires a `Context` of type `Update` (implemented in the next step)
+and takes no additional instruction data. In the instruction logic, we are
+simply incrementing an existing `counter` account’s `count` field by `1`.
 
 ```rust
 pub fn increment(ctx: Context<Update>) -> Result<()> {
@@ -432,12 +539,15 @@ pub fn increment(ctx: Context<Update>) -> Result<()> {
 
 ### 6. Implement `Context` type `Update`
 
-Lastly, using the `#[derive(Accounts)]` macro again, let’s create the `Update` type that lists the accounts that the `increment` instruction requires. It'll need the following accounts:
+Lastly, using the `#[derive(Accounts)]` macro again, let’s create the `Update`
+type that lists the accounts that the `increment` instruction requires. It'll
+need the following accounts:
 
 - `counter` - an existing counter account to increment
 - `user` - payer for the transaction fee
 
-Again, we’ll need to specify any constraints using the `#[account(..)]` attribute:
+Again, we’ll need to specify any constraints using the `#[account(..)]`
+attribute:
 
 ```rust
 #[derive(Accounts)]
@@ -503,7 +613,9 @@ Run `anchor build` to build the program.
 
 ### 8. Testing
 
-Anchor tests are typically Typescript integration tests that use the mocha test framework. We'll learn more about testing later, but for now navigate to `anchor-counter.ts` and replace the default test code with the following:
+Anchor tests are typically Typescript integration tests that use the mocha test
+framework. We'll learn more about testing later, but for now navigate to
+`anchor-counter.ts` and replace the default test code with the following:
 
 ```ts
 import * as anchor from "@project-serum/anchor";
@@ -526,7 +638,8 @@ describe("anchor-counter", () => {
 });
 ```
 
-The above code generates a new keypair for the `counter` account we'll be initializing and creates placeholders for a test of each instruction.
+The above code generates a new keypair for the `counter` account we'll be
+initializing and creates placeholders for a test of each instruction.
 
 Next, create the first test for the `initialize` instruction:
 
@@ -569,19 +682,31 @@ anchor-counter
 2 passing (696ms)
 ```
 
-Running `anchor test` automatically spins up a local test validator, deploys your program, and runs your mocha tests against it. Don't worry if you're confused by the tests for now - we'll dig in more later.
+Running `anchor test` automatically spins up a local test validator, deploys
+your program, and runs your mocha tests against it. Don't worry if you're
+confused by the tests for now - we'll dig in more later.
 
-Congratulations, you just built a Solana program using the Anchor framework! Feel free to reference the [solution code](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-increment) if you need some more time with it.
+Congratulations, you just built a Solana program using the Anchor framework!
+Feel free to reference the
+[solution code](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-increment)
+if you need some more time with it.
 
 # Challenge
 
-Now it’s your turn to build something independently. Because we're starting with very simple programs, yours will look almost identical to what we just created. It's useful to try and get to the point where you can write it from scratch without referencing prior code, so try not to copy and paste here.
+Now it’s your turn to build something independently. Because we're starting with
+very simple programs, yours will look almost identical to what we just created.
+It's useful to try and get to the point where you can write it from scratch
+without referencing prior code, so try not to copy and paste here.
 
 1. Write a new program that initializes a `counter` account
 2. Implement both an `increment` and `decrement` instruction
 3. Build and deploy your program like we did in the demo
-4. Test your newly deployed program and use Solana Explorer to check the program logs
+4. Test your newly deployed program and use Solana Explorer to check the program
+   logs
 
-As always, get creative with these challenges and take them beyond the basic instructions if you want - and have fun!
+As always, get creative with these challenges and take them beyond the basic
+instructions if you want - and have fun!
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-decrement).
+Try to do this independently if you can! But if you get stuck, feel free to
+reference
+the [solution code](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-decrement).

--- a/developers/courses/solana-course/content/intro-to-reading-data.md
+++ b/developers/courses/solana-course/content/intro-to-reading-data.md
@@ -1,14 +1,14 @@
 ---
 title: Read Data From The Solana Network
 objectives:
-- Explain accounts
-- Explain SOL and lamports
-- Explain public keys
-- Explain the JSON RPC API
-- Explain web3.js
-- Install web3.js
-- Use web3.js to create a connection to a Solana node
-- Use web3.js to read data from the blockchain (balance, account info, etc.)
+  - Explain accounts
+  - Explain SOL and lamports
+  - Explain public keys
+  - Explain the JSON RPC API
+  - Explain web3.js
+  - Install web3.js
+  - Use web3.js to create a connection to a Solana node
+  - Use web3.js to read data from the blockchain (balance, account info, etc.)
 ---
 
 ## TL;DR
@@ -20,17 +20,19 @@ objectives:
 - **JSON RPC API**: all interactions with the Solana network happens through the [JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api). This is effectively an HTTP POST with a JSON body that represents the method you want to call.
 - **@solana/web3.js** is an abstraction on top of the JSON RPC API. It can be installed with `npm` and allows you to call Solana methods as JavaScript functions. For example, you can use it to query the SOL balance of any account:
 
-    ```tsx
-    async function getBalanceUsingWeb3(address: PublicKey): Promise<number> {
-        const connection = new Connection(clusterApiUrl('devnet'));
-        return connection.getBalance(address);
-    }
+  ```tsx
+  async function getBalanceUsingWeb3(address: PublicKey): Promise<number> {
+    const connection = new Connection(clusterApiUrl("devnet"));
+    return connection.getBalance(address);
+  }
 
-    const publicKey = new PublicKey('7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp')
-    getBalanceUsingWeb3(publicKey).then(balance => {
-        console.log(balance)
-    })
-    ```
+  const publicKey = new PublicKey(
+    "7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp",
+  );
+  getBalanceUsingWeb3(publicKey).then(balance => {
+    console.log(balance);
+  });
+  ```
 
 # Overview
 
@@ -54,14 +56,13 @@ All client interaction with the Solana network happens through Solana’s [JSON 
 
 Per the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification)
 
-> *JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol. Primarily this specification defines several data structures and the rules around their processing. It is transport agnostic in that the concepts can be used within the same process, over sockets, over http, or in many various message passing environments. It uses [JSON](http://www.json.org/) ([RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)) as data format.*
->
+> _JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol. Primarily this specification defines several data structures and the rules around their processing. It is transport agnostic in that the concepts can be used within the same process, over sockets, over http, or in many various message passing environments. It uses [JSON](http://www.json.org/) ([RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)) as data format._
 
 In practice, this specification simply involves sending a JSON object representing a method you want to call. You can do this with sockets, http, and more.
 
 This JSON object needs four members:
 
-- `jsonrpc` - The JSON RPC version number. This needs to be *exactly* `"2.0"`.
+- `jsonrpc` - The JSON RPC version number. This needs to be _exactly_ `"2.0"`.
 - `id` - An identifier that you choose for identifying the call. This can be a string or a whole number.
 - `method` - The name of the method you want to invoke.
 - `params` - An array containing the parameters to use during the method invocation.
@@ -70,30 +71,29 @@ So, if you want to call the `getBalance` method on the Solana network, you could
 
 ```tsx
 async function getBalanceUsingJSONRPC(address: string): Promise<number> {
-    const url = clusterApiUrl('devnet')
-    console.log(url);
-    return fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "getBalance",
-            "params": [
-                address
-            ]
-        })
-    }).then(response => response.json())
+  const url = clusterApiUrl("devnet");
+  console.log(url);
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getBalance",
+      params: [address],
+    }),
+  })
+    .then(response => response.json())
     .then(json => {
-        if (json.error) {
-            throw json.error
-        }
+      if (json.error) {
+        throw json.error;
+      }
 
-        return json['result']['value'] as number;
+      return json["result"]["value"] as number;
     })
     .catch(error => {
-        throw error
-    })
+      throw error;
+    });
 }
 ```
 
@@ -116,7 +116,7 @@ To install `@solana/web3.js`, set up your project the way you normally would the
 Every interaction with the Solana network using `@solana/web3.js` is going to happen through a `Connection` object. This object establishes a JSON-RPC connection with a Solana cluster (more on clusters later). For now, we’re going to use the url for the Devnet cluster rather than Mainnet. As the name suggests, this cluster is designed for developer use and testing.
 
 ```tsx
-const connection = new Connection(clusterApiUrl('devnet'));
+const connection = new Connection(clusterApiUrl("devnet"));
 ```
 
 ### Read from the Network
@@ -125,8 +125,8 @@ Once you have a `Connection` object, querying the network is as simple as callin
 
 ```tsx
 async function getBalanceUsingWeb3(address: PublicKey): Promise<number> {
-    const connection = new Connection(clusterApiUrl('devnet'));
-    return connection.getBalance(address);
+  const connection = new Connection(clusterApiUrl("devnet"));
+  return connection.getBalance(address);
 }
 ```
 
@@ -198,18 +198,18 @@ To fix this, let’s wrap everything in a `try-catch` block and alert the user i
 ```tsx
 const addressSubmittedHandler = (address: string) => {
   try {
-    setAddress(address)
-    const key = new Web3.PublicKey(address)
-    const connection = new Web3.Connection(Web3.clusterApiUrl('devnet'))
+    setAddress(address);
+    const key = new Web3.PublicKey(address);
+    const connection = new Web3.Connection(Web3.clusterApiUrl("devnet"));
     connection.getBalance(key).then(balance => {
-      setBalance(balance / Web3.LAMPORTS_PER_SOL)
-    })
+      setBalance(balance / Web3.LAMPORTS_PER_SOL);
+    });
   } catch (error) {
-    setAddress('')
-    setBalance(0)
-    alert(error)
+    setAddress("");
+    setBalance(0);
+    alert(error);
   }
-}
+};
 ```
 
 Notice that in the catch block we also cleared out the address and balance to avoid confusion.
@@ -220,7 +220,7 @@ We did it! We have a functioning site that reads SOL balances from the Solana ne
 
 Since this is the first challenge, we’ll keep it simple. Go ahead and add on to the frontend we’ve already created by including a line item after “Balance”. Have the line item display whether or not the account is an executable account or not. Hint: there’s a `getAccountInfo` method.
 
-Your standard wallet address will *not* be executable, so if you want an address that *will* be executable for testing, use `CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
+Your standard wallet address will _not_ be executable, so if you want an address that _will_ be executable for testing, use `CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
 
 ![Screenshot of final challenge solution](../assets/intro-frontend-challenge.png)
 

--- a/developers/courses/solana-course/content/intro-to-reading-data.md
+++ b/developers/courses/solana-course/content/intro-to-reading-data.md
@@ -13,12 +13,23 @@ objectives:
 
 ## TL;DR
 
-- **Accounts** are like the files in Solana’s network ledger. All state data is stored in an account. Accounts can be used for many things, but for now we’ll focus on the aspect of accounts which store SOL.
+- **Accounts** are like the files in Solana’s network ledger. All state data is
+  stored in an account. Accounts can be used for many things, but for now we’ll
+  focus on the aspect of accounts which store SOL.
 - **SOL** is the name of Solana’s native token.
-- **Lamports** are fractional SOL and are named after [Leslie Lamport](https://en.wikipedia.org/wiki/Leslie_Lamport).
-- **Public keys**, often referred to as addresses, point to accounts on the Solana network. While you must have a specific secret key to perform certain functions within accounts, anyone can read account data with a public key.
-- **JSON RPC API**: all interactions with the Solana network happens through the [JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api). This is effectively an HTTP POST with a JSON body that represents the method you want to call.
-- **@solana/web3.js** is an abstraction on top of the JSON RPC API. It can be installed with `npm` and allows you to call Solana methods as JavaScript functions. For example, you can use it to query the SOL balance of any account:
+- **Lamports** are fractional SOL and are named after
+  [Leslie Lamport](https://en.wikipedia.org/wiki/Leslie_Lamport).
+- **Public keys**, often referred to as addresses, point to accounts on the
+  Solana network. While you must have a specific secret key to perform certain
+  functions within accounts, anyone can read account data with a public key.
+- **JSON RPC API**: all interactions with the Solana network happens through the
+  [JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api). This
+  is effectively an HTTP POST with a JSON body that represents the method you
+  want to call.
+- **@solana/web3.js** is an abstraction on top of the JSON RPC API. It can be
+  installed with `npm` and allows you to call Solana methods as JavaScript
+  functions. For example, you can use it to query the SOL balance of any
+  account:
 
   ```tsx
   async function getBalanceUsingWeb3(address: PublicKey): Promise<number> {
@@ -38,36 +49,56 @@ objectives:
 
 ## Accounts
 
-Solana accounts are similar to files in operating systems such as Linux. They hold arbitrary, persistent data and are flexible enough to be used in many different ways.
+Solana accounts are similar to files in operating systems such as Linux. They
+hold arbitrary, persistent data and are flexible enough to be used in many
+different ways.
 
-In this lesson we won’t consider much about accounts beyond their ability to store SOL (Solana’s native token - more on that later). However, accounts are also used to store custom data structures and executable code that can be run as programs. Accounts will be involved in everything you do with Solana.
+In this lesson we won’t consider much about accounts beyond their ability to
+store SOL (Solana’s native token - more on that later). However, accounts are
+also used to store custom data structures and executable code that can be run as
+programs. Accounts will be involved in everything you do with Solana.
 
 ### Public Keys
 
-Public keys are often referred to as addresses. The addresses point to accounts on the Solana network. If you want to run a specific program or transfer SOL, you’ll need to provide the necessary public key (or keys) to do so.
+Public keys are often referred to as addresses. The addresses point to accounts
+on the Solana network. If you want to run a specific program or transfer SOL,
+you’ll need to provide the necessary public key (or keys) to do so.
 
-Public keys are 256-bit and they are often shown as base-58 encoded strings like `7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp`.
+Public keys are 256-bit and they are often shown as base-58 encoded strings like
+`7C4jsPZpht42Tw6MjXWF56Q5RQUocjBBmciEjDa8HRtp`.
 
 ## The Solana JSON RPC API
 
 ![Illustration depicting how client-side interaction with the Solana network happens through the JSON RPC API](../assets/json-rpc-illustration.png)
 
-All client interaction with the Solana network happens through Solana’s [JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api).
+All client interaction with the Solana network happens through Solana’s
+[JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api).
 
 Per the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification)
 
-> _JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol. Primarily this specification defines several data structures and the rules around their processing. It is transport agnostic in that the concepts can be used within the same process, over sockets, over http, or in many various message passing environments. It uses [JSON](http://www.json.org/) ([RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)) as data format._
+> _JSON-RPC is a stateless, light-weight remote procedure call (RPC) protocol.
+> Primarily this specification defines several data structures and the rules
+> around their processing. It is transport agnostic in that the concepts can be
+> used within the same process, over sockets, over http, or in many various
+> message passing environments. It
+> uses [JSON](http://www.json.org/) ([RFC 4627](http://www.ietf.org/rfc/rfc4627.txt))
+> as data format._
 
-In practice, this specification simply involves sending a JSON object representing a method you want to call. You can do this with sockets, http, and more.
+In practice, this specification simply involves sending a JSON object
+representing a method you want to call. You can do this with sockets, http, and
+more.
 
 This JSON object needs four members:
 
 - `jsonrpc` - The JSON RPC version number. This needs to be _exactly_ `"2.0"`.
-- `id` - An identifier that you choose for identifying the call. This can be a string or a whole number.
+- `id` - An identifier that you choose for identifying the call. This can be a
+  string or a whole number.
 - `method` - The name of the method you want to invoke.
-- `params` - An array containing the parameters to use during the method invocation.
+- `params` - An array containing the parameters to use during the method
+  invocation.
 
-So, if you want to call the `getBalance` method on the Solana network, you could send an HTTP call to a Solana cluster as follows:
+So, if you want to call the `getBalance` method on the Solana network, you could
+send an HTTP call to a Solana cluster as follows:
 
 ```tsx
 async function getBalanceUsingJSONRPC(address: string): Promise<number> {
@@ -99,21 +130,36 @@ async function getBalanceUsingJSONRPC(address: string): Promise<number> {
 
 ## Solana’s Web3.js SDK
 
-While the JSON-RPC API is simple enough, it involves a significant amount of tedious boilerplate. To simplify the process of communication, Solana Labs created the `@solana/web3.js` SDK as an abstraction on top of the JSON-RPC API.
+While the JSON-RPC API is simple enough, it involves a significant amount of
+tedious boilerplate. To simplify the process of communication, Solana Labs
+created the `@solana/web3.js` SDK as an abstraction on top of the JSON-RPC API.
 
-Web3.js allows you to call the JSON-RPC API methods using JavaScript functions. The SDK provides a suite of helper functions and objects. We’ll cover a lot of the SDK gradually throughout this course, but we won’t go over everything in depth, so be sure to check out the [documentation](https://docs.solana.com/developing/clients/javascript-reference) at some point.
+Web3.js allows you to call the JSON-RPC API methods using JavaScript functions.
+The SDK provides a suite of helper functions and objects. We’ll cover a lot of
+the SDK gradually throughout this course, but we won’t go over everything in
+depth, so be sure to check out the
+[documentation](https://docs.solana.com/developing/clients/javascript-reference)
+at some point.
 
 ### Installation
 
-Throughout this course, we’ll mostly be using `npm`. How to use `npm` is outside the scope of this course and we’ll assume it’s a tool you use regularly. [Check this out](https://nodesource.com/blog/an-absolute-beginners-guide-to-using-npm/) if that’s not the case.
+Throughout this course, we’ll mostly be using `npm`. How to use `npm` is outside
+the scope of this course and we’ll assume it’s a tool you use regularly.
+[Check this out](https://nodesource.com/blog/an-absolute-beginners-guide-to-using-npm/)
+if that’s not the case.
 
-To install `@solana/web3.js`, set up your project the way you normally would then use:
+To install `@solana/web3.js`, set up your project the way you normally would
+then use:
 
 `npm install @solana/web3.js`.
 
 ### Connect to the Network
 
-Every interaction with the Solana network using `@solana/web3.js` is going to happen through a `Connection` object. This object establishes a JSON-RPC connection with a Solana cluster (more on clusters later). For now, we’re going to use the url for the Devnet cluster rather than Mainnet. As the name suggests, this cluster is designed for developer use and testing.
+Every interaction with the Solana network using `@solana/web3.js` is going to
+happen through a `Connection` object. This object establishes a JSON-RPC
+connection with a Solana cluster (more on clusters later). For now, we’re going
+to use the url for the Devnet cluster rather than Mainnet. As the name suggests,
+this cluster is designed for developer use and testing.
 
 ```tsx
 const connection = new Connection(clusterApiUrl("devnet"));
@@ -121,7 +167,9 @@ const connection = new Connection(clusterApiUrl("devnet"));
 
 ### Read from the Network
 
-Once you have a `Connection` object, querying the network is as simple as calling the appropriate methods. For example, to get the balance of a particular address, you do the following:
+Once you have a `Connection` object, querying the network is as simple as
+calling the appropriate methods. For example, to get the balance of a particular
+address, you do the following:
 
 ```tsx
 async function getBalanceUsingWeb3(address: PublicKey): Promise<number> {
@@ -130,35 +178,57 @@ async function getBalanceUsingWeb3(address: PublicKey): Promise<number> {
 }
 ```
 
-The balance returned is in fractional SOL called lamports. A single lamport represents 0.000000001 SOL. Most of the time when dealing with SOL the system will use lamports instead of SOL. Web3.js provides the constant `LAMPORTS_PER_SOL` for making quick conversions.
+The balance returned is in fractional SOL called lamports. A single lamport
+represents 0.000000001 SOL. Most of the time when dealing with SOL the system
+will use lamports instead of SOL. Web3.js provides the constant
+`LAMPORTS_PER_SOL` for making quick conversions.
 
-...and just like that, now you know how to read data from the Solana blockchain! Once we get into custom data things will get more complicated. But for now, let’s practice what we’ve learned so far.
+...and just like that, now you know how to read data from the Solana blockchain!
+Once we get into custom data things will get more complicated. But for now,
+let’s practice what we’ve learned so far.
 
 # Demo
 
-Let’s create a simple website that lets users check the balance at a particular address.
+Let’s create a simple website that lets users check the balance at a particular
+address.
 
 It’ll look something like this:
 
 ![Screenshot of demo solution](../assets/intro-frontend-demo.png)
 
-In the interest of staying on topic, we won’t be working entirely from scratch. You can find the starter code [here](https://github.com/Unboxed-Software/solana-intro-frontend/tree/starter). The starter project uses Next.js and Typescript. If you’re used to a different stack, don’t worry! The web3 and Solana principles you’ll learn throughout these lessons are applicable to whichever frontend stack you’re most comfortable with.
+In the interest of staying on topic, we won’t be working entirely from scratch.
+You can find the starter code
+[here](https://github.com/Unboxed-Software/solana-intro-frontend/tree/starter).
+The starter project uses Next.js and Typescript. If you’re used to a different
+stack, don’t worry! The web3 and Solana principles you’ll learn throughout these
+lessons are applicable to whichever frontend stack you’re most comfortable with.
 
 ### 1. Get oriented
 
-Once you’ve got the starter code, take a look around. Install the dependencies with `npm install` and then run the app with `npm run dev`. Notice that no matter what you put into the address field, when you click “Check SOL Balance” the balance will be a placeholder value of 1000.
+Once you’ve got the starter code, take a look around. Install the dependencies
+with `npm install` and then run the app with `npm run dev`. Notice that no
+matter what you put into the address field, when you click “Check SOL Balance”
+the balance will be a placeholder value of 1000.
 
-Structurally, the app is composed of `index.tsx` and `AddressForm.tsx`. When a user submits the form, the `addressSubmittedHandler` in `index.tsx` gets called. That’s where we’ll be adding the logic to update the rest of the UI.
+Structurally, the app is composed of `index.tsx` and `AddressForm.tsx`. When a
+user submits the form, the `addressSubmittedHandler` in `index.tsx` gets called.
+That’s where we’ll be adding the logic to update the rest of the UI.
 
 ### 2. Install dependencies
 
-Use `npm install @solana/web3.js` to install our dependency on Solana’s Web3 library.
+Use `npm install @solana/web3.js` to install our dependency on Solana’s Web3
+library.
 
 ### 3. Set the address balance
 
 First, import `@solana/web3.js` at the top of `index.tsx`.
 
-Now that the library is available, let’s go into the `addressSubmittedHandler` and create an instance of `PublicKey` using the address value from the form input. Next, create an instance of `Connection` and use it to call `getBalance`. Pass in the value of the public key you just created. Finally, call `setBalance`, passing in the result from `getBalance`. If you’re up to it, try this independently instead of copying from the code snippet below.
+Now that the library is available, let’s go into the `addressSubmittedHandler`
+and create an instance of `PublicKey` using the address value from the form
+input. Next, create an instance of `Connection` and use it to call `getBalance`.
+Pass in the value of the public key you just created. Finally, call
+`setBalance`, passing in the result from `getBalance`. If you’re up to it, try
+this independently instead of copying from the code snippet below.
 
 ```tsx
 import type { NextPage } from 'next'
@@ -185,15 +255,25 @@ const Home: NextPage = () => {
 }
 ```
 
-Notice that we are taking the balance returned by Solana and dividing it by `LAMPORTS_PER_SOL`. Lamports are fractional SOL (0.000000001 SOL). Most of the time when dealing with SOL, the system will use lamports instead of SOL. In this case, the balance returned by the network is in lamports. Before setting it to our state, we convert it to SOL using the `LAMPORTS_PER_SOL` constant.
+Notice that we are taking the balance returned by Solana and dividing it by
+`LAMPORTS_PER_SOL`. Lamports are fractional SOL (0.000000001 SOL). Most of the
+time when dealing with SOL, the system will use lamports instead of SOL. In this
+case, the balance returned by the network is in lamports. Before setting it to
+our state, we convert it to SOL using the `LAMPORTS_PER_SOL` constant.
 
-At this point you should be able to put a valid address into the form field and click “Check SOL Balance” to see both the Address and Balance populate below.
+At this point you should be able to put a valid address into the form field and
+click “Check SOL Balance” to see both the Address and Balance populate below.
 
 ### 4. Handle invalid addresses
 
-We’re just about done. The only remaining issue is that using an invalid address doesn’t show any error message or change the balance shown. If you open the developer console, you’ll see `Error: Invalid public key input`. When using the `PublicKey` constructor, you need to pass in a valid address or you’ll get this error.
+We’re just about done. The only remaining issue is that using an invalid address
+doesn’t show any error message or change the balance shown. If you open the
+developer console, you’ll see `Error: Invalid public key input`. When using the
+`PublicKey` constructor, you need to pass in a valid address or you’ll get this
+error.
 
-To fix this, let’s wrap everything in a `try-catch` block and alert the user if their input is invalid.
+To fix this, let’s wrap everything in a `try-catch` block and alert the user if
+their input is invalid.
 
 ```tsx
 const addressSubmittedHandler = (address: string) => {
@@ -212,16 +292,28 @@ const addressSubmittedHandler = (address: string) => {
 };
 ```
 
-Notice that in the catch block we also cleared out the address and balance to avoid confusion.
+Notice that in the catch block we also cleared out the address and balance to
+avoid confusion.
 
-We did it! We have a functioning site that reads SOL balances from the Solana network. You’re well on your way to achieving your grand ambitions on Solana. If you need to spend some more time looking at this code to better understand it, have a look at the complete [solution code](https://github.com/Unboxed-Software/solana-intro-frontend). Hang on tight, these lessons will ramp up quickly.
+We did it! We have a functioning site that reads SOL balances from the Solana
+network. You’re well on your way to achieving your grand ambitions on Solana. If
+you need to spend some more time looking at this code to better understand it,
+have a look at the complete
+[solution code](https://github.com/Unboxed-Software/solana-intro-frontend). Hang
+on tight, these lessons will ramp up quickly.
 
 # Challenge
 
-Since this is the first challenge, we’ll keep it simple. Go ahead and add on to the frontend we’ve already created by including a line item after “Balance”. Have the line item display whether or not the account is an executable account or not. Hint: there’s a `getAccountInfo` method.
+Since this is the first challenge, we’ll keep it simple. Go ahead and add on to
+the frontend we’ve already created by including a line item after “Balance”.
+Have the line item display whether or not the account is an executable account
+or not. Hint: there’s a `getAccountInfo` method.
 
-Your standard wallet address will _not_ be executable, so if you want an address that _will_ be executable for testing, use `CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
+Your standard wallet address will _not_ be executable, so if you want an address
+that _will_ be executable for testing, use
+`CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
 
 ![Screenshot of final challenge solution](../assets/intro-frontend-challenge.png)
 
-If you get stuck feel free to take a look at the [solution code](https://github.com/Unboxed-Software/solana-intro-frontend/tree/challenge-solution).
+If you get stuck feel free to take a look at the
+[solution code](https://github.com/Unboxed-Software/solana-intro-frontend/tree/challenge-solution).

--- a/developers/courses/solana-course/content/intro-to-writing-data.md
+++ b/developers/courses/solana-course/content/intro-to-writing-data.md
@@ -1,37 +1,36 @@
 ---
 title: Write Data To The Solana Network
 objectives:
-- Explain keypair
-- Use `@solana/web3.js` to generate a keypair
-- Use `@solana/web3.js` to create a keypair using a secret key
-- Explain transactions
-- Explain transaction fees
-- Use `@solana/web3.js` to send sol
-- Use `@solana/web3.js` to sign transactions
-- Use Solana explorer to view transactions
+  - Explain keypair
+  - Use `@solana/web3.js` to generate a keypair
+  - Use `@solana/web3.js` to create a keypair using a secret key
+  - Explain transactions
+  - Explain transaction fees
+  - Use `@solana/web3.js` to send sol
+  - Use `@solana/web3.js` to sign transactions
+  - Use Solana explorer to view transactions
 ---
 
 # TL;DR
 
-- **Keypair** refers to a pairing of public and secret keys. The public key is used as an “address” that points to an account on the Solana network. The secret key is used to verify identity or authority. As the name suggests, you should always keep secret keys *private*. `@solana/web3.js` provides helper functions for creating a brand new keypair, or for constructing a keypair using an existing secret key.
+- **Keypair** refers to a pairing of public and secret keys. The public key is used as an “address” that points to an account on the Solana network. The secret key is used to verify identity or authority. As the name suggests, you should always keep secret keys _private_. `@solana/web3.js` provides helper functions for creating a brand new keypair, or for constructing a keypair using an existing secret key.
 - **Transactions** are effectively a bundle of instructions that invoke Solana programs. The result of each transaction depends on the program being called. All modifications to on-chain data happen through transactions. Example:
-    ```tsx
-    const transaction = new Transaction()
 
-    const sendSolInstruction = SystemProgram.transfer({
-        fromPubkey: sender,
-        toPubkey: recipient,
-        lamports: LAMPORTS_PER_SOL * amount
-    })
+  ```tsx
+  const transaction = new Transaction();
 
-    transaction.add(sendSolInstruction)
+  const sendSolInstruction = SystemProgram.transfer({
+    fromPubkey: sender,
+    toPubkey: recipient,
+    lamports: LAMPORTS_PER_SOL * amount,
+  });
 
-    const signature = sendAndConfirmTransaction(
-        connection,
-        transaction,
-        [senderKeypair]
-    )
-    ```
+  transaction.add(sendSolInstruction);
+
+  const signature = sendAndConfirmTransaction(connection, transaction, [
+    senderKeypair,
+  ]);
+  ```
 
 # Overview
 
@@ -40,32 +39,32 @@ objectives:
 As the name suggests, a keypair is a pair of keys: a public key and a secret key.
 
 - The public key is used as an “address” that points to an account on the Solana network.
-- The secret key is used to verify identity or authority. As the name suggests, you should always keep secret keys *private*.
+- The secret key is used to verify identity or authority. As the name suggests, you should always keep secret keys _private_.
 
-A keypair is *required* for the vast majority of interactions within the Solana network. If you don’t already have a keypair, or if you want to generate a new one for a specific purpose, `@solana/web3.js` provides a helper function for creating a brand new keypair.
+A keypair is _required_ for the vast majority of interactions within the Solana network. If you don’t already have a keypair, or if you want to generate a new one for a specific purpose, `@solana/web3.js` provides a helper function for creating a brand new keypair.
 
 ```tsx
-const ownerKeypair = Keypair.generate()
+const ownerKeypair = Keypair.generate();
 ```
 
 A keypair is of the data type `Keypair` and can be deconstructed into a public key:
 
 ```tsx
-const publicKey = ownerKeypair.publicKey
+const publicKey = ownerKeypair.publicKey;
 ```
 
 ... or the secret key:
 
 ```tsx
-const secretKey = ownerKeypair.secretKey
+const secretKey = ownerKeypair.secretKey;
 ```
 
 If you already have a keypair you’d like to use, you can create a `Keypair` from the secret key using the `Keypair.fromSecretKey()` function. To ensure that your secret key stays secure, we recommend injecting it through an environment variable and not committing your `.env` file.
 
 ```tsx
-const secret = JSON.parse(process.env.PRIVATE_KEY ?? "") as number[]
-const secretKey = Uint8Array.from(secret)
-const keypairFromSecretKey = Keypair.fromSecretKey(secretKey)
+const secret = JSON.parse(process.env.PRIVATE_KEY ?? "") as number[];
+const secretKey = Uint8Array.from(secret);
+const keypairFromSecretKey = Keypair.fromSecretKey(secretKey);
 ```
 
 ## Transactions
@@ -85,15 +84,15 @@ As you might expect, `@solana/web3.js` provides helper functions for creating tr
 Instructions can get complicated when working with custom programs. Fortunately, `@solana/web3.js` has convenience functions for some of Solana’s native programs and basic operations, like transferring SOL:
 
 ```tsx
-const transaction = new Transaction()
+const transaction = new Transaction();
 
 const sendSolInstruction = SystemProgram.transfer({
-    fromPubkey: sender,
-    toPubkey: recipient,
-    lamports: LAMPORTS_PER_SOL * amount
-})
+  fromPubkey: sender,
+  toPubkey: recipient,
+  lamports: LAMPORTS_PER_SOL * amount,
+});
 
-transaction.add(sendSolInstruction)
+transaction.add(sendSolInstruction);
 ```
 
 The `SystemProgram.transfer()` function requires that you pass as parameters:
@@ -107,11 +106,9 @@ This function then returns the instruction for sending SOL from the sender to th
 Once created, a transaction needs to be sent to the cluster and confirmed:
 
 ```tsx
-const signature = sendAndConfirmTransaction(
-    connection,
-    transaction,
-    [senderKeypair]
-)
+const signature = sendAndConfirmTransaction(connection, transaction, [
+  senderKeypair,
+]);
 ```
 
 The `sendAndConfirmTransaction()` functions takes as parameters
@@ -147,6 +144,7 @@ The `programId` field is fairly self explanatory: it’s the public key associat
 The `keys` array requires a bit more explanation. Each object in this array represents an account that will be read from or written to during a transaction's execution. This means you need to know the behavior of the program you are calling and ensure that you provide all of the necessary accounts in the array.
 
 Each object in the `keys` array must include the following:
+
 - `pubkey` - the public key of the account
 - `isSigner` - a boolean representing whether or not the account is a signer on the transaction
 - `isWritable` - a boolean representing whether or not the account is written to during the transaction's execution
@@ -155,29 +153,29 @@ Putting this all together, we might end up with something like the following:
 
 ```tsx
 async function callProgram(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    programId: web3.PublicKey,
-    programDataAccount: web3.PublicKey
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  programId: web3.PublicKey,
+  programDataAccount: web3.PublicKey,
 ) {
-    const instruction = new web3.TransactionInstruction({
-        keys: [
-            {
-                pubkey: programDataAccount,
-                isSigner: false,
-                isWritable: true
-            },
-        ],
-        programId
-    })
+  const instruction = new web3.TransactionInstruction({
+    keys: [
+      {
+        pubkey: programDataAccount,
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    programId,
+  });
 
-    const signature = await web3.sendAndConfirmTransaction(
-        connection,
-        new web3.Transaction().add(instruction),
-        [payer]
-    )
+  const signature = await web3.sendAndConfirmTransaction(
+    connection,
+    new web3.Transaction().add(instruction),
+    [payer],
+  );
 
-    console.log(signature)
+  console.log(signature);
 }
 ```
 
@@ -251,7 +249,7 @@ If you want to match our code exactly, replace the contents of `tsconfig.json` w
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist"
   },
-  "include": [ "./src/**/*" ]
+  "include": ["./src/**/*"]
 }
 ```
 
@@ -274,20 +272,22 @@ And finally, add the following to the `scripts` object in `package.json`:
 Before you can do anything, you’ll need a keypair. Let’s jump into the `index.ts` file and generate one:
 
 ```tsx
-import web3 = require('@solana/web3.js')
-import Dotenv from 'dotenv'
-Dotenv.config()
+import web3 = require("@solana/web3.js");
+import Dotenv from "dotenv";
+Dotenv.config();
 
 async function main() {
-    const newKeypair = web3.Keypair.generate()
-    console.log(newKeypair.secretKey.toString())
+  const newKeypair = web3.Keypair.generate();
+  console.log(newKeypair.secretKey.toString());
 }
 
-main().then(() => {
-    console.log("Finished successfully")
-}).catch((error) => {
-    console.error(error)
-})
+main()
+  .then(() => {
+    console.log("Finished successfully");
+  })
+  .catch(error => {
+    console.error(error);
+  });
 ```
 
 Most of this code is just boilerplate to run the file properly. The lines inside of the `main()` function generate a new keypair and log the secret key to the console.
@@ -312,10 +312,10 @@ We’ll return to the `main()` function soon, but for now let’s create a new f
 
 ```tsx
 function initializeKeypair(): web3.Keypair {
-    const secret = JSON.parse(process.env.PRIVATE_KEY ?? "") as number[]
-    const secretKey = Uint8Array.from(secret)
-    const keypairFromSecretKey = web3.Keypair.fromSecretKey(secretKey)
-    return keypairFromSecretKey
+  const secret = JSON.parse(process.env.PRIVATE_KEY ?? "") as number[];
+  const secretKey = Uint8Array.from(secret);
+  const keypairFromSecretKey = web3.Keypair.fromSecretKey(secretKey);
+  return keypairFromSecretKey;
 }
 ```
 
@@ -325,15 +325,15 @@ Now that we have a way of initializing our keypair, we need to establish a conne
 
 ```tsx
 async function main() {
-    const payer = initializeKeypair()
-    const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
+  const payer = initializeKeypair();
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
 }
 ```
 
 Now create an async function outside of `main()` called `pingProgram()` with two parameters requiring a connection and a payer’s keypair as arguments:
 
 ```tsx
-async function pingProgram(connection: web3.Connection, payer: web3.Keypair) { }
+async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {}
 ```
 
 Inside this function, we need to:
@@ -346,18 +346,18 @@ Inside this function, we need to:
 Remember, the most challenging piece here is including the right information in the instruction. We know the address of the program that we are calling. We also know that the program writes data to a separate account whose address we also have. Let’s add the string versions of both of those as constants at the top of the `index.ts` file:
 
 ```tsx
-const PROGRAM_ADDRESS = 'ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa'
-const PROGRAM_DATA_ADDRESS = 'Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod'
+const PROGRAM_ADDRESS = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
+const PROGRAM_DATA_ADDRESS = "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
 ```
 
 Now, in the `pingProgram()` function, let’s create a new transaction, then initialize a `PublicKey` for the program account, and another for the data account.
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
-    const transaction = new web3.Transaction()
+  const transaction = new web3.Transaction();
 
-    const programId = new web3.PublicKey(PROGRAM_ADDRESS)
-    const programDataPubkey = new web3.PublicKey(PROGRAM_DATA_ADDRESS)
+  const programId = new web3.PublicKey(PROGRAM_ADDRESS);
+  const programDataPubkey = new web3.PublicKey(PROGRAM_DATA_ADDRESS);
 }
 ```
 
@@ -365,21 +365,21 @@ Next, let’s create the instruction. Remember, the instruction needs to include
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
-    const transaction = new web3.Transaction()
+  const transaction = new web3.Transaction();
 
-    const programId = new web3.PublicKey(PROGRAM_ADDRESS)
-    const programDataPubkey = new web3.PublicKey(PROGRAM_DATA_ADDRESS)
+  const programId = new web3.PublicKey(PROGRAM_ADDRESS);
+  const programDataPubkey = new web3.PublicKey(PROGRAM_DATA_ADDRESS);
 
-    const instruction = new web3.TransactionInstruction({
-        keys: [
-            {
-                pubkey: programDataPubkey,
-                isSigner: false,
-                isWritable: true
-            },
-        ],
-        programId
-    })
+  const instruction = new web3.TransactionInstruction({
+    keys: [
+      {
+        pubkey: programDataPubkey,
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    programId,
+  });
 }
 ```
 
@@ -387,40 +387,41 @@ Next, let’s add the instruction to the transaction we created at the start of 
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
-    const transaction = new web3.Transaction()
+  const transaction = new web3.Transaction();
 
-    const programId = new web3.PublicKey(PROGRAM_ADDRESS)
-    const programDataPubkey = new web3.PublicKey(PROGRAM_DATA_ADDRESS)
+  const programId = new web3.PublicKey(PROGRAM_ADDRESS);
+  const programDataPubkey = new web3.PublicKey(PROGRAM_DATA_ADDRESS);
 
-    const instruction = new web3.TransactionInstruction({
-        keys: [
-            {
-                pubkey: programDataPubkey,
-                isSigner: false,
-                isWritable: true
-            },
-        ],
-        programId
-    })
+  const instruction = new web3.TransactionInstruction({
+    keys: [
+      {
+        pubkey: programDataPubkey,
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    programId,
+  });
 
-    transaction.add(instruction)
+  transaction.add(instruction);
 
-    const signature = await web3.sendAndConfirmTransaction(
-        connection,
-        transaction,
-        [payer]
-    )
+  const signature = await web3.sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [payer],
+  );
 
-    console.log(signature)
+  console.log(signature);
 }
 ```
+
 Finally, let's invoke `pingProgram()` within `main()` using `connection` and `payer`:
 
 ```tsx
 async function main() {
-    const payer = initializeKeypair()
-    const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
-    await pingProgram(connection, payer)
+  const payer = initializeKeypair();
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  await pingProgram(connection, payer);
 }
 ```
 
@@ -433,7 +434,7 @@ Now run the code with `npm start` and see if it works. You may end up with the f
 If you get this error, it’s because your keypair is brand new and doesn’t have any SOL to cover the transaction fees. Let’s fix this by adding the following line in `main()` before the call to `pingProgram()`:
 
 ```tsx
-await connection.requestAirdrop(payer.publicKey, web3.LAMPORTS_PER_SOL*1)
+await connection.requestAirdrop(payer.publicKey, web3.LAMPORTS_PER_SOL * 1);
 ```
 
 This will deposit 1 SOL into your account which you can use for testing. This won’t work on Mainnet where it would actually have value. But it's incredibly convenient for testing locally and on Devnet.
@@ -453,7 +454,9 @@ Copy this confirmation signature. Open a browser and go to [https://explorer.sol
 If you want to make it easier to look at Solana Explorer for transactions in the future, simply change your `console.log` in `pingProgram()` to the following:
 
 ```tsx
-console.log(`You can view your transaction on the Solana Explorer at:\nhttps://explorer.solana.com/tx/${sig}?cluster=devnet`)
+console.log(
+  `You can view your transaction on the Solana Explorer at:\nhttps://explorer.solana.com/tx/${sig}?cluster=devnet`,
+);
 ```
 
 And just like that you’re calling programs on the Solana network and writing data to chain!

--- a/developers/courses/solana-course/content/intro-to-writing-data.md
+++ b/developers/courses/solana-course/content/intro-to-writing-data.md
@@ -13,8 +13,15 @@ objectives:
 
 # TL;DR
 
-- **Keypair** refers to a pairing of public and secret keys. The public key is used as an “address” that points to an account on the Solana network. The secret key is used to verify identity or authority. As the name suggests, you should always keep secret keys _private_. `@solana/web3.js` provides helper functions for creating a brand new keypair, or for constructing a keypair using an existing secret key.
-- **Transactions** are effectively a bundle of instructions that invoke Solana programs. The result of each transaction depends on the program being called. All modifications to on-chain data happen through transactions. Example:
+- **Keypair** refers to a pairing of public and secret keys. The public key is
+  used as an “address” that points to an account on the Solana network. The
+  secret key is used to verify identity or authority. As the name suggests, you
+  should always keep secret keys _private_. `@solana/web3.js` provides helper
+  functions for creating a brand new keypair, or for constructing a keypair
+  using an existing secret key.
+- **Transactions** are effectively a bundle of instructions that invoke Solana
+  programs. The result of each transaction depends on the program being called.
+  All modifications to on-chain data happen through transactions. Example:
 
   ```tsx
   const transaction = new Transaction();
@@ -36,18 +43,25 @@ objectives:
 
 ## Keypair
 
-As the name suggests, a keypair is a pair of keys: a public key and a secret key.
+As the name suggests, a keypair is a pair of keys: a public key and a secret
+key.
 
-- The public key is used as an “address” that points to an account on the Solana network.
-- The secret key is used to verify identity or authority. As the name suggests, you should always keep secret keys _private_.
+- The public key is used as an “address” that points to an account on the Solana
+  network.
+- The secret key is used to verify identity or authority. As the name suggests,
+  you should always keep secret keys _private_.
 
-A keypair is _required_ for the vast majority of interactions within the Solana network. If you don’t already have a keypair, or if you want to generate a new one for a specific purpose, `@solana/web3.js` provides a helper function for creating a brand new keypair.
+A keypair is _required_ for the vast majority of interactions within the Solana
+network. If you don’t already have a keypair, or if you want to generate a new
+one for a specific purpose, `@solana/web3.js` provides a helper function for
+creating a brand new keypair.
 
 ```tsx
 const ownerKeypair = Keypair.generate();
 ```
 
-A keypair is of the data type `Keypair` and can be deconstructed into a public key:
+A keypair is of the data type `Keypair` and can be deconstructed into a public
+key:
 
 ```tsx
 const publicKey = ownerKeypair.publicKey;
@@ -59,7 +73,10 @@ const publicKey = ownerKeypair.publicKey;
 const secretKey = ownerKeypair.secretKey;
 ```
 
-If you already have a keypair you’d like to use, you can create a `Keypair` from the secret key using the `Keypair.fromSecretKey()` function. To ensure that your secret key stays secure, we recommend injecting it through an environment variable and not committing your `.env` file.
+If you already have a keypair you’d like to use, you can create a `Keypair` from
+the secret key using the `Keypair.fromSecretKey()` function. To ensure that your
+secret key stays secure, we recommend injecting it through an environment
+variable and not committing your `.env` file.
 
 ```tsx
 const secret = JSON.parse(process.env.PRIVATE_KEY ?? "") as number[];
@@ -77,11 +94,17 @@ Transaction instructions contain:
 - an array of accounts that will be read from and/or written to
 - data structured as a byte array that is specified to the program being invoked
 
-When you send a transaction to a Solana cluster, a Solana program is invoked with the instructions included in the transaction.
+When you send a transaction to a Solana cluster, a Solana program is invoked
+with the instructions included in the transaction.
 
-As you might expect, `@solana/web3.js` provides helper functions for creating transactions and instructions. You can create a new transaction with the constructor, `new Transaction()`. Once created, then you can add instructions to the transaction with the `add()` method.
+As you might expect, `@solana/web3.js` provides helper functions for creating
+transactions and instructions. You can create a new transaction with the
+constructor, `new Transaction()`. Once created, then you can add instructions to
+the transaction with the `add()` method.
 
-Instructions can get complicated when working with custom programs. Fortunately, `@solana/web3.js` has convenience functions for some of Solana’s native programs and basic operations, like transferring SOL:
+Instructions can get complicated when working with custom programs. Fortunately,
+`@solana/web3.js` has convenience functions for some of Solana’s native programs
+and basic operations, like transferring SOL:
 
 ```tsx
 const transaction = new Transaction();
@@ -101,7 +124,8 @@ The `SystemProgram.transfer()` function requires that you pass as parameters:
 - a public key corresponding to the recipient account
 - the amount of SOL to send in lamports.
 
-This function then returns the instruction for sending SOL from the sender to the recipient, after which the instruction can be added to the transaction.
+This function then returns the instruction for sending SOL from the sender to
+the recipient, after which the instruction can be added to the transaction.
 
 Once created, a transaction needs to be sent to the cluster and confirmed:
 
@@ -115,13 +139,22 @@ The `sendAndConfirmTransaction()` functions takes as parameters
 
 - a cluster connection
 - a transaction
-- an array of keypairs that will act as signers on the transaction - in this example, we only have the one signer: the sender.
+- an array of keypairs that will act as signers on the transaction - in this
+  example, we only have the one signer: the sender.
 
 ### Instructions
 
-The example of sending SOL is great for introducing you to sending transactions, but a lot of web3 development will involve calling non-native programs. In the example above, the `SystemProgram.transfer()` function ensures that you pass all the necessary data required to create the instruction, then it creates the instruction for you. When working with non-native programs, however, you’ll need to be very specific about creating instructions that are structured to match the corresponding program.
+The example of sending SOL is great for introducing you to sending transactions,
+but a lot of web3 development will involve calling non-native programs. In the
+example above, the `SystemProgram.transfer()` function ensures that you pass all
+the necessary data required to create the instruction, then it creates the
+instruction for you. When working with non-native programs, however, you’ll need
+to be very specific about creating instructions that are structured to match the
+corresponding program.
 
-With `@solana/web3.js`, you can create non-native instructions with the `TransactionInstruction` constructor. This constructor takes a single argument of the data type `TransactionInstructionCtorFields`.
+With `@solana/web3.js`, you can create non-native instructions with the
+`TransactionInstruction` constructor. This constructor takes a single argument
+of the data type `TransactionInstructionCtorFields`.
 
 ```tsx
 export type TransactionInstructionCtorFields = {
@@ -131,23 +164,34 @@ export type TransactionInstructionCtorFields = {
 };
 ```
 
-Per the definition above, the object passed to the `TransactionInstruction` constructor requires:
+Per the definition above, the object passed to the `TransactionInstruction`
+constructor requires:
 
 - an array of keys of type `AccountMeta`
 - the public key for the program being called
 - an optional `Buffer` containing data to pass to the program.
 
-We’ll be ignoring the `data` field for now and will revisit it in a future lesson.
+We’ll be ignoring the `data` field for now and will revisit it in a future
+lesson.
 
-The `programId` field is fairly self explanatory: it’s the public key associated with the program. You’ll need to know this in advance of calling the program in the same way that you’d need to know the public key of someone to whom you want to send SOL.
+The `programId` field is fairly self explanatory: it’s the public key associated
+with the program. You’ll need to know this in advance of calling the program in
+the same way that you’d need to know the public key of someone to whom you want
+to send SOL.
 
-The `keys` array requires a bit more explanation. Each object in this array represents an account that will be read from or written to during a transaction's execution. This means you need to know the behavior of the program you are calling and ensure that you provide all of the necessary accounts in the array.
+The `keys` array requires a bit more explanation. Each object in this array
+represents an account that will be read from or written to during a
+transaction's execution. This means you need to know the behavior of the program
+you are calling and ensure that you provide all of the necessary accounts in the
+array.
 
 Each object in the `keys` array must include the following:
 
 - `pubkey` - the public key of the account
-- `isSigner` - a boolean representing whether or not the account is a signer on the transaction
-- `isWritable` - a boolean representing whether or not the account is written to during the transaction's execution
+- `isSigner` - a boolean representing whether or not the account is a signer on
+  the transaction
+- `isWritable` - a boolean representing whether or not the account is written to
+  during the transaction's execution
 
 Putting this all together, we might end up with something like the following:
 
@@ -181,17 +225,29 @@ async function callProgram(
 
 ### Transaction Fees
 
-Transaction fees are built into the Solana economy as compensation to the validator network for the CPU and GPU resources required in processing transactions. Unlike many networks that have a fee market where users can pay higher fees to increase their chances of being included in the next block, Solana transaction fees are deterministic.
+Transaction fees are built into the Solana economy as compensation to the
+validator network for the CPU and GPU resources required in processing
+transactions. Unlike many networks that have a fee market where users can pay
+higher fees to increase their chances of being included in the next block,
+Solana transaction fees are deterministic.
 
-The first signer included in the array of signers on a transaction is responsible for paying the transaction fee. If this signer does not have enough SOL in their account to cover the transaction fee the transaction will be dropped.
+The first signer included in the array of signers on a transaction is
+responsible for paying the transaction fee. If this signer does not have enough
+SOL in their account to cover the transaction fee the transaction will be
+dropped.
 
-When testing, whether locally or on devnet, you can use the Solana CLI command `solana airdrop 1` to get free test SOL in your account for paying transaction fees.
+When testing, whether locally or on devnet, you can use the Solana CLI command
+`solana airdrop 1` to get free test SOL in your account for paying transaction
+fees.
 
 ### Solana Explorer
 
 ![Screenshot of Solana Explorer set to Devnet](../assets/solana-explorer-devnet.png)
 
-All transactions on the blockchain are publicly viewable on the [Solana Explorer](http://explorer.solana.com). For example, you could take the signature returned by `sendAndConfirmTransaction()` in the example above, search for that signature in the Solana Explorer, then see:
+All transactions on the blockchain are publicly viewable on the
+[Solana Explorer](http://explorer.solana.com). For example, you could take the
+signature returned by `sendAndConfirmTransaction()` in the example above, search
+for that signature in the Solana Explorer, then see:
 
 - when it occurred
 - which block it was included in
@@ -202,11 +258,18 @@ All transactions on the blockchain are publicly viewable on the [Solana Explorer
 
 # Demo
 
-We’re going to create a script to ping a simple program that increments a counter each time it has been pinged. This program exists on the Solana Devnet at address `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa`. The program stores the count data in a specific account at the address `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
+We’re going to create a script to ping a simple program that increments a
+counter each time it has been pinged. This program exists on the Solana Devnet
+at address `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa`. The program stores
+the count data in a specific account at the address
+`Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
 
 ### 1. Basic scaffolding
 
-Let’s start with some basic scaffolding. You’re welcome to set up your project however feels most appropriate, but we’ll be using a simple Typescript project with a dependency on the @solana/web3.js package. If you want to use our scaffolding, you can use the following commands in the command line:
+Let’s start with some basic scaffolding. You’re welcome to set up your project
+however feels most appropriate, but we’ll be using a simple Typescript project
+with a dependency on the @solana/web3.js package. If you want to use our
+scaffolding, you can use the following commands in the command line:
 
 ```bash
 mkdir -p solana-ping-client/src && \
@@ -236,7 +299,8 @@ This will:
 10. install the `.dotenv` dependency
 11. create a `.env` file
 
-If you want to match our code exactly, replace the contents of `tsconfig.json` with the following:
+If you want to match our code exactly, replace the contents of `tsconfig.json`
+with the following:
 
 ```json
 {
@@ -269,7 +333,8 @@ And finally, add the following to the `scripts` object in `package.json`:
 
 ### 2. Generate a new keypair
 
-Before you can do anything, you’ll need a keypair. Let’s jump into the `index.ts` file and generate one:
+Before you can do anything, you’ll need a keypair. Let’s jump into the
+`index.ts` file and generate one:
 
 ```tsx
 import web3 = require("@solana/web3.js");
@@ -290,11 +355,19 @@ main()
   });
 ```
 
-Most of this code is just boilerplate to run the file properly. The lines inside of the `main()` function generate a new keypair and log the secret key to the console.
+Most of this code is just boilerplate to run the file properly. The lines inside
+of the `main()` function generate a new keypair and log the secret key to the
+console.
 
-Run `npm start` after saving this file and you should see an array of numbers printed to the console. This array represents the secret key for your new keypair. **Do not** use this keypair for Mainnet operations. **Only use this keypair for testing.**
+Run `npm start` after saving this file and you should see an array of numbers
+printed to the console. This array represents the secret key for your new
+keypair. **Do not** use this keypair for Mainnet operations. **Only use this
+keypair for testing.**
 
-Copy the secret key array from the console log and paste it into the `.env` file as an environment variable called, `PRIVATE_KEY`. This way we can reuse this keypair in future development instead of generating a new keypair every time we run something. It should look something like this but with different numbers:
+Copy the secret key array from the console log and paste it into the `.env` file
+as an environment variable called, `PRIVATE_KEY`. This way we can reuse this
+keypair in future development instead of generating a new keypair every time we
+run something. It should look something like this but with different numbers:
 
 ```
 PRIVATE_KEY=[56,83,31,62,66,154,33,74,106,59,111,224,176,237,89,224,10,220,28,222,128,36,138,89,30,252,100,209,206,155,154,65,98,194,97,182,98,162,107,238,61,183,163,215,44,6,10,49,218,156,5,131,125,253,247,190,181,196,0,249,40,149,119,246]
@@ -302,9 +375,12 @@ PRIVATE_KEY=[56,83,31,62,66,154,33,74,106,59,111,224,176,237,89,224,10,220,28,22
 
 ### 3. Initialize Keypair from secret
 
-Now that we’ve successfully generated a keypair and copied it to the `.env` file, we can remove the code inside of the `main()` function.
+Now that we’ve successfully generated a keypair and copied it to the `.env`
+file, we can remove the code inside of the `main()` function.
 
-We’ll return to the `main()` function soon, but for now let’s create a new function outside of `main()` called `initializeKeypair()`. Inside of this new function:
+We’ll return to the `main()` function soon, but for now let’s create a new
+function outside of `main()` called `initializeKeypair()`. Inside of this new
+function:
 
 1. parse the `PRIVATE_KEY` environment variable as `number[]`
 2. use it to initialize a `Uint8Array`
@@ -321,7 +397,9 @@ function initializeKeypair(): web3.Keypair {
 
 ### 4. Ping program
 
-Now that we have a way of initializing our keypair, we need to establish a connection with Solana’s Devnet. In `main()`, let’s invoke `initializeKeypair()` and create a connection:
+Now that we have a way of initializing our keypair, we need to establish a
+connection with Solana’s Devnet. In `main()`, let’s invoke `initializeKeypair()`
+and create a connection:
 
 ```tsx
 async function main() {
@@ -330,7 +408,8 @@ async function main() {
 }
 ```
 
-Now create an async function outside of `main()` called `pingProgram()` with two parameters requiring a connection and a payer’s keypair as arguments:
+Now create an async function outside of `main()` called `pingProgram()` with two
+parameters requiring a connection and a payer’s keypair as arguments:
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {}
@@ -343,14 +422,20 @@ Inside this function, we need to:
 3. add the instruction to the transaction
 4. send the transaction.
 
-Remember, the most challenging piece here is including the right information in the instruction. We know the address of the program that we are calling. We also know that the program writes data to a separate account whose address we also have. Let’s add the string versions of both of those as constants at the top of the `index.ts` file:
+Remember, the most challenging piece here is including the right information in
+the instruction. We know the address of the program that we are calling. We also
+know that the program writes data to a separate account whose address we also
+have. Let’s add the string versions of both of those as constants at the top of
+the `index.ts` file:
 
 ```tsx
 const PROGRAM_ADDRESS = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
 const PROGRAM_DATA_ADDRESS = "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
 ```
 
-Now, in the `pingProgram()` function, let’s create a new transaction, then initialize a `PublicKey` for the program account, and another for the data account.
+Now, in the `pingProgram()` function, let’s create a new transaction, then
+initialize a `PublicKey` for the program account, and another for the data
+account.
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
@@ -361,7 +446,10 @@ async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
 }
 ```
 
-Next, let’s create the instruction. Remember, the instruction needs to include the public key for the program and it also needs to include an array with all the accounts that will be read from or written to. In this example program, only the data account referenced above is needed.
+Next, let’s create the instruction. Remember, the instruction needs to include
+the public key for the program and it also needs to include an array with all
+the accounts that will be read from or written to. In this example program, only
+the data account referenced above is needed.
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
@@ -383,7 +471,10 @@ async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
 }
 ```
 
-Next, let’s add the instruction to the transaction we created at the start of the function. Then, call upon `sendAndConfirmTransaction()` by passing in the connection, transaction, and payer. Finally, let’s log the result of that function call so we can look it up on the Solana Explorer.
+Next, let’s add the instruction to the transaction we created at the start of
+the function. Then, call upon `sendAndConfirmTransaction()` by passing in the
+connection, transaction, and payer. Finally, let’s log the result of that
+function call so we can look it up on the Solana Explorer.
 
 ```tsx
 async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
@@ -415,7 +506,8 @@ async function pingProgram(connection: web3.Connection, payer: web3.Keypair) {
 }
 ```
 
-Finally, let's invoke `pingProgram()` within `main()` using `connection` and `payer`:
+Finally, let's invoke `pingProgram()` within `main()` using `connection` and
+`payer`:
 
 ```tsx
 async function main() {
@@ -427,31 +519,47 @@ async function main() {
 
 ### 5. Airdrop
 
-Now run the code with `npm start` and see if it works. You may end up with the following error in the console:
+Now run the code with `npm start` and see if it works. You may end up with the
+following error in the console:
 
-> Transaction simulation failed: Attempt to debit an account but found no record of a prior credit.
+> Transaction simulation failed: Attempt to debit an account but found no record
+> of a prior credit.
 
-If you get this error, it’s because your keypair is brand new and doesn’t have any SOL to cover the transaction fees. Let’s fix this by adding the following line in `main()` before the call to `pingProgram()`:
+If you get this error, it’s because your keypair is brand new and doesn’t have
+any SOL to cover the transaction fees. Let’s fix this by adding the following
+line in `main()` before the call to `pingProgram()`:
 
 ```tsx
 await connection.requestAirdrop(payer.publicKey, web3.LAMPORTS_PER_SOL * 1);
 ```
 
-This will deposit 1 SOL into your account which you can use for testing. This won’t work on Mainnet where it would actually have value. But it's incredibly convenient for testing locally and on Devnet.
+This will deposit 1 SOL into your account which you can use for testing. This
+won’t work on Mainnet where it would actually have value. But it's incredibly
+convenient for testing locally and on Devnet.
 
 ### 6. Check the Solana explorer
 
-Now run the code again. It may take a moment or two, but now the code should work and you should see a long string printed to the console, like the following:
+Now run the code again. It may take a moment or two, but now the code should
+work and you should see a long string printed to the console, like the
+following:
 
 ```
 55S47uwMJprFMLhRSewkoUuzUs5V6BpNfRx21MpngRUQG3AswCzCSxvQmS3WEPWDJM7bhHm3bYBrqRshj672cUSG
 ```
 
-Copy this confirmation signature. Open a browser and go to [https://explorer.solana.com/?cluster=devnet](https://explorer.solana.com/?cluster=devnet) (the query parameter at the end of the URL will ensure that you’ll explore transactions on Devnet instead of Mainnet). Paste the signature into the search bar at the top of Solana’s Devnet explorer and hit enter. You should see all the details about the transaction. If you scroll all the way to the bottom, then you will see `Program Logs`, which show how many times the program has been pinged including your ping.
+Copy this confirmation signature. Open a browser and go to
+[https://explorer.solana.com/?cluster=devnet](https://explorer.solana.com/?cluster=devnet)
+(the query parameter at the end of the URL will ensure that you’ll explore
+transactions on Devnet instead of Mainnet). Paste the signature into the search
+bar at the top of Solana’s Devnet explorer and hit enter. You should see all the
+details about the transaction. If you scroll all the way to the bottom, then you
+will see `Program Logs`, which show how many times the program has been pinged
+including your ping.
 
 ![Screenshot of Solana Explorer with logs from calling the Ping program](../assets/solana-explorer-ping-result.png)
 
-If you want to make it easier to look at Solana Explorer for transactions in the future, simply change your `console.log` in `pingProgram()` to the following:
+If you want to make it easier to look at Solana Explorer for transactions in the
+future, simply change your `console.log` in `pingProgram()` to the following:
 
 ```tsx
 console.log(
@@ -459,7 +567,8 @@ console.log(
 );
 ```
 
-And just like that you’re calling programs on the Solana network and writing data to chain!
+And just like that you’re calling programs on the Solana network and writing
+data to chain!
 
 In the next few lessons you’ll learn how to
 
@@ -469,6 +578,9 @@ In the next few lessons you’ll learn how to
 
 # Challenge
 
-Go ahead and create a script from scratch that will allow you to transfer SOL from one account to another on Devnet. Be sure to print out the transaction signature so you can look at it on the Solana Explorer.
+Go ahead and create a script from scratch that will allow you to transfer SOL
+from one account to another on Devnet. Be sure to print out the transaction
+signature so you can look at it on the Solana Explorer.
 
-If you get stuck feel free to glance at the [solution code](https://github.com/Unboxed-Software/solana-send-sol-client).
+If you get stuck feel free to glance at the
+[solution code](https://github.com/Unboxed-Software/solana-send-sol-client).

--- a/developers/courses/solana-course/content/local-setup.md
+++ b/developers/courses/solana-course/content/local-setup.md
@@ -1,11 +1,11 @@
 ---
 title: Local Program Development
 objectives:
-- Set up a local environment for Solana program development
-- Use basic Solana CLI commands
-- Run a local test validator
-- Use Rust and the Solana CLI to deploy a Solana program from your local development environment
-- Use the Solana CLI to view program logs
+  - Set up a local environment for Solana program development
+  - Use basic Solana CLI commands
+  - Run a local test validator
+  - Use Rust and the Solana CLI to deploy a Solana program from your local development environment
+  - Use the Solana CLI to view program logs
 ---
 
 # TL;DR
@@ -352,7 +352,7 @@ let connection = new web3.Connection(web3.clusterApiUrl("devnet"));
 
 ```tsx
 console.log(
-    `Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`
+  `Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`,
 );
 ```
 

--- a/developers/courses/solana-course/content/local-setup.md
+++ b/developers/courses/solana-course/content/local-setup.md
@@ -4,26 +4,44 @@ objectives:
   - Set up a local environment for Solana program development
   - Use basic Solana CLI commands
   - Run a local test validator
-  - Use Rust and the Solana CLI to deploy a Solana program from your local development environment
+  - Use Rust and the Solana CLI to deploy a Solana program from your local
+    development environment
   - Use the Solana CLI to view program logs
 ---
 
 # TL;DR
 
-- To get started with Solana locally, you’ll first need to install **Rust** and the **Solana CLI**
-- Using the Solana CLI you can run a **local test validator** using the `solana-test-validator` command
-- Once you have Rust and Solana CLI installed, you’ll be able to build and deploy your programs locally using the `cargo build-bpf` and `solana program deploy` commands
+- To get started with Solana locally, you’ll first need to install **Rust** and
+  the **Solana CLI**
+- Using the Solana CLI you can run a **local test validator** using the
+  `solana-test-validator` command
+- Once you have Rust and Solana CLI installed, you’ll be able to build and
+  deploy your programs locally using the `cargo build-bpf` and
+  `solana program deploy` commands
 - You can view program logs using the `solana logs` command
 
 # Overview
 
-So far in this course, we've used Solana Playground to develop and deploy Solana programs. And while it's a great tool, for certain complex projects you may prefer to have a local development environment set up. This may be in order to use crates not supported by Solana Playground, to take advantage of custom scripts or tooling you've created, or simply out of personal preference.
+So far in this course, we've used Solana Playground to develop and deploy Solana
+programs. And while it's a great tool, for certain complex projects you may
+prefer to have a local development environment set up. This may be in order to
+use crates not supported by Solana Playground, to take advantage of custom
+scripts or tooling you've created, or simply out of personal preference.
 
-With that said, this lesson will be slightly different from the others. Instead of covering a lot of ground on how to write a program or interact with the Solana network, this lesson will primarily focus on the less glamorous task of setting up your local development environment.
+With that said, this lesson will be slightly different from the others. Instead
+of covering a lot of ground on how to write a program or interact with the
+Solana network, this lesson will primarily focus on the less glamorous task of
+setting up your local development environment.
 
-In order to build, test, and deploy Solana programs from your machine, you'll need to install the Rust compiler and the Solana Command Line Interface (CLI). We'll start by guiding you through these installation processes, then cover how to use what you'll have just installed.
+In order to build, test, and deploy Solana programs from your machine, you'll
+need to install the Rust compiler and the Solana Command Line Interface (CLI).
+We'll start by guiding you through these installation processes, then cover how
+to use what you'll have just installed.
 
-The installation instructions below contain the steps for installing Rust and the Solana CLI at the time of writing. They may have changed by the time you're reading this, so if you run into issues please consult the official installation pages for each:
+The installation instructions below contain the steps for installing Rust and
+the Solana CLI at the time of writing. They may have changed by the time you're
+reading this, so if you run into issues please consult the official installation
+pages for each:
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
 - [Install the Solana Tool Suite](https://docs.solana.com/cli/install-solana-cli-tools)
@@ -32,31 +50,41 @@ The installation instructions below contain the steps for installing Rust and th
 
 ### Download Windows Subsystem for Linux (WSL)
 
-If you are on a Windows computer, it is recommended to use Windows Subsystem for Linux (WSL) to build your Solana Programs.
+If you are on a Windows computer, it is recommended to use Windows Subsystem for
+Linux (WSL) to build your Solana Programs.
 
-Open an **administrator** PowerShell or Windows Command Prompt and check Windows version
+Open an **administrator** PowerShell or Windows Command Prompt and check Windows
+version
 
 ```bash
 winver
 ```
 
-If you are on Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11, run the following command.
+If you are on Windows 10 version 2004 and higher (Build 19041 and higher) or
+Windows 11, run the following command.
 
 ```bash
 wsl --install
 ```
 
-If you are running an older version of Windows, follow the instructions [here](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
+If you are running an older version of Windows, follow the instructions
+[here](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
 
-You can read more about installing WSL [here](https://docs.microsoft.com/en-us/windows/wsl/install).
+You can read more about installing WSL
+[here](https://docs.microsoft.com/en-us/windows/wsl/install).
 
 ### Download Ubuntu
 
-Next, download Ubuntu [here](https://apps.microsoft.com/store/detail/ubuntu-2004/9N6SVWS3RX71?hl=en-us&gl=US). Ubuntu provides a terminal that allows you to run Linux on a Windows computer. This is where you’ll be running Solana CLI commands.
+Next, download Ubuntu
+[here](https://apps.microsoft.com/store/detail/ubuntu-2004/9N6SVWS3RX71?hl=en-us&gl=US).
+Ubuntu provides a terminal that allows you to run Linux on a Windows computer.
+This is where you’ll be running Solana CLI commands.
 
 ### Download Rust (for WSL)
 
-Next, open an Ubuntu terminal and download Rust for WSL using the following command. You can read more about downloading Rust [here](https://www.rust-lang.org/learn/get-started).
+Next, open an Ubuntu terminal and download Rust for WSL using the following
+command. You can read more about downloading Rust
+[here](https://www.rust-lang.org/learn/get-started).
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -64,7 +92,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Download Solana CLI
 
-Now we are ready to download Solana CLI for Linux. Go ahead and run the following command in an Ubuntu terminal. You can read more about downloading Solana CLI [here](https://docs.solana.com/cli/install-solana-cli-tools).
+Now we are ready to download Solana CLI for Linux. Go ahead and run the
+following command in an Ubuntu terminal. You can read more about downloading
+Solana CLI [here](https://docs.solana.com/cli/install-solana-cli-tools).
 
 ```bash
 sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
@@ -74,7 +104,8 @@ sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
 
 ### Download Rust
 
-First, download Rust by following the instructions [here](https://www.rust-lang.org/tools/install)
+First, download Rust by following the instructions
+[here](https://www.rust-lang.org/tools/install)
 
 ### Download the Solana CLI
 
@@ -84,17 +115,22 @@ Next, download the Solana CLI by running the following command in your terminal.
 sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
 ```
 
-You can read more about downloading the Solana CLI [here](https://docs.solana.com/cli/install-solana-cli-tools).
+You can read more about downloading the Solana CLI
+[here](https://docs.solana.com/cli/install-solana-cli-tools).
 
 ## Solana CLI basics
 
-The Solana CLI is a command-line interface tool that provides a collection of commands for interacting with a Solana cluster.
+The Solana CLI is a command-line interface tool that provides a collection of
+commands for interacting with a Solana cluster.
 
-We'll cover some of the most common commands in this lesson, but you can always view the list of all possible Solana CLI commands by running `solana --help`.
+We'll cover some of the most common commands in this lesson, but you can always
+view the list of all possible Solana CLI commands by running `solana --help`.
 
 ### Solana CLI configuration
 
-The Solana CLI stores a number of configuration settings that impact the behavior of certain commands. You can use the following command to view the current configuration:
+The Solana CLI stores a number of configuration settings that impact the
+behavior of certain commands. You can use the following command to view the
+current configuration:
 
 ```bash
 solana config get
@@ -103,14 +139,19 @@ solana config get
 The `solana config get` command will return the following:
 
 - `Config File` - the file Solana CLI is located on your computer
-- `RPC URL` - endpoint you are using, connecting you to localhost, Devnet, or Mainnet
-- `WebSocket URL` - the websocket to listen for events from the cluster you are targeting (computed when you set the `RPC URL`)
+- `RPC URL` - endpoint you are using, connecting you to localhost, Devnet, or
+  Mainnet
+- `WebSocket URL` - the websocket to listen for events from the cluster you are
+  targeting (computed when you set the `RPC URL`)
 - `Keypair Path` - the keypair path used when running Solana CLI subcommands
-- `Commitment` - provides a measure of the network confirmation and describes how finalized a block is at that point in time
+- `Commitment` - provides a measure of the network confirmation and describes
+  how finalized a block is at that point in time
 
-You can change your Solana CLI configuration at any time by using the `solana config set` command followed by the setting you want to update.
+You can change your Solana CLI configuration at any time by using the
+`solana config set` command followed by the setting you want to update.
 
-The most common change will be to the cluster you are targeting. Use the `solana config set --url` command to change the `RPC URL`.
+The most common change will be to the cluster you are targeting. Use the
+`solana config set --url` command to change the `RPC URL`.
 
 ```bash
 solana config set --url localhost
@@ -124,7 +165,9 @@ solana config set --url devnet
 solana config set --url mainnet-beta
 ```
 
-Similarly, you can use the `solana config set --keypair` command to change the `Keypair Path`. Solana CLI will then use the keypair from the specified path when running commands.
+Similarly, you can use the `solana config set --keypair` command to change the
+`Keypair Path`. Solana CLI will then use the keypair from the specified path
+when running commands.
 
 ```bash
 solana config set --keypair ~/<FILE_PATH>
@@ -132,65 +175,93 @@ solana config set --keypair ~/<FILE_PATH>
 
 ### Test validators
 
-You'll often find it helpful to run a local validator for testing and debugging rather than deploying to Devnet.
+You'll often find it helpful to run a local validator for testing and debugging
+rather than deploying to Devnet.
 
-You can run a local test validator using the `solana-test-validator` command. This command creates an ongoing process that will require its own command line window.
+You can run a local test validator using the `solana-test-validator` command.
+This command creates an ongoing process that will require its own command line
+window.
 
 ### Stream program logs
 
-It's often helpful to open a new console and run the `solana logs` command alongside the test validator. This creates another ongoing process that will stream the logs associated with your configuration's cluster.
+It's often helpful to open a new console and run the `solana logs` command
+alongside the test validator. This creates another ongoing process that will
+stream the logs associated with your configuration's cluster.
 
-If your CLI configuration is pointed to `localhost` then the logs will always be associated with the test validator you've created, but you can also stream logs from other clusters like Devnet and Mainnet Beta. When streaming logs from other clusters, you'll want to include a program ID with the command to limit the logs you see to your specific program.
+If your CLI configuration is pointed to `localhost` then the logs will always be
+associated with the test validator you've created, but you can also stream logs
+from other clusters like Devnet and Mainnet Beta. When streaming logs from other
+clusters, you'll want to include a program ID with the command to limit the logs
+you see to your specific program.
 
 ### Keypairs
 
-You can generate a new keypair using the `solana-keygen new --outfile` command followed by the file path to store the keypair.
+You can generate a new keypair using the `solana-keygen new --outfile` command
+followed by the file path to store the keypair.
 
 ```bash
 solana-keygen new --outfile ~/<FILE_PATH>
 ```
 
-At times you may need to check which keypair your configuration is pointed to. To view the `publickey` of the current keypair set in `solana config`, use the `solana address` command.
+At times you may need to check which keypair your configuration is pointed to.
+To view the `publickey` of the current keypair set in `solana config`, use the
+`solana address` command.
 
 ```bash
 solana address
 ```
 
-To view the SOL balance of the current keypair set in `solana config`, use the `solana balance` command.
+To view the SOL balance of the current keypair set in `solana config`, use the
+`solana balance` command.
 
 ```bash
 solana balance
 ```
 
-To airdrop SOL on Devnet or localhost, use the `solana airdrop` command. Note that while on Devnet you are limited to 2 SOL per airdrop.
+To airdrop SOL on Devnet or localhost, use the `solana airdrop` command. Note
+that while on Devnet you are limited to 2 SOL per airdrop.
 
 ```bash
 solana airdrop 2
 ```
 
-As you develop and test programs in your local environment, you'll likely encounter errors that are caused by:
+As you develop and test programs in your local environment, you'll likely
+encounter errors that are caused by:
 
 - Using the wrong keypair
 - Not having enough SOL to deploy your program or perform a transaction
 - Pointing to the wrong cluster
 
-The CLI commands we've covered so far should help you quickly resolve those issues.
+The CLI commands we've covered so far should help you quickly resolve those
+issues.
 
 ## Develop Solana programs in your local environment
 
-While the Solana Playground is enormously helpful, it's hard to beat the flexibility of your own local development environment. As you build more complex programs, you may end up integrating them with one or more clients that are also under development in your local environment. Testing between these programs and clients is often simpler when you write, build, and deploy your programs locally.
+While the Solana Playground is enormously helpful, it's hard to beat the
+flexibility of your own local development environment. As you build more complex
+programs, you may end up integrating them with one or more clients that are also
+under development in your local environment. Testing between these programs and
+clients is often simpler when you write, build, and deploy your programs
+locally.
 
 ### Create a new project
 
-To create a new Rust package to write a Solana program, you can use the `cargo new --lib` command with the name of the new directory you'd like to create.
+To create a new Rust package to write a Solana program, you can use the
+`cargo new --lib` command with the name of the new directory you'd like to
+create.
 
 ```bash
 cargo new --lib <PROJECT_DIRECTORY_NAME>
 ```
 
-This command will create a new directory with the name you specified at the end of the command. This new directory will contain a `Cargo.toml` manifest file that describes the package.
+This command will create a new directory with the name you specified at the end
+of the command. This new directory will contain a `Cargo.toml` manifest file
+that describes the package.
 
-The manifest file contains metadata such as name, version, and dependencies (crates). To write a Solana program, you’ll need to update the `Cargo.toml` file to include `solana-program` as a dependency. You may also need to add the `[lib]` and `crate-type` lines shown below.
+The manifest file contains metadata such as name, version, and dependencies
+(crates). To write a Solana program, you’ll need to update the `Cargo.toml` file
+to include `solana-program` as a dependency. You may also need to add the
+`[lib]` and `crate-type` lines shown below.
 
 ```rust
 [package]
@@ -212,13 +283,15 @@ At that point, you can start writing your program in the `src` folder.
 
 ### Build and deploy
 
-When it comes time to build your Solana program, you can use the `cargo build-bpf` command.
+When it comes time to build your Solana program, you can use the
+`cargo build-bpf` command.
 
 ```bash
 cargo build-bpf
 ```
 
-The output of this command will include instructions for a deploying your program that look something like this:
+The output of this command will include instructions for a deploying your
+program that look something like this:
 
 ```text
 To deploy this program:
@@ -227,7 +300,9 @@ The program address will default to this keypair (override with --program-id):
   /Users/James/Dev/Work/solana-hello-world-local/target/deploy/solana_hello_world_local-keypair.json
 ```
 
-When you are ready to deploy the program, use the `solana program deploy` command output from `cargo build-bpf`. This will deploy your program to the cluster specified in your CLI configuration.
+When you are ready to deploy the program, use the `solana program deploy`
+command output from `cargo build-bpf`. This will deploy your program to the
+cluster specified in your CLI configuration.
 
 ```rust
 solana program deploy <PATH>
@@ -235,19 +310,25 @@ solana program deploy <PATH>
 
 # Demo
 
-Let's practice by building and deploying the "Hello World!" program that we created in the [Hello World lesson](https://github.com/Unboxed-Software/solana-course/pull/content/hello-world-program.md).
+Let's practice by building and deploying the "Hello World!" program that we
+created in
+the [Hello World lesson](https://github.com/Unboxed-Software/solana-course/pull/content/hello-world-program.md).
 
-We'll do this all locally, including deploying to a local test validator. Before we begin, make sure you've installed Rust and the Solana CLI. You can refer to the instructions in the overview to get set up if you haven't already.
+We'll do this all locally, including deploying to a local test validator. Before
+we begin, make sure you've installed Rust and the Solana CLI. You can refer to
+the instructions in the overview to get set up if you haven't already.
 
 ### 1. Create a new Rust project
 
-Let's start by creating a new Rust project. Run the `cargo new --lib` command below. Feel free to replace the directory name with your own.
+Let's start by creating a new Rust project. Run the `cargo new --lib` command
+below. Feel free to replace the directory name with your own.
 
 ```bash
 cargo new --lib solana-hello-world-local
 ```
 
-Remember to update the `cargo.toml` file to include `solana-program` as a dependency and the `crate-type` if isn't there already.
+Remember to update the `cargo.toml` file to include `solana-program` as a
+dependency and the `crate-type` if isn't there already.
 
 ```bash
 [package]
@@ -264,7 +345,8 @@ crate-type = ["cdylib", "lib"]
 
 ### 2. Write your program
 
-Next, update `lib.rs` with the “Hello World!” program below. This program simply prints “Hello, world!” to the program log when the program is invoked.
+Next, update `lib.rs` with the “Hello World!” program below. This program simply
+prints “Hello, world!” to the program log when the program is invoked.
 
 ```rust
 use solana_program::{
@@ -290,19 +372,23 @@ pub fn process_instruction(
 
 ### 3. Run a local test validator
 
-With your program written, let's make sure our Solana CLI configuration points to localhost by using the `solana config set --url` command.
+With your program written, let's make sure our Solana CLI configuration points
+to localhost by using the `solana config set --url` command.
 
 ```bash
 solana config set --url localhost
 ```
 
-Next, check that the Solana CLI configuration has updated using the `solana config get` command.
+Next, check that the Solana CLI configuration has updated using the
+`solana config get` command.
 
 ```bash
 solana config get
 ```
 
-Finally, run a local test validator. In a separate terminal window, run the `solana-test-validator` command. This is only necessary when our `RPC URL` is set to localhost.
+Finally, run a local test validator. In a separate terminal window, run the
+`solana-test-validator` command. This is only necessary when our `RPC URL` is
+set to localhost.
 
 ```bash
 solana-test-validator
@@ -310,41 +396,60 @@ solana-test-validator
 
 ### 4. Build and deploy
 
-We're now ready to build and deploy our program. Build the program by running the `cargo build-bpf` command.
+We're now ready to build and deploy our program. Build the program by running
+the `cargo build-bpf` command.
 
 ```bash
 cargo build-bpf
 ```
 
-Now let's deploy our program. Run the `solana program deploy` command output from `cargo build-bpf`.
+Now let's deploy our program. Run the `solana program deploy` command output
+from `cargo build-bpf`.
 
 ```bash
 solana program deploy <PATH>
 ```
 
-The `solana program deploy` will output the `Program ID` for your program. You can now look up deployed program on [Solana Explorer](https://explorer.solana.com/?cluster=custom) (for localhost, select “Custom RPC URL” as the cluster).
+The `solana program deploy` will output the `Program ID` for your program. You
+can now look up deployed program on
+[Solana Explorer](https://explorer.solana.com/?cluster=custom) (for localhost,
+select “Custom RPC URL” as the cluster).
 
 ### 5. View program logs
 
-Before we invoke our program, open a separate terminal and run the `solana logs` command. This will allow use to view the program logs in the terminal.
+Before we invoke our program, open a separate terminal and run the `solana logs`
+command. This will allow use to view the program logs in the terminal.
 
 ```bash
 solana logs <PROGRAM_ID>
 ```
 
-With the test validator still running, try invoking your program using the client-side script [here](https://github.com/Unboxed-Software/solana-hello-world-client).
+With the test validator still running, try invoking your program using the
+client-side script
+[here](https://github.com/Unboxed-Software/solana-hello-world-client).
 
-Replace the program ID in `index.ts` with the one from the program you just deployed, then run `npm install` followed by `npm start`. This will return a Solana Explorer URL. Copy the URL into the browser to look up the transaction on Solana Explorer and check that “Hello, world!” was printed to the program log. Alternatively, you can view the program logs in the terminal where you ran the `solana logs` command.
+Replace the program ID in `index.ts` with the one from the program you just
+deployed, then run `npm install` followed by `npm start`. This will return a
+Solana Explorer URL. Copy the URL into the browser to look up the transaction on
+Solana Explorer and check that “Hello, world!” was printed to the program log.
+Alternatively, you can view the program logs in the terminal where you ran the
+`solana logs` command.
 
-And that's it! You've just created and deployed your first program from a local development environment.
+And that's it! You've just created and deployed your first program from a local
+development environment.
 
 # Challenge
 
-Now it’s your turn to build something independently. Try to create a new program to print your own message to the program logs. This time deploy your program to Devnet instead of localhost.
+Now it’s your turn to build something independently. Try to create a new program
+to print your own message to the program logs. This time deploy your program to
+Devnet instead of localhost.
 
-Remember to update your `RPC URL` to Devnet using the `solana config set --url` command.
+Remember to update your `RPC URL` to Devnet using the `solana config set --url`
+command.
 
-You can invoke the program using the same client-side script from the demo as long as you update the `connection` and Solana Explorer URL to both point to Devnet instead of localhost.
+You can invoke the program using the same client-side script from the demo as
+long as you update the `connection` and Solana Explorer URL to both point to
+Devnet instead of localhost.
 
 ```tsx
 let connection = new web3.Connection(web3.clusterApiUrl("devnet"));
@@ -356,7 +461,12 @@ console.log(
 );
 ```
 
-You can also open a separate command line window and use the `solana logs | grep "<PROGRAM_ID> invoke" -A <NUMBER_OF_LINES_TO_RETURN>`. When using `solana logs` on Devnet you must specify the program ID. Otherwise, the `solana logs` command will return a constant stream of logs from Devnet. For example, you would do the following to monitor invocations to the Token Program and show the first 5 lines of logs for each invocation:
+You can also open a separate command line window and use the
+`solana logs | grep "<PROGRAM_ID> invoke" -A <NUMBER_OF_LINES_TO_RETURN>`. When
+using `solana logs` on Devnet you must specify the program ID. Otherwise, the
+`solana logs` command will return a constant stream of logs from Devnet. For
+example, you would do the following to monitor invocations to the Token Program
+and show the first 5 lines of logs for each invocation:
 
 ```bash
 solana logs | grep "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke" -A 5

--- a/developers/courses/solana-course/content/nfts-with-metaplex.md
+++ b/developers/courses/solana-course/content/nfts-with-metaplex.md
@@ -4,58 +4,109 @@ objectives:
   - Explain NFTs and how they're represented on the Solana network
   - Explain the role of Metaplex in the Solana NFT ecosystem
   - Create and update NFTs using the Metaplex SDK
-  - Explain the basic functionality of the Token Metadata program, Candy Machine program, and Sugar CLI as tools that assist in creating and distributing NFTs on Solana
+  - Explain the basic functionality of the Token Metadata program, Candy Machine
+    program, and Sugar CLI as tools that assist in creating and distributing
+    NFTs on Solana
 ---
 
 # TL;DR
 
-- **Non-Fungible Tokens (NFTs)** are represented on Solana as SPL Tokens with an associated metadata account, 0 decimals, and a maximum supply of 1
-- **Metaplex** offers a collection of tools that simplify the creation and distribution of NFTs on the Solana blockchain
-- The **Token Metadata** program standardizes the process of attaching metadata to SPL Tokens
-- The **Metaplex SDK** is a tool that offers user-friendly APIs to assist developers in utilizing the on-chain tools provided by Metaplex
-- The **Candy Machine** program is an NFT distribution tool used to create and mint NFTs from a collection
-- **Sugar CLI** is a tool that simplifies the process of uploading media/metadata files and creating a Candy Machine for a collection
+- **Non-Fungible Tokens (NFTs)** are represented on Solana as SPL Tokens with an
+  associated metadata account, 0 decimals, and a maximum supply of 1
+- **Metaplex** offers a collection of tools that simplify the creation and
+  distribution of NFTs on the Solana blockchain
+- The **Token Metadata** program standardizes the process of attaching metadata
+  to SPL Tokens
+- The **Metaplex SDK** is a tool that offers user-friendly APIs to assist
+  developers in utilizing the on-chain tools provided by Metaplex
+- The **Candy Machine** program is an NFT distribution tool used to create and
+  mint NFTs from a collection
+- **Sugar CLI** is a tool that simplifies the process of uploading
+  media/metadata files and creating a Candy Machine for a collection
 
 # Overview
 
-Solana Non-Fungible Tokens (NFTs) are SPL tokens created using the Token program. These tokens, however, also have an additional metadata account associated with each token mint. This allows for a wide variety of use cases for tokens. You can effectively tokenize anything, from game inventory to art.
+Solana Non-Fungible Tokens (NFTs) are SPL tokens created using the Token
+program. These tokens, however, also have an additional metadata account
+associated with each token mint. This allows for a wide variety of use cases for
+tokens. You can effectively tokenize anything, from game inventory to art.
 
-In this lesson, we'll cover the basics of how NFTs are represented on Solana, how to create and update them using the Metaplex SDK, and provide a brief introduction to tools that can assist you in creating and distributing NFTs on Solana at scale.
+In this lesson, we'll cover the basics of how NFTs are represented on Solana,
+how to create and update them using the Metaplex SDK, and provide a brief
+introduction to tools that can assist you in creating and distributing NFTs on
+Solana at scale.
 
 ## NFTs on Solana
 
-A Solana NFT is a non-divisible token with associated metadata. Further, the token's mint has a maximum supply of 1.
+A Solana NFT is a non-divisible token with associated metadata. Further, the
+token's mint has a maximum supply of 1.
 
-In other words, an NFT is a standard token from the Token Program but differs from what you might think of as "standard tokens" in that it:
+In other words, an NFT is a standard token from the Token Program but differs
+from what you might think of as "standard tokens" in that it:
 
 1. Has 0 decimals so that it cannot be divided into parts
-2. Comes from a token mint with supply of 1 so that only 1 of these tokens exists
-3. Comes from a token mint whose authority is set to `null` (to ensure that the supply never changes)
+2. Comes from a token mint with supply of 1 so that only 1 of these tokens
+   exists
+3. Comes from a token mint whose authority is set to `null` (to ensure that the
+   supply never changes)
 4. Has an associated account that stores metadata
 
-While the first three points are features that can be achieved with the SPL Token Program, the associated metadata requires some additional functionality.
+While the first three points are features that can be achieved with the SPL
+Token Program, the associated metadata requires some additional functionality.
 
-Typically, an NFT’s metadata has both an on-chain and off-chain component. The on-chain metadata is stored in an account associated with the token mint. One of its fields is URI that typically points to an off-chain JSON file (see [this link](https://lsc6xffbdvalb5dvymf5gwjpeou7rr2btkoltutn5ij5irlpg3wa.arweave.net/XIXrlKEdQLD0dcML01kvI6n4x0GanLnSbeoT1EVvNuw) as an example). The off-chain component stores additional data and a link to the image. Permanent data storage systems such as Arweave are often used to store the off-chain component of NFT metadata.
+Typically, an NFT’s metadata has both an on-chain and off-chain component. The
+on-chain metadata is stored in an account associated with the token mint. One of
+its fields is URI that typically points to an off-chain JSON file (see
+[this link](https://lsc6xffbdvalb5dvymf5gwjpeou7rr2btkoltutn5ij5irlpg3wa.arweave.net/XIXrlKEdQLD0dcML01kvI6n4x0GanLnSbeoT1EVvNuw)
+as an example). The off-chain component stores additional data and a link to the
+image. Permanent data storage systems such as Arweave are often used to store
+the off-chain component of NFT metadata.
 
-Below is an example of the relationship between on-chain and off-chain metadata. The on-chain metadata contains a URI field that points to an off-chain `.json` file that stores the link to the image of the NFT and additional metadata.
+Below is an example of the relationship between on-chain and off-chain metadata.
+The on-chain metadata contains a URI field that points to an off-chain `.json`
+file that stores the link to the image of the NFT and additional metadata.
 
 ![Screenshot of Metadata](../assets/solana-nft-metaplex-metadata.png)
 
 ## **Metaplex**
 
-[Metaplex](https://www.metaplex.com/) is an organization that provides a suite of tools, like the [Metaplex SDK](https://docs.metaplex.com/sdks/js/), that simplify the creation and distribution of NFTs on the Solana blockchain. These tools cater to a wide range of use cases and allow you to easily manage the entire NFT process of creating and minting an NFT collection.
+[Metaplex](https://www.metaplex.com/) is an organization that provides a suite
+of tools, like the [Metaplex SDK](https://docs.metaplex.com/sdks/js/), that
+simplify the creation and distribution of NFTs on the Solana blockchain. These
+tools cater to a wide range of use cases and allow you to easily manage the
+entire NFT process of creating and minting an NFT collection.
 
-More specifically, the Metaplex SDK is designed to assist developers in utilizing the on-chain tools offered by Metaplex. It offers a user-friendly API that focuses on popular use cases and allows for easy integration with third-party plugins. To learn more about the capabilities of the Metaplex SDK, you can refer to the [README](https://github.com/metaplex-foundation/js#readme).
+More specifically, the Metaplex SDK is designed to assist developers in
+utilizing the on-chain tools offered by Metaplex. It offers a user-friendly API
+that focuses on popular use cases and allows for easy integration with
+third-party plugins. To learn more about the capabilities of the Metaplex SDK,
+you can refer to the [README](https://github.com/metaplex-foundation/js#readme).
 
-One of the essential programs offered by Metaplex is the Token Metadata program. The Token Metadata program standardizes the process of attaching metadata to SPL Tokens. When creating an NFT with Metaplex, the Token Metadata program creates a metadata account using a Program Derived Address (PDA) with the token mint as a seed. This allows the metadata account for any NFT to be located deterministically using the address of the token mint. To learn more about the Token Metadata program, you can refer to the Metaplex [documentation](https://docs.metaplex.com/programs/token-metadata/).
+One of the essential programs offered by Metaplex is the Token Metadata program.
+The Token Metadata program standardizes the process of attaching metadata to SPL
+Tokens. When creating an NFT with Metaplex, the Token Metadata program creates a
+metadata account using a Program Derived Address (PDA) with the token mint as a
+seed. This allows the metadata account for any NFT to be located
+deterministically using the address of the token mint. To learn more about the
+Token Metadata program, you can refer to the Metaplex
+[documentation](https://docs.metaplex.com/programs/token-metadata/).
 
-In the following sections, we'll cover the basics of using the Metaplex SDK to prepare assets, create NFTs, update NFTs, and associate an NFT with a broader collection.
+In the following sections, we'll cover the basics of using the Metaplex SDK to
+prepare assets, create NFTs, update NFTs, and associate an NFT with a broader
+collection.
 
 ### Metaplex instance
 
-A `Metaplex` instance serves as the entry point for accessing the Metaplex SDK APIs. This instance accepts a connection used to communicate with the cluster. Additionally, developers can customize the SDK's interactions by specifying an "Identity Driver" and a "Storage Driver".
+A `Metaplex` instance serves as the entry point for accessing the Metaplex SDK
+APIs. This instance accepts a connection used to communicate with the cluster.
+Additionally, developers can customize the SDK's interactions by specifying an
+"Identity Driver" and a "Storage Driver".
 
-The Identity Driver is effectively a keypair that can be used to sign transactions, a requirement when creating an NFT. The Storage Driver is used to specify the storage service you want to use for uploading assets. The `bundlrStorage` driver is the default option and it uploads assets to Arweave, a permanent and decentralized storage service.
+The Identity Driver is effectively a keypair that can be used to sign
+transactions, a requirement when creating an NFT. The Storage Driver is used to
+specify the storage service you want to use for uploading assets. The
+`bundlrStorage` driver is the default option and it uploads assets to Arweave, a
+permanent and decentralized storage service.
 
 Below is an example of how you can set up the `Metaplex` instance for devnet.
 
@@ -83,11 +134,20 @@ const metaplex = Metaplex.make(connection)
 
 ### Upload assets
 
-Before you can create an NFT, you need to prepare and upload any assets you plan to associate with the NFT. While this doesn't have to be an image, most NFTs have an image associated with them.
+Before you can create an NFT, you need to prepare and upload any assets you plan
+to associate with the NFT. While this doesn't have to be an image, most NFTs
+have an image associated with them.
 
-Preparing and uploading an image involves converting the image to a buffer, converting it to the Metaplex format using the `toMetaplexFile` function,, and finally uploading it to the designated Storage Driver.
+Preparing and uploading an image involves converting the image to a buffer,
+converting it to the Metaplex format using the `toMetaplexFile` function,, and
+finally uploading it to the designated Storage Driver.
 
-The Metaplex SDK supports the creation of a new Metaplex file from either files present on your local computer or those uploaded by a user through a browser. You can do the former by using `fs.readFileSync` to read the image file, then convert it into a Metaplex file using `toMetaplexFile`. Finally, use your `Metaplex` instance to call `storage().upload(file)` to upload the file. The function's return value will be the URI where the image was stored.
+The Metaplex SDK supports the creation of a new Metaplex file from either files
+present on your local computer or those uploaded by a user through a browser.
+You can do the former by using `fs.readFileSync` to read the image file, then
+convert it into a Metaplex file using `toMetaplexFile`. Finally, use your
+`Metaplex` instance to call `storage().upload(file)` to upload the file. The
+function's return value will be the URI where the image was stored.
 
 ```tsx
 const buffer = fs.readFileSync("/path/to/image.png");
@@ -98,11 +158,20 @@ const imageUri = await metaplex.storage().upload(file);
 
 ### Upload metadata
 
-After uploading an image, it's time to upload the off-chain JSON metadata using the `nfts().uploadMetadata` function. This will return a URI where the JSON metadata is stored.
+After uploading an image, it's time to upload the off-chain JSON metadata using
+the `nfts().uploadMetadata` function. This will return a URI where the JSON
+metadata is stored.
 
-Remember, the off-chain portion of the metadata includes things like the image URI as well as additional information like the name and description of the NFT. While you can technically include anything you'd like in this JSON object, in most cases you should follow the [NFT standard](https://docs.metaplex.com/programs/token-metadata/token-standard#the-non-fungible-standard) to ensure compatibility with wallets, programs, and applications.
+Remember, the off-chain portion of the metadata includes things like the image
+URI as well as additional information like the name and description of the NFT.
+While you can technically include anything you'd like in this JSON object, in
+most cases you should follow the
+[NFT standard](https://docs.metaplex.com/programs/token-metadata/token-standard#the-non-fungible-standard)
+to ensure compatibility with wallets, programs, and applications.
 
-To create the metadata, use the `uploadMetadata` method provided by the SDK. This method accepts a metadata object and returns a URI that points to the uploaded metadata.
+To create the metadata, use the `uploadMetadata` method provided by the SDK.
+This method accepts a metadata object and returns a URI that points to the
+uploaded metadata.
 
 ```tsx
 const { uri } = await metaplex.nfts().uploadMetadata({
@@ -114,7 +183,13 @@ const { uri } = await metaplex.nfts().uploadMetadata({
 
 ### Create NFT
 
-After uploading the NFT's metadata, you can finally create the NFT on the network. The Metaplex SDK's `create` method allows you to create a new NFT with minimal configuration. This method will handle the creation of the mint account, token account, metadata account, and the master edition account for you. The data provided to this method will represent the on-chain portion of the NFT metadata. You can explore the SDK to see all the other input that can be optionally provided to this method.
+After uploading the NFT's metadata, you can finally create the NFT on the
+network. The Metaplex SDK's `create` method allows you to create a new NFT with
+minimal configuration. This method will handle the creation of the mint account,
+token account, metadata account, and the master edition account for you. The
+data provided to this method will represent the on-chain portion of the NFT
+metadata. You can explore the SDK to see all the other input that can be
+optionally provided to this method.
 
 ```tsx
 const { nft } = await metaplex.nfts().create(
@@ -127,11 +202,20 @@ const { nft } = await metaplex.nfts().create(
 );
 ```
 
-This method returns an object containing information about the newly created NFT. By default, the SDK sets the `isMutable` property to true, allowing for updates to be made to the NFT's metadata. However, you can choose to set `isMutable` to false, making the NFT's metadata immutable.
+This method returns an object containing information about the newly created
+NFT. By default, the SDK sets the `isMutable` property to true, allowing for
+updates to be made to the NFT's metadata. However, you can choose to set
+`isMutable` to false, making the NFT's metadata immutable.
 
 ### Update NFT
 
-If you've left `isMutable` as true, you may end up having a reason to update your NFT's metadata. The SDK's `update` method allows you to update both the on-chain and off-chain portions of the NFT's metadata. To update the off-chain metadata, you'll need to repeat the steps of uploading a new image and metadata URI as outlined in the previous steps, then provide the new metadata URI to this method. This will change the URI that the on-chain metadata points to, effectively updating the off-chain metadata as well.
+If you've left `isMutable` as true, you may end up having a reason to update
+your NFT's metadata. The SDK's `update` method allows you to update both the
+on-chain and off-chain portions of the NFT's metadata. To update the off-chain
+metadata, you'll need to repeat the steps of uploading a new image and metadata
+URI as outlined in the previous steps, then provide the new metadata URI to this
+method. This will change the URI that the on-chain metadata points to,
+effectively updating the off-chain metadata as well.
 
 ```tsx
 const nft = await metaplex.nfts().findByMint({ mintAddress });
@@ -147,13 +231,26 @@ const { response } = await metaplex.nfts().update(
 );
 ```
 
-Note that any fields you don't include in the call to `update` will stay the same, by design.
+Note that any fields you don't include in the call to `update` will stay the
+same, by design.
 
 ### Add NFT to Collection
 
-A [Certified Collection](https://docs.metaplex.com/programs/token-metadata/certified-collections#introduction) is a NFT that individual NFT's can belong to. Think of a large NFT collection like Solana Monkey Business. If you look at an individual NFT's [Metadata](https://explorer.solana.com/address/C18YQWbfwjpCMeCm2MPGTgfcxGeEDPvNaGpVjwYv33q1/metadata) you will see a `collection` field with a `key` that point's to the `Certified Collection` [NFT](https://explorer.solana.com/address/SMBH3wF6baUj6JWtzYvqcKuj2XCKWDqQxzspY12xPND/). Simply put, NFTs that are part of a collection are associated with another NFT that represents the collection itself.
+A
+[Certified Collection](https://docs.metaplex.com/programs/token-metadata/certified-collections#introduction)
+is a NFT that individual NFT's can belong to. Think of a large NFT collection
+like Solana Monkey Business. If you look at an individual NFT's
+[Metadata](https://explorer.solana.com/address/C18YQWbfwjpCMeCm2MPGTgfcxGeEDPvNaGpVjwYv33q1/metadata)
+you will see a `collection` field with a `key` that point's to the
+`Certified Collection`
+[NFT](https://explorer.solana.com/address/SMBH3wF6baUj6JWtzYvqcKuj2XCKWDqQxzspY12xPND/).
+Simply put, NFTs that are part of a collection are associated with another NFT
+that represents the collection itself.
 
-In order to add an NFT to a collection, first the Collection NFT has to be created. The process is the same as before, except you'll include one additional field on our NFT Metadata: `isCollection`. This field tells the token program that this NFT is a Collection NFT.
+In order to add an NFT to a collection, first the Collection NFT has to be
+created. The process is the same as before, except you'll include one additional
+field on our NFT Metadata: `isCollection`. This field tells the token program
+that this NFT is a Collection NFT.
 
 ```tsx
 const { collectionNft } = await metaplex.nfts().create(
@@ -167,7 +264,8 @@ const { collectionNft } = await metaplex.nfts().create(
 );
 ```
 
-You then list the collection's Mint Address as the reference for the `collection` field in our new Nft.
+You then list the collection's Mint Address as the reference for the
+`collection` field in our new Nft.
 
 ```tsx
 const { nft } = await metaplex.nfts().create(
@@ -181,7 +279,8 @@ const { nft } = await metaplex.nfts().create(
 );
 ```
 
-When you checkout the metadata on your newly created NFT, you should now see a `collection` field like so:
+When you checkout the metadata on your newly created NFT, you should now see a
+`collection` field like so:
 
 ```JSON
 "collection":{
@@ -190,7 +289,10 @@ When you checkout the metadata on your newly created NFT, you should now see a `
 }
 ```
 
-The last thing you need to do is verify the NFT. This effectively just flips the `verified` field above to true, but it's incredibly important. This is what lets consuming programs and apps know that your NFT is in fact part of the collection. You can do this using the `verifyCollection` function:
+The last thing you need to do is verify the NFT. This effectively just flips the
+`verified` field above to true, but it's incredibly important. This is what lets
+consuming programs and apps know that your NFT is in fact part of the
+collection. You can do this using the `verifyCollection` function:
 
 ```tsx
 await metaplex.nfts().verifyCollection({
@@ -202,25 +304,43 @@ await metaplex.nfts().verifyCollection({
 
 ### Candy Machine
 
-When creating and distributing a bulk supply of NFT's, Metaplex makes it easy with their [Candy Machine](https://docs.metaplex.com/programs/candy-machine/overview) program and [Sugar CLI](https://docs.metaplex.com/developer-tools/sugar/).
+When creating and distributing a bulk supply of NFT's, Metaplex makes it easy
+with their
+[Candy Machine](https://docs.metaplex.com/programs/candy-machine/overview)
+program and [Sugar CLI](https://docs.metaplex.com/developer-tools/sugar/).
 
-Candy Machine is effectively a minting and distribution program to help launch NFT collections. Sugar is a command line interface that helps you create a candy machine, prepare assets, and create NFTs at scale. The steps covered above for creating an NFT would be incredibly tedious to execute for thousands of NFTs in one go. Candy Machine and Sugar solve this and help ensure a fair launch by offering a number of safeguards.
+Candy Machine is effectively a minting and distribution program to help launch
+NFT collections. Sugar is a command line interface that helps you create a candy
+machine, prepare assets, and create NFTs at scale. The steps covered above for
+creating an NFT would be incredibly tedious to execute for thousands of NFTs in
+one go. Candy Machine and Sugar solve this and help ensure a fair launch by
+offering a number of safeguards.
 
-We won't cover these tools in-depth, but definitely check out how they work together [here](https://docs.metaplex.com/developer-tools/sugar/overview/introduction).
+We won't cover these tools in-depth, but definitely check out how they work
+together
+[here](https://docs.metaplex.com/developer-tools/sugar/overview/introduction).
 
-To explore the full range of tools offered by Metaplex, you can view the [Metaplex repository](https://github.com/metaplex-foundation/metaplex) on GitHub.
+To explore the full range of tools offered by Metaplex, you can view the
+[Metaplex repository](https://github.com/metaplex-foundation/metaplex) on
+GitHub.
 
 # Demo
 
-In this demo, we'll go through the steps to create an NFT using the Metaplex SDK, update the NFT's metadata after the fact, then associate the NFT with a collection. By the end, you will have a basic understanding of how to use the Metaplex SDK interact with NFTs on Solana.
+In this demo, we'll go through the steps to create an NFT using the Metaplex
+SDK, update the NFT's metadata after the fact, then associate the NFT with a
+collection. By the end, you will have a basic understanding of how to use the
+Metaplex SDK interact with NFTs on Solana.
 
 ### 1. Starter
 
-To begin, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-metaplex/tree/starter).
+To begin, download the starter code from the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-metaplex/tree/starter).
 
-The project contains two images in the `src` directory that we will be using for the NFTs.
+The project contains two images in the `src` directory that we will be using for
+the NFTs.
 
-Additionally, in the `index.ts` file, you will find the following code snippet which includes sample data for the NFT we’ll be creating and updating.
+Additionally, in the `index.ts` file, you will find the following code snippet
+which includes sample data for the NFT we’ll be creating and updating.
 
 ```tsx
 interface NftData {
@@ -272,7 +392,8 @@ async function main() {
 
 To install the necessary dependencies, run `npm install` in the command line.
 
-Next, execute the code by running `npm start`. This will create a new keypair, write it to the `.env` file, and airdrop devnet SOL to the keypair.
+Next, execute the code by running `npm start`. This will create a new keypair,
+write it to the `.env` file, and airdrop devnet SOL to the keypair.
 
 ```
 Current balance is 0
@@ -284,7 +405,8 @@ Finished successfully
 
 ### 2. Set up Metaplex
 
-Before we start creating and updating NFTs, we need to set up the Metaplex instance. Update the `main()` function with the following:
+Before we start creating and updating NFTs, we need to set up the Metaplex
+instance. Update the `main()` function with the following:
 
 ```tsx
 async function main() {
@@ -311,7 +433,9 @@ async function main() {
 
 ### 3. `uploadMetadata` helper function
 
-Next, lets create a helper function to handle the process of uploading an image and metadata, and returning the metadata URI. This function will take in the Metaplex instance and NFT data as input, and return the metadata URI as output.
+Next, lets create a helper function to handle the process of uploading an image
+and metadata, and returning the metadata URI. This function will take in the
+Metaplex instance and NFT data as input, and return the metadata URI as output.
 
 ```tsx
 // helper function to upload image and metadata
@@ -342,11 +466,18 @@ async function uploadMetadata(
 }
 ```
 
-This function will read an image file, convert it to a buffer, then upload it to get an image URI. It will then upload the NFT metadata, which includes the name, symbol, description, and image URI, and get a metadata URI. This URI is the off-chain metadata. This function will also log the image URI and metadata URI for reference.
+This function will read an image file, convert it to a buffer, then upload it to
+get an image URI. It will then upload the NFT metadata, which includes the name,
+symbol, description, and image URI, and get a metadata URI. This URI is the
+off-chain metadata. This function will also log the image URI and metadata URI
+for reference.
 
 ### 5. `createNft` helper function
 
-Next, let's create a helper function to handle creating the NFT. This function takes in the Metaplex instance, metadata URI and NFT data as inputs. It uses the `create` method of the SDK to create the NFT, passing in the metadata URI, name, seller fee, and symbol as parameters.
+Next, let's create a helper function to handle creating the NFT. This function
+takes in the Metaplex instance, metadata URI and NFT data as inputs. It uses the
+`create` method of the SDK to create the NFT, passing in the metadata URI, name,
+seller fee, and symbol as parameters.
 
 ```tsx
 // helper function create NFT
@@ -373,11 +504,18 @@ async function createNft(
 }
 ```
 
-The function `createNft` logs the token mint URL and returns the an `nft` object containing information about the newly created NFT. The NFT will be minted to the public key corresponding to the `user` used as the Identity Driver when setting up the Metaplex instance.
+The function `createNft` logs the token mint URL and returns the an `nft` object
+containing information about the newly created NFT. The NFT will be minted to
+the public key corresponding to the `user` used as the Identity Driver when
+setting up the Metaplex instance.
 
 ### 6. Create NFT
 
-Now that we have set up the Metaplex instance and created helper functions for uploading metadata and creating NFTs, we can test these functions by creating an NFT. In the `main()` function, call the `uploadMetadata` function to upload the NFT data and get the URI for the metadata. Then, use the `createNft` function and metadata URI to create an NFT.
+Now that we have set up the Metaplex instance and created helper functions for
+uploading metadata and creating NFTs, we can test these functions by creating an
+NFT. In the `main()` function, call the `uploadMetadata` function to upload the
+NFT data and get the URI for the metadata. Then, use the `createNft` function
+and metadata URI to create an NFT.
 
 ```tsx
 async function main() {
@@ -391,7 +529,8 @@ async function main() {
 }
 ```
 
-Run `npm start` in the command line to execute the `main` function. You should see output similar to the following:
+Run `npm start` in the command line to execute the `main` function. You should
+see output similar to the following:
 
 ```tsx
 Current balance is 1.770520342
@@ -402,11 +541,17 @@ Token Mint: https://explorer.solana.com/address/QdK4oCUZ1zMroCd4vqndnTH7aPAsr8Ap
 Finished successfully
 ```
 
-Feel free to inspect the generated URIs for the image and metadata, as well as view the NFT on the Solana explorer by visiting the URL provided in the output.
+Feel free to inspect the generated URIs for the image and metadata, as well as
+view the NFT on the Solana explorer by visiting the URL provided in the output.
 
 ### 7. `updateNftUri` helper function
 
-Next, let's create a helper function to handle updating an existing NFT's URI. This function will take in the Metaplex instance, metadata URI, and mint address of the NFT. It uses the `findByMint` method of the SDK to fetch the existing NFT data using the mint address, and then uses the `update` method to update the metadata with the new URI. Finally, it will log the token mint URL and transaction signature for reference.
+Next, let's create a helper function to handle updating an existing NFT's URI.
+This function will take in the Metaplex instance, metadata URI, and mint address
+of the NFT. It uses the `findByMint` method of the SDK to fetch the existing NFT
+data using the mint address, and then uses the `update` method to update the
+metadata with the new URI. Finally, it will log the token mint URL and
+transaction signature for reference.
 
 ```tsx
 // helper function update NFT
@@ -439,7 +584,12 @@ async function updateNftUri(
 
 ### 8. Update NFT
 
-To update an existing NFT, we first need to upload new metadata for the NFT and get the new URI. In the `main()` function, call the `uploadMetadata` function again to upload the updated NFT data and get the new URI for the metadata. Then, we can use the `updateNftUri` helper function, passing in the Metaplex instance, the new URI from the metadata, and the mint address of the NFT. The `nft.address` is from the output of the `createNft` function.
+To update an existing NFT, we first need to upload new metadata for the NFT and
+get the new URI. In the `main()` function, call the `uploadMetadata` function
+again to upload the updated NFT data and get the new URI for the metadata. Then,
+we can use the `updateNftUri` helper function, passing in the Metaplex instance,
+the new URI from the metadata, and the mint address of the NFT. The
+`nft.address` is from the output of the `createNft` function.
 
 ```tsx
 async function main() {
@@ -453,7 +603,8 @@ async function main() {
 }
 ```
 
-Run `npm start` in the command line to execute the `main` function. You should see additional output similar to the following:
+Run `npm start` in the command line to execute the `main` function. You should
+see additional output similar to the following:
 
 ```tsx
 ...
@@ -462,13 +613,17 @@ Transaction: https://explorer.solana.com/tx/5VkG47iGmECrqD11zbF7psaVqFkA4tz3iZar
 Finished successfully
 ```
 
-You can also view the NFTs in Phantom wallet by importing the `PRIVATE_KEY` from the .env file.
+You can also view the NFTs in Phantom wallet by importing the `PRIVATE_KEY` from
+the .env file.
 
 ### 9. Create an NFT collection
 
-Awesome, you now know how to create a single NFT and update it on the Solana blockchain! But, how do you add it to a collection?
+Awesome, you now know how to create a single NFT and update it on the Solana
+blockchain! But, how do you add it to a collection?
 
-First, let's create a helper function called `createCollectionNft`. Note that it's very similar to `createNft`, but ensures that `isCollection` is set to true and that the data matches the requirements for a collection.
+First, let's create a helper function called `createCollectionNft`. Note that
+it's very similar to `createNft`, but ensures that `isCollection` is set to true
+and that the data matches the requirements for a collection.
 
 ```tsx
 async function createCollectionNft(
@@ -495,7 +650,9 @@ async function createCollectionNft(
 }
 ```
 
-Next, we need to create the off-chain data for the collection. In `main` _before_ the existing calls to `createNft`, add the following `collectionNftData`:
+Next, we need to create the off-chain data for the collection. In `main`
+_before_ the existing calls to `createNft`, add the following
+`collectionNftData`:
 
 ```tsx
 const collectionNftData = {
@@ -509,7 +666,8 @@ const collectionNftData = {
 };
 ```
 
-Now, let's call `uploadMetadata` with the `collectionNftData` and then call `createCollectionNft`. Again, do this _before_ the code that creates an NFT.
+Now, let's call `uploadMetadata` with the `collectionNftData` and then call
+`createCollectionNft`. Again, do this _before_ the code that creates an NFT.
 
 ```tsx
 async function main() {
@@ -527,11 +685,17 @@ async function main() {
 }
 ```
 
-This will return our collection's mint address so we can use it to assign NFTs to the collection.
+This will return our collection's mint address so we can use it to assign NFTs
+to the collection.
 
 ### 10. Assign an NFT to a collection
 
-Now that we have a collection, let's change our existing code so that newly created NFTs get added to the collection. First, let's modify our `createNft` function so that the call to `nfts().create` includes the `collection` field. Then, add code that calls `verifyCollection` to make it so the `verified` field in the on-chain metadata is set to true. This is how consuming programs and apps can know for sure that the NFT in fact belongs to the collection.
+Now that we have a collection, let's change our existing code so that newly
+created NFTs get added to the collection. First, let's modify our `createNft`
+function so that the call to `nfts().create` includes the `collection` field.
+Then, add code that calls `verifyCollection` to make it so the `verified` field
+in the on-chain metadata is set to true. This is how consuming programs and apps
+can know for sure that the NFT in fact belongs to the collection.
 
 ```tsx
 async function createNft(
@@ -564,16 +728,35 @@ async function createNft(
 }
 ```
 
-Now, run `npm start` and voila! If you follow the new nft link and look at the Metadata tab you will see a `collection` field with your collection's mint address listed.
+Now, run `npm start` and voila! If you follow the new nft link and look at the
+Metadata tab you will see a `collection` field with your collection's mint
+address listed.
 
-Congratulations! You've successfully learned how to use the Metaplex SDK to create, update, and verify NFTs as part of a collection. That's everything you need to build out your own collection for just about any use case. You could build a TicketMaster competitor, revamp Costco's Membership Program, or even digitize your school's Student ID system. The possibilities are endless!
+Congratulations! You've successfully learned how to use the Metaplex SDK to
+create, update, and verify NFTs as part of a collection. That's everything you
+need to build out your own collection for just about any use case. You could
+build a TicketMaster competitor, revamp Costco's Membership Program, or even
+digitize your school's Student ID system. The possibilities are endless!
 
-If you want to take a look at the final solution code you can find it on the solution branch of the same [repository](https://github.com/Unboxed-Software/solana-metaplex/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+solution branch of the same
+[repository](https://github.com/Unboxed-Software/solana-metaplex/tree/solution).
 
 # Challenge
 
-To deepen your understanding of the Metaplex tools, dive into the Metaplex documentation and familiarize yourself with the various programs and tools offered by Metaplex. For instance, you can delve into learning about the Candy Machine program to understand its functionality.
+To deepen your understanding of the Metaplex tools, dive into the Metaplex
+documentation and familiarize yourself with the various programs and tools
+offered by Metaplex. For instance, you can delve into learning about the Candy
+Machine program to understand its functionality.
 
-Once you have an understanding of how the the Candy Machine program works, put your knowledge to the test by using the Sugar CLI to create a Candy Machine for your own collection. This hands-on experience will not only reinforce your understanding of the tools, but also boost your confidence in your ability to use them effectively in the future.
+Once you have an understanding of how the the Candy Machine program works, put
+your knowledge to the test by using the Sugar CLI to create a Candy Machine for
+your own collection. This hands-on experience will not only reinforce your
+understanding of the tools, but also boost your confidence in your ability to
+use them effectively in the future.
 
-Have some fun with this! This will be your first independently created NFT collection! With this, you'll complete Module 2. Hope you're feeling the process! Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%202) so that we can continue to improve the course!
+Have some fun with this! This will be your first independently created NFT
+collection! With this, you'll complete Module 2. Hope you're feeling the
+process! Feel free to share some quick feedback
+[here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%202) so that
+we can continue to improve the course!

--- a/developers/courses/solana-course/content/nfts-with-metaplex.md
+++ b/developers/courses/solana-course/content/nfts-with-metaplex.md
@@ -1,16 +1,16 @@
 ---
 title: Create Solana NFTs With Metaplex
 objectives:
-- Explain NFTs and how they're represented on the Solana network
-- Explain the role of Metaplex in the Solana NFT ecosystem
-- Create and update NFTs using the Metaplex SDK
-- Explain the basic functionality of the Token Metadata program, Candy Machine program, and Sugar CLI as tools that assist in creating and distributing NFTs on Solana
+  - Explain NFTs and how they're represented on the Solana network
+  - Explain the role of Metaplex in the Solana NFT ecosystem
+  - Create and update NFTs using the Metaplex SDK
+  - Explain the basic functionality of the Token Metadata program, Candy Machine program, and Sugar CLI as tools that assist in creating and distributing NFTs on Solana
 ---
 
 # TL;DR
 
 - **Non-Fungible Tokens (NFTs)** are represented on Solana as SPL Tokens with an associated metadata account, 0 decimals, and a maximum supply of 1
--   **Metaplex** offers a collection of tools that simplify the creation and distribution of NFTs on the Solana blockchain
+- **Metaplex** offers a collection of tools that simplify the creation and distribution of NFTs on the Solana blockchain
 - The **Token Metadata** program standardizes the process of attaching metadata to SPL Tokens
 - The **Metaplex SDK** is a tool that offers user-friendly APIs to assist developers in utilizing the on-chain tools provided by Metaplex
 - The **Candy Machine** program is an NFT distribution tool used to create and mint NFTs from a collection
@@ -24,7 +24,7 @@ In this lesson, we'll cover the basics of how NFTs are represented on Solana, ho
 
 ## NFTs on Solana
 
-A Solana NFT is a non-divisible token with associated metadata. Further, the token's mint has a maximum supply of 1. 
+A Solana NFT is a non-divisible token with associated metadata. Further, the token's mint has a maximum supply of 1.
 
 In other words, an NFT is a standard token from the Token Program but differs from what you might think of as "standard tokens" in that it:
 
@@ -61,9 +61,9 @@ Below is an example of how you can set up the `Metaplex` instance for devnet.
 
 ```tsx
 import {
-    Metaplex,
-    keypairIdentity,
-    bundlrStorage,
+  Metaplex,
+  keypairIdentity,
+  bundlrStorage,
 } from "@metaplex-foundation/js";
 import { Connection, clusterApiUrl, Keypair } from "@solana/web3.js";
 
@@ -71,14 +71,14 @@ const connection = new Connection(clusterApiUrl("devnet"));
 const wallet = Keypair.generate();
 
 const metaplex = Metaplex.make(connection)
-    .use(keypairIdentity(wallet))
-    .use(
-        bundlrStorage({
-            address: "https://devnet.bundlr.network",
-            providerUrl: "https://api.devnet.solana.com",
-            timeout: 60000,
-        }),
-    );
+  .use(keypairIdentity(wallet))
+  .use(
+    bundlrStorage({
+      address: "https://devnet.bundlr.network",
+      providerUrl: "https://api.devnet.solana.com",
+      timeout: 60000,
+    }),
+  );
 ```
 
 ### Upload assets
@@ -106,9 +106,9 @@ To create the metadata, use the `uploadMetadata` method provided by the SDK. Thi
 
 ```tsx
 const { uri } = await metaplex.nfts().uploadMetadata({
-    name: "My NFT",
-    description: "My description",
-    image: imageUri,
+  name: "My NFT",
+  description: "My description",
+  image: imageUri,
 });
 ```
 
@@ -118,12 +118,12 @@ After uploading the NFT's metadata, you can finally create the NFT on the networ
 
 ```tsx
 const { nft } = await metaplex.nfts().create(
-    {
-        uri: uri,
-        name: "My NFT",
-        sellerFeeBasisPoints: 0,
-    },
-    { commitment: "finalized" },
+  {
+    uri: uri,
+    name: "My NFT",
+    sellerFeeBasisPoints: 0,
+  },
+  { commitment: "finalized" },
 );
 ```
 
@@ -137,13 +137,13 @@ If you've left `isMutable` as true, you may end up having a reason to update you
 const nft = await metaplex.nfts().findByMint({ mintAddress });
 
 const { response } = await metaplex.nfts().update(
-    {
-        nftOrSft: nft,
-        name: "Updated Name",
-        uri: uri,
-        sellerFeeBasisPoints: 100,
-    },
-    { commitment: "finalized" },
+  {
+    nftOrSft: nft,
+    name: "Updated Name",
+    uri: uri,
+    sellerFeeBasisPoints: 100,
+  },
+  { commitment: "finalized" },
 );
 ```
 
@@ -157,13 +157,13 @@ In order to add an NFT to a collection, first the Collection NFT has to be creat
 
 ```tsx
 const { collectionNft } = await metaplex.nfts().create(
-    {
-        uri: uri,
-        name: "My NFT Collection",
-        sellerFeeBasisPoints: 0,
-        isCollection: true
-    },
-    { commitment: "finalized" },
+  {
+    uri: uri,
+    name: "My NFT Collection",
+    sellerFeeBasisPoints: 0,
+    isCollection: true,
+  },
+  { commitment: "finalized" },
 );
 ```
 
@@ -171,13 +171,13 @@ You then list the collection's Mint Address as the reference for the `collection
 
 ```tsx
 const { nft } = await metaplex.nfts().create(
-    {
-        uri: uri,
-        name: "My NFT",
-        sellerFeeBasisPoints: 0,
-        collection: collectionNft.mintAddress
-    },
-    { commitment: "finalized" },
+  {
+    uri: uri,
+    name: "My NFT",
+    sellerFeeBasisPoints: 0,
+    collection: collectionNft.mintAddress,
+  },
+  { commitment: "finalized" },
 );
 ```
 
@@ -194,13 +194,13 @@ The last thing you need to do is verify the NFT. This effectively just flips the
 
 ```tsx
 await metaplex.nfts().verifyCollection({
-    mintAddress: nft.address,
-    collectionMintAddress: collectionNft.address,
-    isSizedCollection: true,
-})
+  mintAddress: nft.address,
+  collectionMintAddress: collectionNft.address,
+  isSizedCollection: true,
+});
 ```
 
-### Candy Machine 
+### Candy Machine
 
 When creating and distributing a bulk supply of NFT's, Metaplex makes it easy with their [Candy Machine](https://docs.metaplex.com/programs/candy-machine/overview) program and [Sugar CLI](https://docs.metaplex.com/developer-tools/sugar/).
 
@@ -208,8 +208,7 @@ Candy Machine is effectively a minting and distribution program to help launch N
 
 We won't cover these tools in-depth, but definitely check out how they work together [here](https://docs.metaplex.com/developer-tools/sugar/overview/introduction).
 
-To explore the full range of tools offered by Metaplex, you can view the [Metaplex repository](https://github.com/metaplex-foundation/metaplex) on GitHub. 
-
+To explore the full range of tools offered by Metaplex, you can view the [Metaplex repository](https://github.com/metaplex-foundation/metaplex) on GitHub.
 
 # Demo
 
@@ -225,49 +224,49 @@ Additionally, in the `index.ts` file, you will find the following code snippet w
 
 ```tsx
 interface NftData {
-    name: string;
-    symbol: string;
-    description: string;
-    sellerFeeBasisPoints: number;
-    imageFile: string;
+  name: string;
+  symbol: string;
+  description: string;
+  sellerFeeBasisPoints: number;
+  imageFile: string;
 }
 
 interface CollectionNftData {
-    name: string
-    symbol: string
-    description: string
-    sellerFeeBasisPoints: number
-    imageFile: string
-    isCollection: boolean
-    collectionAuthority: Signer
+  name: string;
+  symbol: string;
+  description: string;
+  sellerFeeBasisPoints: number;
+  imageFile: string;
+  isCollection: boolean;
+  collectionAuthority: Signer;
 }
 
 // example data for a new NFT
 const nftData = {
-    name: "Name",
-    symbol: "SYMBOL",
-    description: "Description",
-    sellerFeeBasisPoints: 0,
-    imageFile: "solana.png",
-}
+  name: "Name",
+  symbol: "SYMBOL",
+  description: "Description",
+  sellerFeeBasisPoints: 0,
+  imageFile: "solana.png",
+};
 
 // example data for updating an existing NFT
 const updateNftData = {
-    name: "Update",
-    symbol: "UPDATE",
-    description: "Update Description",
-    sellerFeeBasisPoints: 100,
-    imageFile: "success.png",
-}
+  name: "Update",
+  symbol: "UPDATE",
+  description: "Update Description",
+  sellerFeeBasisPoints: 100,
+  imageFile: "success.png",
+};
 
 async function main() {
-    // create a new connection to the cluster's API
-    const connection = new Connection(clusterApiUrl("devnet"));
+  // create a new connection to the cluster's API
+  const connection = new Connection(clusterApiUrl("devnet"));
 
-    // initialize a keypair for the user
-    const user = await initializeKeypair(connection);
+  // initialize a keypair for the user
+  const user = await initializeKeypair(connection);
 
-    console.log("PublicKey:", user.publicKey.toBase58());
+  console.log("PublicKey:", user.publicKey.toBase58());
 }
 ```
 
@@ -289,24 +288,24 @@ Before we start creating and updating NFTs, we need to set up the Metaplex insta
 
 ```tsx
 async function main() {
-    // create a new connection to the cluster's API
-    const connection = new Connection(clusterApiUrl("devnet"));
+  // create a new connection to the cluster's API
+  const connection = new Connection(clusterApiUrl("devnet"));
 
-    // initialize a keypair for the user
-    const user = await initializeKeypair(connection);
+  // initialize a keypair for the user
+  const user = await initializeKeypair(connection);
 
-    console.log("PublicKey:", user.publicKey.toBase58());
+  console.log("PublicKey:", user.publicKey.toBase58());
 
-    // metaplex set up
-    const metaplex = Metaplex.make(connection)
-        .use(keypairIdentity(user))
-        .use(
-            bundlrStorage({
-                address: "https://devnet.bundlr.network",
-                providerUrl: "https://api.devnet.solana.com",
-                timeout: 60000,
-            }),
-        );
+  // metaplex set up
+  const metaplex = Metaplex.make(connection)
+    .use(keypairIdentity(user))
+    .use(
+      bundlrStorage({
+        address: "https://devnet.bundlr.network",
+        providerUrl: "https://api.devnet.solana.com",
+        timeout: 60000,
+      }),
+    );
 }
 ```
 
@@ -317,29 +316,29 @@ Next, lets create a helper function to handle the process of uploading an image 
 ```tsx
 // helper function to upload image and metadata
 async function uploadMetadata(
-    metaplex: Metaplex,
-    nftData: NftData,
+  metaplex: Metaplex,
+  nftData: NftData,
 ): Promise<string> {
-    // file to buffer
-    const buffer = fs.readFileSync("src/" + nftData.imageFile);
+  // file to buffer
+  const buffer = fs.readFileSync("src/" + nftData.imageFile);
 
-    // buffer to metaplex file
-    const file = toMetaplexFile(buffer, nftData.imageFile);
+  // buffer to metaplex file
+  const file = toMetaplexFile(buffer, nftData.imageFile);
 
-    // upload image and get image uri
-    const imageUri = await metaplex.storage().upload(file);
-    console.log("image uri:", imageUri);
+  // upload image and get image uri
+  const imageUri = await metaplex.storage().upload(file);
+  console.log("image uri:", imageUri);
 
-    // upload metadata and get metadata uri (off chain metadata)
-    const { uri } = await metaplex.nfts().uploadMetadata({
-        name: nftData.name,
-        symbol: nftData.symbol,
-        description: nftData.description,
-        image: imageUri,
-    });
+  // upload metadata and get metadata uri (off chain metadata)
+  const { uri } = await metaplex.nfts().uploadMetadata({
+    name: nftData.name,
+    symbol: nftData.symbol,
+    description: nftData.description,
+    image: imageUri,
+  });
 
-    console.log("metadata uri:", uri);
-    return uri;
+  console.log("metadata uri:", uri);
+  return uri;
 }
 ```
 
@@ -352,25 +351,25 @@ Next, let's create a helper function to handle creating the NFT. This function t
 ```tsx
 // helper function create NFT
 async function createNft(
-    metaplex: Metaplex,
-    uri: string,
-    nftData: NftData,
+  metaplex: Metaplex,
+  uri: string,
+  nftData: NftData,
 ): Promise<NftWithToken> {
-    const { nft } = await metaplex.nfts().create(
-        {
-            uri: uri, // metadata URI
-            name: nftData.name,
-            sellerFeeBasisPoints: nftData.sellerFeeBasisPoints,
-            symbol: nftData.symbol,
-        },
-        { commitment: "finalized" },
-    );
+  const { nft } = await metaplex.nfts().create(
+    {
+      uri: uri, // metadata URI
+      name: nftData.name,
+      sellerFeeBasisPoints: nftData.sellerFeeBasisPoints,
+      symbol: nftData.symbol,
+    },
+    { commitment: "finalized" },
+  );
 
-    console.log(
-        `Token Mint: https://explorer.solana.com/address/${nft.address.toString()}?cluster=devnet`,
-    );
+  console.log(
+    `Token Mint: https://explorer.solana.com/address/${nft.address.toString()}?cluster=devnet`,
+  );
 
-    return nft;
+  return nft;
 }
 ```
 
@@ -412,29 +411,29 @@ Next, let's create a helper function to handle updating an existing NFT's URI. T
 ```tsx
 // helper function update NFT
 async function updateNftUri(
-    metaplex: Metaplex,
-    uri: string,
-    mintAddress: PublicKey,
+  metaplex: Metaplex,
+  uri: string,
+  mintAddress: PublicKey,
 ) {
-    // fetch NFT data using mint address
-    const nft = await metaplex.nfts().findByMint({ mintAddress });
+  // fetch NFT data using mint address
+  const nft = await metaplex.nfts().findByMint({ mintAddress });
 
-    // update the NFT metadata
-    const { response } = await metaplex.nfts().update(
-        {
-            nftOrSft: nft,
-            uri: uri,
-        },
-        { commitment: "finalized" },
-    );
+  // update the NFT metadata
+  const { response } = await metaplex.nfts().update(
+    {
+      nftOrSft: nft,
+      uri: uri,
+    },
+    { commitment: "finalized" },
+  );
 
-    console.log(
-        `Token Mint: https://explorer.solana.com/address/${nft.address.toString()}?cluster=devnet`,
-    );
+  console.log(
+    `Token Mint: https://explorer.solana.com/address/${nft.address.toString()}?cluster=devnet`,
+  );
 
-    console.log(
-        `Transaction: https://explorer.solana.com/tx/${response.signature}?cluster=devnet`,
-    );
+  console.log(
+    `Transaction: https://explorer.solana.com/tx/${response.signature}?cluster=devnet`,
+  );
 }
 ```
 
@@ -473,44 +472,44 @@ First, let's create a helper function called `createCollectionNft`. Note that it
 
 ```tsx
 async function createCollectionNft(
-    metaplex: Metaplex,
-    uri: string,
-    data: CollectionNftData
+  metaplex: Metaplex,
+  uri: string,
+  data: CollectionNftData,
 ): Promise<NftWithToken> {
-    const { nft } = await metaplex.nfts().create(
-        {
-            uri: uri,
-            name: data.name,
-            sellerFeeBasisPoints: data.sellerFeeBasisPoints,
-            symbol: data.symbol,
-            isCollection: true,
-        },
-        { commitment: "finalized" }
-    )
+  const { nft } = await metaplex.nfts().create(
+    {
+      uri: uri,
+      name: data.name,
+      sellerFeeBasisPoints: data.sellerFeeBasisPoints,
+      symbol: data.symbol,
+      isCollection: true,
+    },
+    { commitment: "finalized" },
+  );
 
-    console.log(
-        `Collection Mint: https://explorer.solana.com/address/${nft.address.toString()}?cluster=devnet`
-    )
+  console.log(
+    `Collection Mint: https://explorer.solana.com/address/${nft.address.toString()}?cluster=devnet`,
+  );
 
-    return nft
+  return nft;
 }
 ```
 
-Next, we need to create the off-chain data for the collection. In `main` *before* the existing calls to `createNft`, add the following `collectionNftData`:
+Next, we need to create the off-chain data for the collection. In `main` _before_ the existing calls to `createNft`, add the following `collectionNftData`:
 
 ```tsx
 const collectionNftData = {
-    name: "TestCollectionNFT",
-    symbol: "TEST",
-    description: "Test Description Collection",
-    sellerFeeBasisPoints: 100,
-    imageFile: "success.png",
-    isCollection: true,
-    collectionAuthority: user,
-}
+  name: "TestCollectionNFT",
+  symbol: "TEST",
+  description: "Test Description Collection",
+  sellerFeeBasisPoints: 100,
+  imageFile: "success.png",
+  isCollection: true,
+  collectionAuthority: user,
+};
 ```
 
-Now, let's call `uploadMetadata` with the `collectionNftData` and then call `createCollectionNft`. Again, do this *before* the code that creates an NFT. 
+Now, let's call `uploadMetadata` with the `collectionNftData` and then call `createCollectionNft`. Again, do this _before_ the code that creates an NFT.
 
 ```tsx
 async function main() {
@@ -538,30 +537,30 @@ Now that we have a collection, let's change our existing code so that newly crea
 async function createNft(
   metaplex: Metaplex,
   uri: string,
-  nftData: NftData
+  nftData: NftData,
 ): Promise<NftWithToken> {
-    const { nft } = await metaplex.nfts().create(
-        {
-            uri: uri, // metadata URI
-            name: nftData.name,
-            sellerFeeBasisPoints: nftData.sellerFeeBasisPoints,
-            symbol: nftData.symbol,
-        },
-        { commitment: "finalized" }
-    )
+  const { nft } = await metaplex.nfts().create(
+    {
+      uri: uri, // metadata URI
+      name: nftData.name,
+      sellerFeeBasisPoints: nftData.sellerFeeBasisPoints,
+      symbol: nftData.symbol,
+    },
+    { commitment: "finalized" },
+  );
 
-    console.log(
-        `Token Mint: https://explorer.solana.com/address/${nft.address.toString()}? cluster=devnet`
-    )
+  console.log(
+    `Token Mint: https://explorer.solana.com/address/${nft.address.toString()}? cluster=devnet`,
+  );
 
-    //this is what verifies our collection as a Certified Collection
-    await metaplex.nfts().verifyCollection({    
-        mintAddress: nft.mint.address,
-        collectionMintAddress: collectionMint,
-        isSizedCollection: true,
-    })
+  //this is what verifies our collection as a Certified Collection
+  await metaplex.nfts().verifyCollection({
+    mintAddress: nft.mint.address,
+    collectionMintAddress: collectionMint,
+    isSizedCollection: true,
+  });
 
-    return nft
+  return nft;
 }
 ```
 

--- a/developers/courses/solana-course/content/owner-checks.md
+++ b/developers/courses/solana-course/content/owner-checks.md
@@ -1,10 +1,10 @@
 ---
 title: Owner Checks
 objectives:
-- Explain the security risks associated with not performing appropriate owner checks
-- Implement owner checks using long-form Rust
-- Use Anchor’s `Account<'info, T>` wrapper and an account type to automate owner checks
-- Use Anchor’s `#[account(owner = <expr>)]` constraint to explicitly define an external program that should own an account
+  - Explain the security risks associated with not performing appropriate owner checks
+  - Implement owner checks using long-form Rust
+  - Use Anchor’s `Account<'info, T>` wrapper and an account type to automate owner checks
+  - Use Anchor’s `#[account(owner = <expr>)]` constraint to explicitly define an external program that should own an account
 ---
 
 # TL;DR

--- a/developers/courses/solana-course/content/paging-ordering-filtering-data.md
+++ b/developers/courses/solana-course/content/paging-ordering-filtering-data.md
@@ -1,12 +1,12 @@
 ---
 title: Page, Order, and Filter Custom Account Data
 objectives:
-- Page, order, and filter accounts
-- Prefetch accounts without data
-- Determine where in an account’s buffer layout specific data is stored
-- Prefetch accounts with a subset of data that can be used to order accounts
-- Fetch only accounts whose data matches specific criteria
-- Fetch a subset of total accounts using `getMultipleAccounts`
+  - Page, order, and filter accounts
+  - Prefetch accounts without data
+  - Determine where in an account’s buffer layout specific data is stored
+  - Prefetch accounts with a subset of data that can be used to order accounts
+  - Fetch only accounts whose data matches specific criteria
+  - Fetch a subset of total accounts using `getMultipleAccounts`
 ---
 
 # TL;DR
@@ -35,24 +35,21 @@ When you include a `dataSlice` in the configuration object, the function will on
 One area this becomes helpful is with paging. If you want to have a list that displays all accounts but there are so many accounts that you don’t want to pull all the data at once, you can fetch all of the accounts with no data. You can then map the result to a list of account keys whose data you can fetch only when needed.
 
 ```tsx
-const accountsWithoutData = await connection.getProgramAccounts(
-	programId,
-	{
-		dataSlice: { offset: 0, length: 0 }
-	}
-)
+const accountsWithoutData = await connection.getProgramAccounts(programId, {
+  dataSlice: { offset: 0, length: 0 },
+});
 
-const accountKeys = accountsWithoutData.map(account => account.pubkey)
+const accountKeys = accountsWithoutData.map(account => account.pubkey);
 ```
 
 With this list of keys, you can then fetch account data in “pages” using the `getMultipleAccountsInfo` method:
 
 ```tsx
-const paginatedKeys = accountKeys.slice(0, 10)
-const accountInfos = await connection.getMultipleAccountsInfo(paginatedKeys)
-const deserializedObjects = accountInfos.map((accountInfo) => {
-	// put logic to deserialize accountInfo.data here
-})
+const paginatedKeys = accountKeys.slice(0, 10);
+const accountInfos = await connection.getMultipleAccountsInfo(paginatedKeys);
+const deserializedObjects = accountInfos.map(accountInfo => {
+  // put logic to deserialize accountInfo.data here
+});
 ```
 
 ### Ordering Accounts
@@ -73,22 +70,19 @@ You then need to determine the length to make the data slice. Since the length i
 Once you’ve fetched accounts with the given data slice, you can use the `sort` method to sort the array before mapping it to an array of public keys.
 
 ```tsx
-const accounts = await connection.getProgramAccounts(
-	programId,
-	{
-		dataSlice: { offset: 13, length: 15 }
-	}
-)
+const accounts = await connection.getProgramAccounts(programId, {
+  dataSlice: { offset: 13, length: 15 },
+});
 
-	accounts.sort( (a, b) => {
-		const lengthA = a.account.data.readUInt32LE(0)
-		const lengthB = b.account.data.readUInt32LE(0)
-		const dataA = a.account.data.slice(4, 4 + lengthA)
-		const dataB = b.account.data.slice(4, 4 + lengthB)
-		return dataA.compare(dataB)
-	})
+accounts.sort((a, b) => {
+  const lengthA = a.account.data.readUInt32LE(0);
+  const lengthB = b.account.data.readUInt32LE(0);
+  const dataA = a.account.data.slice(4, 4 + lengthA);
+  const dataB = b.account.data.slice(4, 4 + lengthB);
+  return dataA.compare(dataB);
+});
 
-const accountKeys = accounts.map(account => account.pubkey)
+const accountKeys = accounts.map(account => account.pubkey);
 ```
 
 Note that in the snippet above we don’t compare the data as given. This is because for dynamically sized types like strings, Borsh places an unsigned, 32-bit integer at the start to indicate the length of the data representing that field. So to compare the first names directly, we need to get the length for each, then create a data slice with a 4 byte offset and the proper length.
@@ -98,8 +92,8 @@ Note that in the snippet above we don’t compare the data as given. This is bec
 Limiting the data received per account is great, but what if you only want to return accounts that match a specific criteria rather than all of them? That’s where the `filters` configuration option comes in. This option is an array that can have objects matching the following:
 
 - `memcmp` - compares a provided series of bytes with program account data at a particular offset. Fields:
-    - `offset` - the number to offset into program account data before comparing data
-    - `bytes` - a base-58 encoded string representing the data to match; limited to less than 129 bytes
+  - `offset` - the number to offset into program account data before comparing data
+  - `bytes` - a base-58 encoded string representing the data to match; limited to less than 129 bytes
 - `dataSize` - compares the program account data length with the provided data size
 
 These let you filter based on matching data and/or total data size.
@@ -107,22 +101,21 @@ These let you filter based on matching data and/or total data size.
 For example, you could search through a list of contacts by including a `memcmp` filter:
 
 ```tsx
-async function fetchMatchingContactAccounts(connection: web3.Connection, search: string): Promise<(web3.AccountInfo<Buffer> | null)[]> {
-	const accounts = await connection.getProgramAccounts(
-		programId,
-		{
-			dataSlice: { offset: 0, length: 0 },
-			filters: [
-				{
-					memcmp:
-						{
-							offset: 13,
-							bytes: bs58.encode(Buffer.from(search))
-						}
-				}
-			]
-		}
-	)
+async function fetchMatchingContactAccounts(
+  connection: web3.Connection,
+  search: string,
+): Promise<(web3.AccountInfo<Buffer> | null)[]> {
+  const accounts = await connection.getProgramAccounts(programId, {
+    dataSlice: { offset: 0, length: 0 },
+    filters: [
+      {
+        memcmp: {
+          offset: 13,
+          bytes: bs58.encode(Buffer.from(search)),
+        },
+      },
+    ],
+  });
 }
 ```
 
@@ -148,9 +141,9 @@ The project is a fairly simple Next.js application. It includes the `WalletConte
 First things first, let’s create a space to encapsulate the code for fetching account data. Create a new file `MovieCoordinator.ts` and declare a `MovieCoordinator` class. Then let’s move the `MOVIE_REVIEW_PROGRAM_ID` constant from `MovieList` into this new file since we’ll be moving all references to it
 
 ```tsx
-const MOVIE_REVIEW_PROGRAM_ID = 'CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN'
+const MOVIE_REVIEW_PROGRAM_ID = "CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN";
 
-export class MovieCoordinator { }
+export class MovieCoordinator {}
 ```
 
 Now we can use `MovieCoordinator` to create a paging implementation. A quick note before we dive in: this will be as simple a paging implementation as possible so that we can focus on the complex part of interacting with Solana accounts. You can, and should, do better for a production application.
@@ -158,21 +151,21 @@ Now we can use `MovieCoordinator` to create a paging implementation. A quick not
 With that out of the way, let’s create a static property `accounts` of type `web3.PublicKey[]`, a static function `prefetchAccounts(connection: web3.Connection)`, and a static function `fetchPage(connection: web3.Connection, page: number, perPage: number): Promise<Movie[]>`. You’ll also need to import `@solana/web3.js` and `Movie`.
 
 ```tsx
-import * as web3 from '@solana/web3.js'
-import { Movie } from '../models/Movie'
+import * as web3 from "@solana/web3.js";
+import { Movie } from "../models/Movie";
 
-const MOVIE_REVIEW_PROGRAM_ID = 'CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN'
+const MOVIE_REVIEW_PROGRAM_ID = "CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN";
 
 export class MovieCoordinator {
-	static accounts: web3.PublicKey[] = []
+  static accounts: web3.PublicKey[] = [];
 
-	static async prefetchAccounts(connection: web3.Connection) {
+  static async prefetchAccounts(connection: web3.Connection) {}
 
-	}
-
-	static async fetchPage(connection: web3.Connection, page: number, perPage: number): Promise<Movie[]> {
-
-	}
+  static async fetchPage(
+    connection: web3.Connection,
+    page: number,
+    perPage: number,
+  ): Promise<Movie[]> {}
 }
 ```
 
@@ -226,41 +219,36 @@ static async fetchPage(connection: web3.Connection, page: number, perPage: numbe
 With that done, we can reconfigure `MovieList` to use these methods. In `MovieList.tsx`, add `const [page, setPage] = useState(1)` near the existing `useState` calls. Then, update `useEffect` to call `MovieCoordinator.fetchPage` instead of fetching the accounts inline.
 
 ```tsx
-const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
-const [movies, setMovies] = useState<Movie[]>([])
-const [page, setPage] = useState(1)
+const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+const [movies, setMovies] = useState<Movie[]>([]);
+const [page, setPage] = useState(1);
 
 useEffect(() => {
-	MovieCoordinator.fetchPage(
-		connection,
-		page,
-		10
-	).then(setMovies)
-}, [page, search])
+  MovieCoordinator.fetchPage(connection, page, 10).then(setMovies);
+}, [page, search]);
 ```
 
 Lastly, we need to add buttons to the bottom of the list for navigating to different pages:
 
 ```tsx
 return (
-	<div>
-		{
-			movies.map((movie, i) => <Card key={i} movie={movie} /> )
-		}
-		<Center>
-			<HStack w='full' mt={2} mb={8} ml={4} mr={4}>
-				{
-					page > 1 && <Button onClick={() => setPage(page - 1)}>Previous</Button>
-				}
-				<Spacer />
-				{
-					MovieCoordinator.accounts.length > page * 2 &&
-						<Button onClick={() => setPage(page + 1)}>Next</Button>
-				}
-			</HStack>
-		</Center>
-	</div>
-)
+  <div>
+    {movies.map((movie, i) => (
+      <Card key={i} movie={movie} />
+    ))}
+    <Center>
+      <HStack w="full" mt={2} mb={8} ml={4} mr={4}>
+        {page > 1 && (
+          <Button onClick={() => setPage(page - 1)}>Previous</Button>
+        )}
+        <Spacer />
+        {MovieCoordinator.accounts.length > page * 2 && (
+          <Button onClick={() => setPage(page + 1)}>Next</Button>
+        )}
+      </HStack>
+    </Center>
+  </div>
+);
 ```
 
 At this point, you should be able to run the project and click between pages!
@@ -380,43 +368,37 @@ With that in place, let’s update the code in `MovieList` to call this properly
 First, add `const [search, setSearch] = useState('')` near the other `useState` calls. Then update the call to `MovieCoordinator.fetchPage` in the `useEffect` to pass the `search` parameter and to reload when `search !== ''`.
 
 ```tsx
-const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
-const [movies, setMovies] = useState<Movie[]>([])
-const [page, setPage] = useState(1)
-const [search, setSearch] = useState('')
+const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+const [movies, setMovies] = useState<Movie[]>([]);
+const [page, setPage] = useState(1);
+const [search, setSearch] = useState("");
 
 useEffect(() => {
-	MovieCoordinator.fetchPage(
-		connection,
-		page,
-		2,
-		search,
-		search !== ''
-	).then(setMovies)
-}, [page, search])
+  MovieCoordinator.fetchPage(connection, page, 2, search, search !== "").then(
+    setMovies,
+  );
+}, [page, search]);
 ```
 
 Finally, add a search bar that will set the value of `search`:
 
 ```tsx
 return (
-	<div>
-		<Center>
-			<Input
-				id='search'
-				color='gray.400'
-				onChange={event => setSearch(event.currentTarget.value)}
-				placeholder='Search'
-				w='97%'
-				mt={2}
-				mb={2}
-			/>
-		</Center>
-
-...
-
-	</div>
-)
+  <div>
+    <Center>
+      <Input
+        id="search"
+        color="gray.400"
+        onChange={event => setSearch(event.currentTarget.value)}
+        placeholder="Search"
+        w="97%"
+        mt={2}
+        mb={2}
+      />
+    </Center>
+    ...
+  </div>
+);
 ```
 
 And that’s it! The app now has ordered reviews, paging, and search.
@@ -436,4 +418,4 @@ Now it’s your turn to try and do this on your own. Using the Student Intros ap
 
 This is challenging. If you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-paging-account-data). With this you complete Module 1! How was your experience? Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%201), so that we can continue to improve the course!
 
-As always, get creative with these challenges and take them beyond the instructions if you want! 
+As always, get creative with these challenges and take them beyond the instructions if you want!

--- a/developers/courses/solana-course/content/paging-ordering-filtering-data.md
+++ b/developers/courses/solana-course/content/paging-ordering-filtering-data.md
@@ -11,28 +11,45 @@ objectives:
 
 # TL;DR
 
-- This lesson delves into some functionality of the RPC calls that we used in the deserializing account data lesson
-- To save on compute time, you can fetch a large number of accounts without their data by filtering them to return just an array of public keys
-- Once you have a filtered list of public keys, you can order them and fetch the account data they belong to
+- This lesson delves into some functionality of the RPC calls that we used in
+  the deserializing account data lesson
+- To save on compute time, you can fetch a large number of accounts without
+  their data by filtering them to return just an array of public keys
+- Once you have a filtered list of public keys, you can order them and fetch the
+  account data they belong to
 
 # Overview
 
-You may have noticed in the last lesson that while we could fetch and display a list of account data, we didn’t have any granular control over how many accounts to fetch or their order. In this lesson, we’ll learn about some configuration options for the `getProgramAccounts` function that will enable things like paging, ordering accounts, and filtering.
+You may have noticed in the last lesson that while we could fetch and display a
+list of account data, we didn’t have any granular control over how many accounts
+to fetch or their order. In this lesson, we’ll learn about some configuration
+options for the `getProgramAccounts` function that will enable things like
+paging, ordering accounts, and filtering.
 
 ## Use `dataSlice` to only fetch data you need
 
-Imagine the Movie Review app we worked on in past lessons having four million movie reviews and that the average review is 500 bytes. That would make the total download for all review accounts over 2GB. Definitely not something you want to have your frontend download every time the page refreshes.
+Imagine the Movie Review app we worked on in past lessons having four million
+movie reviews and that the average review is 500 bytes. That would make the
+total download for all review accounts over 2GB. Definitely not something you
+want to have your frontend download every time the page refreshes.
 
-Fortunately, the `getProgramAccounts` function that you use to get all of the accounts takes a configuration object as argument. One of the configuration options is `dataSlice` which lets you provide two things:
+Fortunately, the `getProgramAccounts` function that you use to get all of the
+accounts takes a configuration object as argument. One of the configuration
+options is `dataSlice` which lets you provide two things:
 
 - `offset` - the offset from the beginning of the data buffer to start the slice
 - `length` - the number of bytes to return, starting from the provided offset
 
-When you include a `dataSlice` in the configuration object, the function will only return the subset of the data buffer that you specified.
+When you include a `dataSlice` in the configuration object, the function will
+only return the subset of the data buffer that you specified.
 
 ### Paging Accounts
 
-One area this becomes helpful is with paging. If you want to have a list that displays all accounts but there are so many accounts that you don’t want to pull all the data at once, you can fetch all of the accounts with no data. You can then map the result to a list of account keys whose data you can fetch only when needed.
+One area this becomes helpful is with paging. If you want to have a list that
+displays all accounts but there are so many accounts that you don’t want to pull
+all the data at once, you can fetch all of the accounts with no data. You can
+then map the result to a list of account keys whose data you can fetch only when
+needed.
 
 ```tsx
 const accountsWithoutData = await connection.getProgramAccounts(programId, {
@@ -42,7 +59,8 @@ const accountsWithoutData = await connection.getProgramAccounts(programId, {
 const accountKeys = accountsWithoutData.map(account => account.pubkey);
 ```
 
-With this list of keys, you can then fetch account data in “pages” using the `getMultipleAccountsInfo` method:
+With this list of keys, you can then fetch account data in “pages” using the
+`getMultipleAccountsInfo` method:
 
 ```tsx
 const paginatedKeys = accountKeys.slice(0, 10);
@@ -54,7 +72,11 @@ const deserializedObjects = accountInfos.map(accountInfo => {
 
 ### Ordering Accounts
 
-The `dataSlice` option is also helpful when you need to order a list of accounts while paging. You still don’t want to fetch all the data at once, but you do need all of the keys and a way to order them up front. In this case, you need to understand the layout of the account data and configure the data slice to only be the data you need to use for ordering.
+The `dataSlice` option is also helpful when you need to order a list of accounts
+while paging. You still don’t want to fetch all the data at once, but you do
+need all of the keys and a way to order them up front. In this case, you need to
+understand the layout of the account data and configure the data slice to only
+be the data you need to use for ordering.
 
 For example, you might have an account that stores contact information like so:
 
@@ -63,11 +85,21 @@ For example, you might have an account that stores contact information like so:
 - `firstName` as a string
 - `secondName` as a string
 
-If you want to order all of the account keys alphabetically based on the user’s first name, you need to find out the offset where the name starts. The first field, `initialized`, takes the first byte, then `phoneNumber` takes another 8, so the `firstName` field starts at offset `1 + 8 = 9`. However, dynamic data fields in borsh use the first 4 bytes to record the length of the data, so we can skip an additional 4 bytes, making the offset 13.
+If you want to order all of the account keys alphabetically based on the user’s
+first name, you need to find out the offset where the name starts. The first
+field, `initialized`, takes the first byte, then `phoneNumber` takes another 8,
+so the `firstName` field starts at offset `1 + 8 = 9`. However, dynamic data
+fields in borsh use the first 4 bytes to record the length of the data, so we
+can skip an additional 4 bytes, making the offset 13.
 
-You then need to determine the length to make the data slice. Since the length is variable, we can’t know for sure before fetching the data. But you can choose a length that is large enough to cover most cases and short enough to not be too much of a burden to fetch. 15 bytes is plenty for most first names, but would result in a small enough download even with a million users.
+You then need to determine the length to make the data slice. Since the length
+is variable, we can’t know for sure before fetching the data. But you can choose
+a length that is large enough to cover most cases and short enough to not be too
+much of a burden to fetch. 15 bytes is plenty for most first names, but would
+result in a small enough download even with a million users.
 
-Once you’ve fetched accounts with the given data slice, you can use the `sort` method to sort the array before mapping it to an array of public keys.
+Once you’ve fetched accounts with the given data slice, you can use the `sort`
+method to sort the array before mapping it to an array of public keys.
 
 ```tsx
 const accounts = await connection.getProgramAccounts(programId, {
@@ -85,20 +117,32 @@ accounts.sort((a, b) => {
 const accountKeys = accounts.map(account => account.pubkey);
 ```
 
-Note that in the snippet above we don’t compare the data as given. This is because for dynamically sized types like strings, Borsh places an unsigned, 32-bit integer at the start to indicate the length of the data representing that field. So to compare the first names directly, we need to get the length for each, then create a data slice with a 4 byte offset and the proper length.
+Note that in the snippet above we don’t compare the data as given. This is
+because for dynamically sized types like strings, Borsh places an unsigned,
+32-bit integer at the start to indicate the length of the data representing that
+field. So to compare the first names directly, we need to get the length for
+each, then create a data slice with a 4 byte offset and the proper length.
 
 ## Use `filters` to only retrieve specific accounts
 
-Limiting the data received per account is great, but what if you only want to return accounts that match a specific criteria rather than all of them? That’s where the `filters` configuration option comes in. This option is an array that can have objects matching the following:
+Limiting the data received per account is great, but what if you only want to
+return accounts that match a specific criteria rather than all of them? That’s
+where the `filters` configuration option comes in. This option is an array that
+can have objects matching the following:
 
-- `memcmp` - compares a provided series of bytes with program account data at a particular offset. Fields:
-  - `offset` - the number to offset into program account data before comparing data
-  - `bytes` - a base-58 encoded string representing the data to match; limited to less than 129 bytes
-- `dataSize` - compares the program account data length with the provided data size
+- `memcmp` - compares a provided series of bytes with program account data at a
+  particular offset. Fields:
+  - `offset` - the number to offset into program account data before comparing
+    data
+  - `bytes` - a base-58 encoded string representing the data to match; limited
+    to less than 129 bytes
+- `dataSize` - compares the program account data length with the provided data
+  size
 
 These let you filter based on matching data and/or total data size.
 
-For example, you could search through a list of contacts by including a `memcmp` filter:
+For example, you could search through a list of contacts by including a `memcmp`
+filter:
 
 ```tsx
 async function fetchMatchingContactAccounts(
@@ -121,24 +165,41 @@ async function fetchMatchingContactAccounts(
 
 Two things to note in the example above:
 
-1. We’re setting the offset to 13 because we determined previously that the offset for `firstName` in the data layout is 9 and we want to additionally skip the first 4 bytes indicating the length of the string.
-2. We’re using a third party library `bs58` to perform base-58 encoding on the search term. You can install it using `npm install bs58`.
+1. We’re setting the offset to 13 because we determined previously that the
+   offset for `firstName` in the data layout is 9 and we want to additionally
+   skip the first 4 bytes indicating the length of the string.
+2. We’re using a third party library `bs58` to perform base-58 encoding on the
+   search term. You can install it using `npm install bs58`.
 
 # Demo
 
-Remember that Movie Review app we worked on in the last two lessons? We’re going to spice it up a little by paging the review list, ordering the reviews so they aren’t so random, and adding some basic search functionality. No worries if you’re just jumping into this lesson without having looked at the previous ones - as long as you have the prerequisite knowledge, you should be able to follow the demo without having worked in this specific project yet.
+Remember that Movie Review app we worked on in the last two lessons? We’re going
+to spice it up a little by paging the review list, ordering the reviews so they
+aren’t so random, and adding some basic search functionality. No worries if
+you’re just jumping into this lesson without having looked at the previous
+ones - as long as you have the prerequisite knowledge, you should be able to
+follow the demo without having worked in this specific project yet.
 
 ![Screenshot of movie review frontend](../assets/movie-reviews-frontend.png)
 
 ### **1. Download the starter code**
 
-If you didn’t complete the demo from the last lesson or just want to make sure that you didn’t miss anything, you can download the [starter code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-deserialize-account-data).
+If you didn’t complete the demo from the last lesson or just want to make sure
+that you didn’t miss anything, you can download the
+[starter code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-deserialize-account-data).
 
-The project is a fairly simple Next.js application. It includes the `WalletContextProvider` we created in the Wallets lesson, a `Card` component for displaying a movie review, a `MovieList` component that displays reviews in a list, a `Form` component for submitting a new review, and a `Movie.ts` file that contains a class definition for a `Movie` object.
+The project is a fairly simple Next.js application. It includes the
+`WalletContextProvider` we created in the Wallets lesson, a `Card` component for
+displaying a movie review, a `MovieList` component that displays reviews in a
+list, a `Form` component for submitting a new review, and a `Movie.ts` file that
+contains a class definition for a `Movie` object.
 
 ### 2. Add paging to the reviews
 
-First things first, let’s create a space to encapsulate the code for fetching account data. Create a new file `MovieCoordinator.ts` and declare a `MovieCoordinator` class. Then let’s move the `MOVIE_REVIEW_PROGRAM_ID` constant from `MovieList` into this new file since we’ll be moving all references to it
+First things first, let’s create a space to encapsulate the code for fetching
+account data. Create a new file `MovieCoordinator.ts` and declare a
+`MovieCoordinator` class. Then let’s move the `MOVIE_REVIEW_PROGRAM_ID` constant
+from `MovieList` into this new file since we’ll be moving all references to it
 
 ```tsx
 const MOVIE_REVIEW_PROGRAM_ID = "CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN";
@@ -146,9 +207,16 @@ const MOVIE_REVIEW_PROGRAM_ID = "CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN";
 export class MovieCoordinator {}
 ```
 
-Now we can use `MovieCoordinator` to create a paging implementation. A quick note before we dive in: this will be as simple a paging implementation as possible so that we can focus on the complex part of interacting with Solana accounts. You can, and should, do better for a production application.
+Now we can use `MovieCoordinator` to create a paging implementation. A quick
+note before we dive in: this will be as simple a paging implementation as
+possible so that we can focus on the complex part of interacting with Solana
+accounts. You can, and should, do better for a production application.
 
-With that out of the way, let’s create a static property `accounts` of type `web3.PublicKey[]`, a static function `prefetchAccounts(connection: web3.Connection)`, and a static function `fetchPage(connection: web3.Connection, page: number, perPage: number): Promise<Movie[]>`. You’ll also need to import `@solana/web3.js` and `Movie`.
+With that out of the way, let’s create a static property `accounts` of type
+`web3.PublicKey[]`, a static function
+`prefetchAccounts(connection: web3.Connection)`, and a static function
+`fetchPage(connection: web3.Connection, page: number, perPage: number): Promise<Movie[]>`.
+You’ll also need to import `@solana/web3.js` and `Movie`.
 
 ```tsx
 import * as web3 from "@solana/web3.js";
@@ -169,7 +237,9 @@ export class MovieCoordinator {
 }
 ```
 
-The key to paging is to prefetch all the accounts without data. Let’s fill in the body of `prefetchAccounts` to do this and set the retrieved public keys to the static `accounts` property.
+The key to paging is to prefetch all the accounts without data. Let’s fill in
+the body of `prefetchAccounts` to do this and set the retrieved public keys to
+the static `accounts` property.
 
 ```tsx
 static async prefetchAccounts(connection: web3.Connection) {
@@ -184,7 +254,11 @@ static async prefetchAccounts(connection: web3.Connection) {
 }
 ```
 
-Now, let’s fill in the `fetchPage` method. First, if the accounts haven’t been prefetched yet, we’ll need to do that. Then, we can get the account public keys that correspond to the requested page and call `connection.getMultipleAccountsInfo`. Finally, we deserialize the account data and return the corresponding `Movie` objects.
+Now, let’s fill in the `fetchPage` method. First, if the accounts haven’t been
+prefetched yet, we’ll need to do that. Then, we can get the account public keys
+that correspond to the requested page and call
+`connection.getMultipleAccountsInfo`. Finally, we deserialize the account data
+and return the corresponding `Movie` objects.
 
 ```tsx
 static async fetchPage(connection: web3.Connection, page: number, perPage: number): Promise<Movie[]> {
@@ -216,7 +290,10 @@ static async fetchPage(connection: web3.Connection, page: number, perPage: numbe
 }
 ```
 
-With that done, we can reconfigure `MovieList` to use these methods. In `MovieList.tsx`, add `const [page, setPage] = useState(1)` near the existing `useState` calls. Then, update `useEffect` to call `MovieCoordinator.fetchPage` instead of fetching the accounts inline.
+With that done, we can reconfigure `MovieList` to use these methods. In
+`MovieList.tsx`, add `const [page, setPage] = useState(1)` near the existing
+`useState` calls. Then, update `useEffect` to call `MovieCoordinator.fetchPage`
+instead of fetching the accounts inline.
 
 ```tsx
 const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
@@ -228,7 +305,8 @@ useEffect(() => {
 }, [page, search]);
 ```
 
-Lastly, we need to add buttons to the bottom of the list for navigating to different pages:
+Lastly, we need to add buttons to the bottom of the list for navigating to
+different pages:
 
 ```tsx
 return (
@@ -255,18 +333,30 @@ At this point, you should be able to run the project and click between pages!
 
 ### 3. Order reviews alphabetically by title
 
-If you look at the reviews, you might notice they aren’t in any specific order. We can fix this by adding back just enough data into our data slice to help us do some sorting. The various properties in the movie review data buffer are laid out as follows
+If you look at the reviews, you might notice they aren’t in any specific order.
+We can fix this by adding back just enough data into our data slice to help us
+do some sorting. The various properties in the movie review data buffer are laid
+out as follows
 
 - `initialized` - unsigned 8-bit integer; 1 byte
 - `rating` - unsigned 8-bit integer; 1 byte
 - `title` - string; unknown number of bytes
 - `description` - string; unknown number of bytes
 
-Based on this, the offset we need to provide to the data slice to access `title` is 2. The length, however, is indeterminate, so we can just provide what seems to be a reasonable length. I’ll stick with 18 as that will cover the length of most titles without fetching too much data every time.
+Based on this, the offset we need to provide to the data slice to access `title`
+is 2. The length, however, is indeterminate, so we can just provide what seems
+to be a reasonable length. I’ll stick with 18 as that will cover the length of
+most titles without fetching too much data every time.
 
-Once we’ve modified the data slice in `getProgramAccounts`, we then need to actually sort the returned array. To do this, we need to compare the part of the data buffer that actually corresponds to `title`. The first 4 bytes of a dynamic field in Borsh are used to store the length of the field in bytes. So in any given buffer `data` that is sliced the way we discussed above, the string portion is `data.slice(4, 4 + data[0])`.
+Once we’ve modified the data slice in `getProgramAccounts`, we then need to
+actually sort the returned array. To do this, we need to compare the part of the
+data buffer that actually corresponds to `title`. The first 4 bytes of a dynamic
+field in Borsh are used to store the length of the field in bytes. So in any
+given buffer `data` that is sliced the way we discussed above, the string
+portion is `data.slice(4, 4 + data[0])`.
 
-Now that we’ve thought through this, let’s modify the implementation of `prefetchAccounts` in `MovieCoordinator`:
+Now that we’ve thought through this, let’s modify the implementation of
+`prefetchAccounts` in `MovieCoordinator`:
 
 ```tsx
 static async prefetchAccounts(connection: web3.Connection, filters: AccountFilter[]) {
@@ -289,13 +379,20 @@ static async prefetchAccounts(connection: web3.Connection, filters: AccountFilte
 }
 ```
 
-And just like that, you should be able to run the app and see the list of movie reviews ordered alphabetically.
+And just like that, you should be able to run the app and see the list of movie
+reviews ordered alphabetically.
 
 ### 4. Add search
 
-The last thing we’ll do to improve this app is to add some basic search capability. Let’s add a `search` parameter to `prefetchAccounts` and reconfigure the body of the function to use it.
+The last thing we’ll do to improve this app is to add some basic search
+capability. Let’s add a `search` parameter to `prefetchAccounts` and reconfigure
+the body of the function to use it.
 
-We can use the `filters` property of the `config` parameter of `getProgramAccounts` to filter accounts by specific data. The offset to the `title` fields is 2, but the first 4 bytes are the length of the title so the actual offset to the string itself is 6. Remember that the bytes need to be base 58 encoded, so let’s install and import `bs58`.
+We can use the `filters` property of the `config` parameter of
+`getProgramAccounts` to filter accounts by specific data. The offset to the
+`title` fields is 2, but the first 4 bytes are the length of the title so the
+actual offset to the string itself is 6. Remember that the bytes need to be base
+58 encoded, so let’s install and import `bs58`.
 
 ```tsx
 import bs58 from 'bs58'
@@ -331,7 +428,10 @@ static async prefetchAccounts(connection: web3.Connection, search: string) {
 }
 ```
 
-Now, add a `search` parameter to `fetchPage` and update its call to `prefetchAccounts` to pass it along. We’ll also need to add a `reload` boolean parameter to `fetchPage` so that we can force a refresh of the account prefetching every time the search value changes.
+Now, add a `search` parameter to `fetchPage` and update its call to
+`prefetchAccounts` to pass it along. We’ll also need to add a `reload` boolean
+parameter to `fetchPage` so that we can force a refresh of the account
+prefetching every time the search value changes.
 
 ```tsx
 static async fetchPage(connection: web3.Connection, page: number, perPage: number, search: string, reload: boolean = false): Promise<Movie[]> {
@@ -365,7 +465,9 @@ static async fetchPage(connection: web3.Connection, page: number, perPage: numbe
 
 With that in place, let’s update the code in `MovieList` to call this properly.
 
-First, add `const [search, setSearch] = useState('')` near the other `useState` calls. Then update the call to `MovieCoordinator.fetchPage` in the `useEffect` to pass the `search` parameter and to reload when `search !== ''`.
+First, add `const [search, setSearch] = useState('')` near the other `useState`
+calls. Then update the call to `MovieCoordinator.fetchPage` in the `useEffect`
+to pass the `search` parameter and to reload when `search !== ''`.
 
 ```tsx
 const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
@@ -403,19 +505,32 @@ return (
 
 And that’s it! The app now has ordered reviews, paging, and search.
 
-That was a lot to digest, but you made it through. If you need to spend some more time with the concepts, feel free to reread the sections that were most challenging for you and/or have a look at the [solution code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-paging-account-data).
+That was a lot to digest, but you made it through. If you need to spend some
+more time with the concepts, feel free to reread the sections that were most
+challenging for you and/or have a look at the
+[solution code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-paging-account-data).
 
 # Challenge
 
-Now it’s your turn to try and do this on your own. Using the Student Intros app from last lesson, add paging, ordering alphabetically by name, and searching by name.
+Now it’s your turn to try and do this on your own. Using the Student Intros app
+from last lesson, add paging, ordering alphabetically by name, and searching by
+name.
 
 ![Screenshot of Student Intros frontend](../assets/student-intros-frontend.png)
 
-1. You can build this from scratch or you can download the [starter code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-deserialize-account-data)
-2. Add paging to the project by prefetching accounts without data, then only fetching the account data for each account when it’s needed.
+1. You can build this from scratch or you can download the
+   [starter code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-deserialize-account-data)
+2. Add paging to the project by prefetching accounts without data, then only
+   fetching the account data for each account when it’s needed.
 3. Order the accounts displayed in the app alphabetically by name.
 4. Add the ability to search through introductions by a student’s name.
 
-This is challenging. If you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-paging-account-data). With this you complete Module 1! How was your experience? Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%201), so that we can continue to improve the course!
+This is challenging. If you get stuck, feel free to reference the
+[solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-paging-account-data).
+With this you complete Module 1! How was your experience? Feel free to share
+some quick feedback
+[here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%201), so
+that we can continue to improve the course!
 
-As always, get creative with these challenges and take them beyond the instructions if you want!
+As always, get creative with these challenges and take them beyond the
+instructions if you want!

--- a/developers/courses/solana-course/content/pda-sharing.md
+++ b/developers/courses/solana-course/content/pda-sharing.md
@@ -1,9 +1,9 @@
 ---
 title: PDA Sharing
 objectives:
-- Explain the security risks associated with PDA sharing
-- Derive PDAs that have discrete authority domains
-- Use Anchor’s `seeds` and `bump` constraints to validate PDA accounts
+  - Explain the security risks associated with PDA sharing
+  - Derive PDAs that have discrete authority domains
+  - Use Anchor’s `seeds` and `bump` constraints to validate PDA accounts
 ---
 
 # TL;DR
@@ -131,7 +131,7 @@ PDAs can be used as both the address of an account and allow programs to sign fo
 
 The example below uses a PDA derived using the `withdraw_destination` as both the address of the `pool` account and owner of the `vault` token account. This means that only the `pool` account associated with correct `vault` and `withdraw_destination` can be used in the `withdraw_tokens` instruction.
 
-You can use Anchor’s `seeds` and `bump` constraints with the `#[account(...)]` attribute to validate the `pool` account PDA. Anchor derives a PDA using the `seeds` and `bump` specified and compare against the account passed into the instruction as the `pool` account. The `has_one` constraint is used to further ensure that only the correct accounts stored on the `pool` account are passed into the instruction. 
+You can use Anchor’s `seeds` and `bump` constraints with the `#[account(...)]` attribute to validate the `pool` account PDA. Anchor derives a PDA using the `seeds` and `bump` specified and compare against the account passed into the instruction as the `pool` account. The `has_one` constraint is used to further ensure that only the correct accounts stored on the `pool` account are passed into the instruction.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -198,7 +198,7 @@ To get started, download the starter code on the `starter` branch of [this repo
 
 The `initialize_pool` instruction initializes a new `TokenPool` that stores a `vault`, `mint`, `withdraw_destination`, and `bump`. The `vault` is a token account where the authority is set as a PDA derived using the `mint` address.
 
-The `withdraw_insecure` instruction will transfer tokens in the `vault` token account to a `withdraw_destination` token account. 
+The `withdraw_insecure` instruction will transfer tokens in the `vault` token account to a `withdraw_destination` token account.
 
 However, as written the seeds used for signing are not specific to the vault's withdraw destination, thus opening up the program to security exploits. Take a minute to familiarize yourself with the code before continuing on.
 
@@ -214,56 +214,56 @@ The second test withdraws from this pool, effectively stealing funds from the va
 
 ```tsx
 it("Insecure initialize allows pool to be initialized with wrong vault", async () => {
-    await program.methods
-      .initializePool(authInsecureBump)
-      .accounts({
-        pool: poolInsecureFake.publicKey,
-        mint: mint,
-        vault: vaultInsecure.address,
-        withdrawDestination: withdrawDestinationFake,
-        payer: walletFake.publicKey,
-      })
-      .signers([walletFake, poolInsecureFake])
-      .rpc()
+  await program.methods
+    .initializePool(authInsecureBump)
+    .accounts({
+      pool: poolInsecureFake.publicKey,
+      mint: mint,
+      vault: vaultInsecure.address,
+      withdrawDestination: withdrawDestinationFake,
+      payer: walletFake.publicKey,
+    })
+    .signers([walletFake, poolInsecureFake])
+    .rpc();
 
-    await new Promise((x) => setTimeout(x, 1000))
+  await new Promise(x => setTimeout(x, 1000));
 
-    await spl.mintTo(
-      connection,
-      wallet.payer,
-      mint,
-      vaultInsecure.address,
-      wallet.payer,
-      100
-    )
+  await spl.mintTo(
+    connection,
+    wallet.payer,
+    mint,
+    vaultInsecure.address,
+    wallet.payer,
+    100,
+  );
 
-    const account = await spl.getAccount(connection, vaultInsecure.address)
-    expect(Number(account.amount)).to.equal(100)
-})
+  const account = await spl.getAccount(connection, vaultInsecure.address);
+  expect(Number(account.amount)).to.equal(100);
+});
 
 it("Insecure withdraw allows stealing from vault", async () => {
-    await program.methods
-      .withdrawInsecure()
-      .accounts({
-        pool: poolInsecureFake.publicKey,
-        vault: vaultInsecure.address,
-        withdrawDestination: withdrawDestinationFake,
-        authority: authInsecure,
-        signer: walletFake.publicKey,
-      })
-      .signers([walletFake])
-      .rpc()
+  await program.methods
+    .withdrawInsecure()
+    .accounts({
+      pool: poolInsecureFake.publicKey,
+      vault: vaultInsecure.address,
+      withdrawDestination: withdrawDestinationFake,
+      authority: authInsecure,
+      signer: walletFake.publicKey,
+    })
+    .signers([walletFake])
+    .rpc();
 
-    const account = await spl.getAccount(connection, vaultInsecure.address)
-    expect(Number(account.amount)).to.equal(0)
-})
+  const account = await spl.getAccount(connection, vaultInsecure.address);
+  expect(Number(account.amount)).to.equal(0);
+});
 ```
 
 Run `anchor test` to see that the transactions complete successfully and the `withdraw_instrucure` instruction allows the `vault` token account to be drained to a fake withdraw destination stored on the fake `pool` account.
 
 ### 3. Add `initialize_pool_secure` instruction
 
-Now let's add a new instruction to the program for securely initializing a pool. 
+Now let's add a new instruction to the program for securely initializing a pool.
 
 This new `initialize_pool_secure` instruction will initialize a `pool` account as a PDA derived using the `withdraw_destination`. It will also initialize a `vault` token account with the authority set as the `pool` PDA.
 
@@ -307,7 +307,7 @@ pub struct InitializePoolSecure<'info> {
 
 ### 4. Add `withdraw_secure` instruction
 
-Next, add a `withdraw_secure` instruction. This instruction will withdraw tokens from the `vault` token account to the `withdraw_destination`. The `pool` account is validated using the `seeds` and `bump` constraints to ensure the correct PDA account is provided. The `has_one` constraints check that the correct `vault` and `withdraw_destination` token accounts are provided. 
+Next, add a `withdraw_secure` instruction. This instruction will withdraw tokens from the `vault` token account to the `withdraw_destination`. The `pool` account is validated using the `seeds` and `bump` constraints to ensure the correct PDA account is provided. The `has_one` constraints check that the correct `vault` and `withdraw_destination` token accounts are provided.
 
 ```rust
 pub fn withdraw_secure(ctx: Context<WithdrawTokensSecure>) -> Result<()> {
@@ -358,51 +358,51 @@ Before we write a test showing the vulnerability has been patched let's write a 
 
 ```typescript
 it("Secure pool initialization and withdraw works", async () => {
-    const withdrawDestinationAccount = await getAccount(
-      provider.connection,
-      withdrawDestination
-    )
+  const withdrawDestinationAccount = await getAccount(
+    provider.connection,
+    withdrawDestination,
+  );
 
-    await program.methods
-      .initializePoolSecure()
-      .accounts({
-        pool: authSecure,
-        mint: mint,
-        vault: vaultRecommended.publicKey,
-        withdrawDestination: withdrawDestination,
-      })
-      .signers([vaultRecommended])
-      .rpc()
+  await program.methods
+    .initializePoolSecure()
+    .accounts({
+      pool: authSecure,
+      mint: mint,
+      vault: vaultRecommended.publicKey,
+      withdrawDestination: withdrawDestination,
+    })
+    .signers([vaultRecommended])
+    .rpc();
 
-    await new Promise((x) => setTimeout(x, 1000))
+  await new Promise(x => setTimeout(x, 1000));
 
-    await spl.mintTo(
-      connection,
-      wallet.payer,
-      mint,
-      vaultRecommended.publicKey,
-      wallet.payer,
-      100
-    )
+  await spl.mintTo(
+    connection,
+    wallet.payer,
+    mint,
+    vaultRecommended.publicKey,
+    wallet.payer,
+    100,
+  );
 
-    await program.methods
-      .withdrawSecure()
-      .accounts({
-        pool: authSecure,
-        vault: vaultRecommended.publicKey,
-        withdrawDestination: withdrawDestination,
-      })
-      .rpc()
+  await program.methods
+    .withdrawSecure()
+    .accounts({
+      pool: authSecure,
+      vault: vaultRecommended.publicKey,
+      withdrawDestination: withdrawDestination,
+    })
+    .rpc();
 
-    const afterAccount = await getAccount(
-      provider.connection,
-      withdrawDestination
-    )
+  const afterAccount = await getAccount(
+    provider.connection,
+    withdrawDestination,
+  );
 
-    expect(
-      Number(afterAccount.amount) - Number(withdrawDestinationAccount.amount)
-    ).to.equal(100)
-})
+  expect(
+    Number(afterAccount.amount) - Number(withdrawDestinationAccount.amount),
+  ).to.equal(100);
+});
 ```
 
 Now, we'll test that the exploit no longer works. Since the `vault` authority is the `pool` PDA derived using the intended `withdraw_destination` token account, there should no longer be a way to withdraw to an account other than the intended `withdraw_destination`.
@@ -410,48 +410,48 @@ Now, we'll test that the exploit no longer works. Since the `vault` authority is
 Add a test that shows you can't call `withdraw_secure` with the wrong withdrawal destination. It can use the pool and vault created in the previous test.
 
 ```typescript
-  it("Secure withdraw doesn't allow withdraw to wrong destination", async () => {
-    try {
-      await program.methods
-        .withdrawSecure()
-        .accounts({
-          pool: authSecure,
-          vault: vaultRecommended.publicKey,
-          withdrawDestination: withdrawDestinationFake,
-        })
-        .signers([walletFake])
-        .rpc()
+it("Secure withdraw doesn't allow withdraw to wrong destination", async () => {
+  try {
+    await program.methods
+      .withdrawSecure()
+      .accounts({
+        pool: authSecure,
+        vault: vaultRecommended.publicKey,
+        withdrawDestination: withdrawDestinationFake,
+      })
+      .signers([walletFake])
+      .rpc();
 
-      assert.fail("expected error")
-    } catch (error) {
-      console.log(error.message)
-      expect(error)
-    }
-  })
+    assert.fail("expected error");
+  } catch (error) {
+    console.log(error.message);
+    expect(error);
+  }
+});
 ```
 
 Lastly, since the `pool` account is a PDA derived using the `withdraw_destination` token account, we can’t create a fake `pool` account using the same PDA. Add one more test showing that the new `initialize_pool_secure` instruction won't let an attacker put in the wrong vault.
 
 ```typescript
 it("Secure pool initialization doesn't allow wrong vault", async () => {
-    try {
-      await program.methods
-        .initializePoolSecure()
-        .accounts({
-          pool: authSecure,
-          mint: mint,
-          vault: vaultInsecure.address,
-          withdrawDestination: withdrawDestination,
-        })
-        .signers([vaultRecommended])
-        .rpc()
+  try {
+    await program.methods
+      .initializePoolSecure()
+      .accounts({
+        pool: authSecure,
+        mint: mint,
+        vault: vaultInsecure.address,
+        withdrawDestination: withdrawDestination,
+      })
+      .signers([vaultRecommended])
+      .rpc();
 
-      assert.fail("expected error")
-    } catch (error) {
-      console.log(error.message)
-      expect(error)
-    }
-})
+    assert.fail("expected error");
+  } catch (error) {
+    console.log(error.message);
+    expect(error);
+  }
+});
 ```
 
 Run `anchor test` and to see that the new instructions don't allow an attacker to withdraw from a vault that isn't theirs.

--- a/developers/courses/solana-course/content/pda-sharing.md
+++ b/developers/courses/solana-course/content/pda-sharing.md
@@ -8,19 +8,34 @@ objectives:
 
 # TL;DR
 
-- Using the same PDA for multiple authority domains opens your program up to the possibility of users accessing data and funds that don't belong to them
-- Prevent the same PDA from being used for multiple accounts by using seeds that are user and/or domain-specific
-- Use Anchor’s `seeds` and `bump` constraints to validate that a PDA is derived using the expected seeds and bump
+- Using the same PDA for multiple authority domains opens your program up to the
+  possibility of users accessing data and funds that don't belong to them
+- Prevent the same PDA from being used for multiple accounts by using seeds that
+  are user and/or domain-specific
+- Use Anchor’s `seeds` and `bump` constraints to validate that a PDA is derived
+  using the expected seeds and bump
 
 # Overview
 
-PDA sharing refers to using the same PDA as a signer across multiple users or domains. Especially when using PDAs for signing, it may seem appropriate to use a global PDA to represent the program. However, this opens up the possibility of account validation passing but a user being able to access funds, transfers, or data not belonging to them.
+PDA sharing refers to using the same PDA as a signer across multiple users or
+domains. Especially when using PDAs for signing, it may seem appropriate to use
+a global PDA to represent the program. However, this opens up the possibility of
+account validation passing but a user being able to access funds, transfers, or
+data not belonging to them.
 
 ## Insecure global PDA
 
-In the example below, the `authority` of the `vault` account is a PDA derived using the `mint` address stored on the `pool` account. This PDA is passed into the instruction as the `authority` account to sign for the transfer tokens from the `vault` to the `withdraw_destination`.
+In the example below, the `authority` of the `vault` account is a PDA derived
+using the `mint` address stored on the `pool` account. This PDA is passed into
+the instruction as the `authority` account to sign for the transfer tokens from
+the `vault` to the `withdraw_destination`.
 
-Using the `mint` address as a seed to derive the PDA to sign for the `vault` is insecure because multiple `pool` accounts could be created for the same `vault` token account, but a different `withdraw_destination`. By using the `mint` as a seed derive the PDA to sign for token transfers, any `pool` account could sign for the transfer of tokens from a `vault` token account to an arbitrary `withdraw_destination`.
+Using the `mint` address as a seed to derive the PDA to sign for the `vault` is
+insecure because multiple `pool` accounts could be created for the same `vault`
+token account, but a different `withdraw_destination`. By using the `mint` as a
+seed derive the PDA to sign for token transfers, any `pool` account could sign
+for the transfer of tokens from a `vault` token account to an arbitrary
+`withdraw_destination`.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -72,7 +87,13 @@ pub struct TokenPool {
 
 ## Secure account specific PDA
 
-One approach to create an account specific PDA is to use the `withdraw_destination` as a seed to derive the PDA used as the authority of the `vault` token account. This ensures the PDA signing for the CPI in the `withdraw_tokens` instruction is derived using the intended `withdraw_destination` token account. In other words, tokens from a `vault` token account can only be withdrawn to the `withdraw_destination` that was originally initialized with the `pool` account.
+One approach to create an account specific PDA is to use the
+`withdraw_destination` as a seed to derive the PDA used as the authority of the
+`vault` token account. This ensures the PDA signing for the CPI in the
+`withdraw_tokens` instruction is derived using the intended
+`withdraw_destination` token account. In other words, tokens from a `vault`
+token account can only be withdrawn to the `withdraw_destination` that was
+originally initialized with the `pool` account.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -127,11 +148,20 @@ pub struct TokenPool {
 
 ## Anchor’s `seeds` and `bump` constraints
 
-PDAs can be used as both the address of an account and allow programs to sign for the PDAs they own.
+PDAs can be used as both the address of an account and allow programs to sign
+for the PDAs they own.
 
-The example below uses a PDA derived using the `withdraw_destination` as both the address of the `pool` account and owner of the `vault` token account. This means that only the `pool` account associated with correct `vault` and `withdraw_destination` can be used in the `withdraw_tokens` instruction.
+The example below uses a PDA derived using the `withdraw_destination` as both
+the address of the `pool` account and owner of the `vault` token account. This
+means that only the `pool` account associated with correct `vault` and
+`withdraw_destination` can be used in the `withdraw_tokens` instruction.
 
-You can use Anchor’s `seeds` and `bump` constraints with the `#[account(...)]` attribute to validate the `pool` account PDA. Anchor derives a PDA using the `seeds` and `bump` specified and compare against the account passed into the instruction as the `pool` account. The `has_one` constraint is used to further ensure that only the correct accounts stored on the `pool` account are passed into the instruction.
+You can use Anchor’s `seeds` and `bump` constraints with the `#[account(...)]`
+attribute to validate the `pool` account PDA. Anchor derives a PDA using the
+`seeds` and `bump` specified and compare against the account passed into the
+instruction as the `pool` account. The `has_one` constraint is used to further
+ensure that only the correct accounts stored on the `pool` account are passed
+into the instruction.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -190,27 +220,45 @@ pub struct TokenPool {
 
 # Demo
 
-Let’s practice by creating a simple program to demonstrate how a PDA sharing can allow an attacker to withdraw tokens that don’t belong to them. This demo expands on the examples above by including the instructions to initialize the required program accounts.
+Let’s practice by creating a simple program to demonstrate how a PDA sharing can
+allow an attacker to withdraw tokens that don’t belong to them. This demo
+expands on the examples above by including the instructions to initialize the
+required program accounts.
 
 ### 1. Starter
 
-To get started, download the starter code on the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-pda-sharing/tree/starter). The starter code includes a program with two instructions and the boilerplate setup for the test file.
+To get started, download the starter code on the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-pda-sharing/tree/starter).
+The starter code includes a program with two instructions and the boilerplate
+setup for the test file.
 
-The `initialize_pool` instruction initializes a new `TokenPool` that stores a `vault`, `mint`, `withdraw_destination`, and `bump`. The `vault` is a token account where the authority is set as a PDA derived using the `mint` address.
+The `initialize_pool` instruction initializes a new `TokenPool` that stores a
+`vault`, `mint`, `withdraw_destination`, and `bump`. The `vault` is a token
+account where the authority is set as a PDA derived using the `mint` address.
 
-The `withdraw_insecure` instruction will transfer tokens in the `vault` token account to a `withdraw_destination` token account.
+The `withdraw_insecure` instruction will transfer tokens in the `vault` token
+account to a `withdraw_destination` token account.
 
-However, as written the seeds used for signing are not specific to the vault's withdraw destination, thus opening up the program to security exploits. Take a minute to familiarize yourself with the code before continuing on.
+However, as written the seeds used for signing are not specific to the vault's
+withdraw destination, thus opening up the program to security exploits. Take a
+minute to familiarize yourself with the code before continuing on.
 
 ### 2. Test `withdraw_insecure` instruction
 
-The test file includes the code to invoke the `initialize_pool` instruction and then mint 100 tokens to the `vault` token account. It also includes a test to invoke the `withdraw_insecure` using the intended `withdraw_destination`. This shows that the instructions can be used as intended.
+The test file includes the code to invoke the `initialize_pool` instruction and
+then mint 100 tokens to the `vault` token account. It also includes a test to
+invoke the `withdraw_insecure` using the intended `withdraw_destination`. This
+shows that the instructions can be used as intended.
 
-After that, there are two more tests to show how the instructions are vulnerable to exploit.
+After that, there are two more tests to show how the instructions are vulnerable
+to exploit.
 
-The first test invokes the `initialize_pool` instruction to create a "fake" `pool` account using the same `vault` token account, but a different `withdraw_destination`.
+The first test invokes the `initialize_pool` instruction to create a "fake"
+`pool` account using the same `vault` token account, but a different
+`withdraw_destination`.
 
-The second test withdraws from this pool, effectively stealing funds from the vault.
+The second test withdraws from this pool, effectively stealing funds from the
+vault.
 
 ```tsx
 it("Insecure initialize allows pool to be initialized with wrong vault", async () => {
@@ -259,13 +307,17 @@ it("Insecure withdraw allows stealing from vault", async () => {
 });
 ```
 
-Run `anchor test` to see that the transactions complete successfully and the `withdraw_instrucure` instruction allows the `vault` token account to be drained to a fake withdraw destination stored on the fake `pool` account.
+Run `anchor test` to see that the transactions complete successfully and the
+`withdraw_instrucure` instruction allows the `vault` token account to be drained
+to a fake withdraw destination stored on the fake `pool` account.
 
 ### 3. Add `initialize_pool_secure` instruction
 
 Now let's add a new instruction to the program for securely initializing a pool.
 
-This new `initialize_pool_secure` instruction will initialize a `pool` account as a PDA derived using the `withdraw_destination`. It will also initialize a `vault` token account with the authority set as the `pool` PDA.
+This new `initialize_pool_secure` instruction will initialize a `pool` account
+as a PDA derived using the `withdraw_destination`. It will also initialize a
+`vault` token account with the authority set as the `pool` PDA.
 
 ```rust
 pub fn initialize_pool_secure(ctx: Context<InitializePoolSecure>) -> Result<()> {
@@ -307,7 +359,11 @@ pub struct InitializePoolSecure<'info> {
 
 ### 4. Add `withdraw_secure` instruction
 
-Next, add a `withdraw_secure` instruction. This instruction will withdraw tokens from the `vault` token account to the `withdraw_destination`. The `pool` account is validated using the `seeds` and `bump` constraints to ensure the correct PDA account is provided. The `has_one` constraints check that the correct `vault` and `withdraw_destination` token accounts are provided.
+Next, add a `withdraw_secure` instruction. This instruction will withdraw tokens
+from the `vault` token account to the `withdraw_destination`. The `pool` account
+is validated using the `seeds` and `bump` constraints to ensure the correct PDA
+account is provided. The `has_one` constraints check that the correct `vault`
+and `withdraw_destination` token accounts are provided.
 
 ```rust
 pub fn withdraw_secure(ctx: Context<WithdrawTokensSecure>) -> Result<()> {
@@ -352,9 +408,13 @@ impl<'info> WithdrawTokensSecure<'info> {
 
 ### 5. Test `withdraw_secure` instruction
 
-Finally, return to the test file to test the `withdraw_secure` instruction and show that by narrowing the scope of our PDA signing authority, we've removed the vulnerability.
+Finally, return to the test file to test the `withdraw_secure` instruction and
+show that by narrowing the scope of our PDA signing authority, we've removed the
+vulnerability.
 
-Before we write a test showing the vulnerability has been patched let's write a test that simply shows that the initialization and withdraw instructions work as expected:
+Before we write a test showing the vulnerability has been patched let's write a
+test that simply shows that the initialization and withdraw instructions work as
+expected:
 
 ```typescript
 it("Secure pool initialization and withdraw works", async () => {
@@ -405,9 +465,13 @@ it("Secure pool initialization and withdraw works", async () => {
 });
 ```
 
-Now, we'll test that the exploit no longer works. Since the `vault` authority is the `pool` PDA derived using the intended `withdraw_destination` token account, there should no longer be a way to withdraw to an account other than the intended `withdraw_destination`.
+Now, we'll test that the exploit no longer works. Since the `vault` authority is
+the `pool` PDA derived using the intended `withdraw_destination` token account,
+there should no longer be a way to withdraw to an account other than the
+intended `withdraw_destination`.
 
-Add a test that shows you can't call `withdraw_secure` with the wrong withdrawal destination. It can use the pool and vault created in the previous test.
+Add a test that shows you can't call `withdraw_secure` with the wrong withdrawal
+destination. It can use the pool and vault created in the previous test.
 
 ```typescript
 it("Secure withdraw doesn't allow withdraw to wrong destination", async () => {
@@ -430,7 +494,11 @@ it("Secure withdraw doesn't allow withdraw to wrong destination", async () => {
 });
 ```
 
-Lastly, since the `pool` account is a PDA derived using the `withdraw_destination` token account, we can’t create a fake `pool` account using the same PDA. Add one more test showing that the new `initialize_pool_secure` instruction won't let an attacker put in the wrong vault.
+Lastly, since the `pool` account is a PDA derived using the
+`withdraw_destination` token account, we can’t create a fake `pool` account
+using the same PDA. Add one more test showing that the new
+`initialize_pool_secure` instruction won't let an attacker put in the wrong
+vault.
 
 ```typescript
 it("Secure pool initialization doesn't allow wrong vault", async () => {
@@ -454,7 +522,8 @@ it("Secure pool initialization doesn't allow wrong vault", async () => {
 });
 ```
 
-Run `anchor test` and to see that the new instructions don't allow an attacker to withdraw from a vault that isn't theirs.
+Run `anchor test` and to see that the new instructions don't allow an attacker
+to withdraw from a vault that isn't theirs.
 
 ```
   pda-sharing
@@ -469,14 +538,23 @@ unknown signer: GJcHJLot3whbY1aC9PtCsBYk5jWoZnZRJPy5uUwzktAY
     ✔ Secure pool initialization doesn't allow wrong vault
 ```
 
-And that's it! Unlike some of the other security vulnerabilities we've discussed, this one is more conceptual and can't be fixed by simply using a particular Anchor type. You'll need to think through the architecture of your program and ensure that you aren't sharing PDAs across different domains.
+And that's it! Unlike some of the other security vulnerabilities we've
+discussed, this one is more conceptual and can't be fixed by simply using a
+particular Anchor type. You'll need to think through the architecture of your
+program and ensure that you aren't sharing PDAs across different domains.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-pda-sharing/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the same repository](https://github.com/Unboxed-Software/solana-pda-sharing/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and look for potential vulnerabilities in its PDA structure. PDAs used for signing should be narrow and focused on a single domain as much as possible.
+Take some time to review at least one program and look for potential
+vulnerabilities in its PDA structure. PDAs used for signing should be narrow and
+focused on a single domain as much as possible.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/pda.md
+++ b/developers/courses/solana-course/content/pda.md
@@ -1,12 +1,11 @@
 ---
 title: PDAs
 objectives:
-- Explain Program Derived Addresses (PDAs)
-- Explain various use cases of PDAs
-- Describe how PDAs are derived
-- Use PDA derivations to locate and retrieve data
+  - Explain Program Derived Addresses (PDAs)
+  - Explain various use cases of PDAs
+  - Describe how PDAs are derived
+  - Use PDA derivations to locate and retrieve data
 ---
-
 
 # TL;DR
 
@@ -31,11 +30,11 @@ In this lesson we'll focus on using PDAs to find and store data. We'll discuss s
 
 ## Finding PDAs
 
-PDAs are not technically created. Rather, they are *found* or *derived* based on a program ID and one or more input seeds.
+PDAs are not technically created. Rather, they are _found_ or _derived_ based on a program ID and one or more input seeds.
 
 Solana keypairs can be found on what is called the Ed25519 Elliptic Curve (Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to generate corresponding public and private keys. Together, we call these keypairs.
 
-Alternatively, PDAs are addresses that lie *off* the Ed25519 curve. This effectively means they are public keys *without* a corresponding private key. This property of PDAs is essential for programs to be able to sign on their behalf, but we'll cover that in a future lesson.
+Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. This effectively means they are public keys _without_ a corresponding private key. This property of PDAs is essential for programs to be able to sign on their behalf, but we'll cover that in a future lesson.
 
 To find a PDA within a Solana program, we'll use the `find_program_address` function. This function takes an optional list of “seeds” and a program ID as inputs, and then returns the PDA and a bump seed.
 
@@ -47,7 +46,7 @@ let (pda, bump_seed) = Pubkey::find_program_address(&[user.key.as_ref(), user_in
 
 “Seeds” are optional inputs used in the `find_program_address` function to derive a PDA. For example, seeds can be any combination of public keys, inputs provided by a user, or hardcoded values. A PDA can also be derived using only the program ID and no additional seeds. Using seeds to find our PDAs, however, allows us to create an arbitrary number of accounts that our program can own.
 
-While you, the developer, determine the seeds to pass into the `find_program_address` function, the function itself provides an additional seed called a "bump seed." The cryptographic function for deriving a PDA results in a key that lies *on* the Ed25519 curve about 50% of the time. In order to ensure that the result *is not* on the Ed25519 curve and therefore does not have a private key, the `find_program_address` function adds a numeric seed called a bump seed.
+While you, the developer, determine the seeds to pass into the `find_program_address` function, the function itself provides an additional seed called a "bump seed." The cryptographic function for deriving a PDA results in a key that lies _on_ the Ed25519 curve about 50% of the time. In order to ensure that the result _is not_ on the Ed25519 curve and therefore does not have a private key, the `find_program_address` function adds a numeric seed called a bump seed.
 
 The function starts by using the value `255` as the bump seed, then checks to see if the output is a valid PDA. If the result is not a valid PDA, the function decreases the bump seed by 1 and tries again (`255`, `254`, `253`, et cetera). Once a valid PDA is found, the function returns both the PDA and the bump that was used to derive the PDA.
 
@@ -87,7 +86,7 @@ pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<
 }
 ```
 
-The `create_program_address` function performs a set of hash operations over the seeds and `program_id`. These operations compute a key, then verify if the computed key lies on the Ed25519 elliptic curve or not. If a valid PDA is found (i.e. an address that is *off* the curve), then the PDA is returned. Otherwise, an error is returned.
+The `create_program_address` function performs a set of hash operations over the seeds and `program_id`. These operations compute a key, then verify if the computed key lies on the Ed25519 elliptic curve or not. If a valid PDA is found (i.e. an address that is _off_ the curve), then the PDA is returned. Otherwise, an error is returned.
 
 ```rust
 pub fn create_program_address(
@@ -113,9 +112,9 @@ pub fn create_program_address(
 
 In summary, the `find_program_address` function passes our input seeds and `program_id` to the `try_find_program_address` function. The `try_find_program_address` function adds a `bump_seed` (starting from 255) to our input seeds, then calls the `create_program_address` function until a valid PDA is found. Once found, both the PDA and the `bump_seed` are returned.
 
-Note that for the same input seeds, different valid bumps will generate different valid PDAs. The `bump_seed` returned by `find_program_address` will always be the first valid PDA found. Because the function starts with a `bump_seed` value of 255 and iterates downwards to zero, the `bump_seed` that ultimately gets returned will always be the largest valid 8-bit value possible. This `bump_seed` is commonly referred to as the "*canonical bump*". To avoid confusion, it's recommended to only use the canonical bump, and to *always validate every PDA passed into your program.*
+Note that for the same input seeds, different valid bumps will generate different valid PDAs. The `bump_seed` returned by `find_program_address` will always be the first valid PDA found. Because the function starts with a `bump_seed` value of 255 and iterates downwards to zero, the `bump_seed` that ultimately gets returned will always be the largest valid 8-bit value possible. This `bump_seed` is commonly referred to as the "_canonical bump_". To avoid confusion, it's recommended to only use the canonical bump, and to _always validate every PDA passed into your program._
 
-One point to emphasize is that the `find_program_address` function only returns a Program Derived Address and the bump seed used to derive it. The `find_program_address` function does *not* initialize a new account, nor is any PDA returned by the function necessarily associated with an account that stores data.
+One point to emphasize is that the `find_program_address` function only returns a Program Derived Address and the bump seed used to derive it. The `find_program_address` function does _not_ initialize a new account, nor is any PDA returned by the function necessarily associated with an account that stores data.
 
 ## Use PDA accounts to store data
 
@@ -142,7 +141,7 @@ While such a solution is perhaps more approachable for traditional web developer
 
 You could mitigate this issue to some degree by creating a separate map account for each user. For example, rather than having a single PDA map account for the entire program, you would construct a PDA map account per user. Each of these map accounts could be derived with the user's public key. The addresses for each note could then be stored inside the corresponding user's map account.
 
-This approach reduces the size required for each map account, but ultimately still adds an unnecessary requirement to the process: having to read the information on the map account *before* being able to find the accounts with the relevant note data.
+This approach reduces the size required for each map account, but ultimately still adds an unnecessary requirement to the process: having to read the information on the map account _before_ being able to find the accounts with the relevant note data.
 
 There may be times where using this approach makes sense for your application, but we don't recommend it as your "go to" strategy.
 
@@ -150,7 +149,7 @@ There may be times where using this approach makes sense for your application, b
 
 If you're strategic about the seeds you use to derive PDAs, you can embed the required mappings into the seeds themselves. This is the natural evolution of the note-taking app example we just discussed. If you start to use the note creator's public key as a seed to create one map account per user, then why not use both the creator's public key and some other known piece of information to derive a PDA for the note itself?
 
-Now, without talking about it explicitly, we’ve been mapping seeds to accounts this entire course. Think about the Movie Review program we've been built in previous lessons. This program uses a review creator's public key and the title of the movie they're reviewing to find the address that *should* be used to store the review. This approach lets the program create a unique address for every new review while also making it easy to locate a review when needed. When you want to find a user's review of "Spiderman," you know that it is stored at the PDA account whose address can be derived using the user's public key and the text "Spiderman" as seeds.
+Now, without talking about it explicitly, we’ve been mapping seeds to accounts this entire course. Think about the Movie Review program we've been built in previous lessons. This program uses a review creator's public key and the title of the movie they're reviewing to find the address that _should_ be used to store the review. This approach lets the program create a unique address for every new review while also making it easy to locate a review when needed. When you want to find a user's review of "Spiderman," you know that it is stored at the PDA account whose address can be derived using the user's public key and the text "Spiderman" as seeds.
 
 ```rust
 let (pda, bump_seed) = Pubkey::find_program_address(&[
@@ -238,7 +237,7 @@ To do this, we'll create two new account types:
 
 There will be one comment counter account per review and one comment account per comment. The comment counter account will be linked to a given review by using a review's address as a seed for finding the comment counter PDA. It will also use the static string "comment" as a seed.
 
-The comment account will be linked to a review in the same way. However, it will not include the "comment" string as a seed and will instead use the *actual comment count* as a seed. That way the client can easily retrieve comments for a given review by doing the following:
+The comment account will be linked to a review in the same way. However, it will not include the "comment" string as a seed and will instead use the _actual comment count_ as a seed. That way the client can easily retrieve comments for a given review by doing the following:
 
 1. Read the data on the comment counter account to determine the number of comments on a review.
 2. Where `n` is the total number of comments on the review, loop `n` times. Each iteration of the loop will derive a PDA using the review address and the current number as seeds. The result is `n` number of PDAs, each of which is the address of an account that stores a comment.

--- a/developers/courses/solana-course/content/pda.md
+++ b/developers/courses/solana-course/content/pda.md
@@ -9,9 +9,11 @@ objectives:
 
 # TL;DR
 
-- A **Program Derived Address** (PDA) is derived from a **program ID** and an optional list of **seeds**
+- A **Program Derived Address** (PDA) is derived from a **program ID** and an
+  optional list of **seeds**
 - PDAs are owned and controlled by the program they are derived from
-- PDA derivation provides a deterministic way to find data based on the seeds used for the derivation
+- PDA derivation provides a deterministic way to find data based on the seeds
+  used for the derivation
 - Seeds can be used to map to the data stored in a separate PDA account
 - A program can sign instructions on behalf of the PDAs derived from its ID
 
@@ -19,24 +21,40 @@ objectives:
 
 ## What is a Program Derived Address?
 
-Program Derived Addresses (PDAs) are account addresses designed to be signed for by a program rather than a secret key. As the name suggests, PDAs are derived using a program ID. Optionally, these derived accounts can also be found using the ID along with a set of "seeds." More on this later, but these seeds will play an important role in how we use PDAs for data storage and retrieval.
+Program Derived Addresses (PDAs) are account addresses designed to be signed for
+by a program rather than a secret key. As the name suggests, PDAs are derived
+using a program ID. Optionally, these derived accounts can also be found using
+the ID along with a set of "seeds." More on this later, but these seeds will
+play an important role in how we use PDAs for data storage and retrieval.
 
 PDAs serve two main functions:
 
 1. Provide a deterministic way to find the address of a program-owned account
-2. Authorize the program from which a PDA was derived to sign on its behalf in the same way a user may sign with their private key
+2. Authorize the program from which a PDA was derived to sign on its behalf in
+   the same way a user may sign with their private key
 
-In this lesson we'll focus on using PDAs to find and store data. We'll discuss signing with a PDA more thoroughly in a future lesson where we cover Cross Program Invocations (CPIs).
+In this lesson we'll focus on using PDAs to find and store data. We'll discuss
+signing with a PDA more thoroughly in a future lesson where we cover Cross
+Program Invocations (CPIs).
 
 ## Finding PDAs
 
-PDAs are not technically created. Rather, they are _found_ or _derived_ based on a program ID and one or more input seeds.
+PDAs are not technically created. Rather, they are _found_ or _derived_ based on
+a program ID and one or more input seeds.
 
-Solana keypairs can be found on what is called the Ed25519 Elliptic Curve (Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to generate corresponding public and private keys. Together, we call these keypairs.
+Solana keypairs can be found on what is called the Ed25519 Elliptic Curve
+(Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to
+generate corresponding public and private keys. Together, we call these
+keypairs.
 
-Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. This effectively means they are public keys _without_ a corresponding private key. This property of PDAs is essential for programs to be able to sign on their behalf, but we'll cover that in a future lesson.
+Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. This
+effectively means they are public keys _without_ a corresponding private key.
+This property of PDAs is essential for programs to be able to sign on their
+behalf, but we'll cover that in a future lesson.
 
-To find a PDA within a Solana program, we'll use the `find_program_address` function. This function takes an optional list of “seeds” and a program ID as inputs, and then returns the PDA and a bump seed.
+To find a PDA within a Solana program, we'll use the `find_program_address`
+function. This function takes an optional list of “seeds” and a program ID as
+inputs, and then returns the PDA and a bump seed.
 
 ```rust
 let (pda, bump_seed) = Pubkey::find_program_address(&[user.key.as_ref(), user_input.as_bytes().as_ref(), "SEED".as_bytes()], program_id)
@@ -44,11 +62,25 @@ let (pda, bump_seed) = Pubkey::find_program_address(&[user.key.as_ref(), user_in
 
 ### Seeds
 
-“Seeds” are optional inputs used in the `find_program_address` function to derive a PDA. For example, seeds can be any combination of public keys, inputs provided by a user, or hardcoded values. A PDA can also be derived using only the program ID and no additional seeds. Using seeds to find our PDAs, however, allows us to create an arbitrary number of accounts that our program can own.
+“Seeds” are optional inputs used in the `find_program_address` function to
+derive a PDA. For example, seeds can be any combination of public keys, inputs
+provided by a user, or hardcoded values. A PDA can also be derived using only
+the program ID and no additional seeds. Using seeds to find our PDAs, however,
+allows us to create an arbitrary number of accounts that our program can own.
 
-While you, the developer, determine the seeds to pass into the `find_program_address` function, the function itself provides an additional seed called a "bump seed." The cryptographic function for deriving a PDA results in a key that lies _on_ the Ed25519 curve about 50% of the time. In order to ensure that the result _is not_ on the Ed25519 curve and therefore does not have a private key, the `find_program_address` function adds a numeric seed called a bump seed.
+While you, the developer, determine the seeds to pass into the
+`find_program_address` function, the function itself provides an additional seed
+called a "bump seed." The cryptographic function for deriving a PDA results in a
+key that lies _on_ the Ed25519 curve about 50% of the time. In order to ensure
+that the result _is not_ on the Ed25519 curve and therefore does not have a
+private key, the `find_program_address` function adds a numeric seed called a
+bump seed.
 
-The function starts by using the value `255` as the bump seed, then checks to see if the output is a valid PDA. If the result is not a valid PDA, the function decreases the bump seed by 1 and tries again (`255`, `254`, `253`, et cetera). Once a valid PDA is found, the function returns both the PDA and the bump that was used to derive the PDA.
+The function starts by using the value `255` as the bump seed, then checks to
+see if the output is a valid PDA. If the result is not a valid PDA, the function
+decreases the bump seed by 1 and tries again (`255`, `254`, `253`, et cetera).
+Once a valid PDA is found, the function returns both the PDA and the bump that
+was used to derive the PDA.
 
 ### Under the hood of `find_program_address`
 
@@ -61,9 +93,15 @@ Let's take a look at the source code for `find_program_address`.
 }
 ```
 
-Under the hood, the `find_program_address` function passes the input `seeds` and `program_id` to the `try_find_program_address` function.
+Under the hood, the `find_program_address` function passes the input `seeds` and
+`program_id` to the `try_find_program_address` function.
 
-The `try_find_program_address` function then introduces the `bump_seed`. The `bump_seed` is a `u8` variable with a value ranging between 0 to 255. Iterating over a descending range starting from 255, a `bump_seed` is appended to the optional input seeds which are then passed to the `create_program_address` function. If the output of `create_program_address` is not a valid PDA, then the `bump_seed` is decreased by 1 and the loop continues until a valid PDA is found.
+The `try_find_program_address` function then introduces the `bump_seed`. The
+`bump_seed` is a `u8` variable with a value ranging between 0 to 255. Iterating
+over a descending range starting from 255, a `bump_seed` is appended to the
+optional input seeds which are then passed to the `create_program_address`
+function. If the output of `create_program_address` is not a valid PDA, then the
+`bump_seed` is decreased by 1 and the loop continues until a valid PDA is found.
 
 ```rust
 pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<(Pubkey, u8)> {
@@ -86,7 +124,11 @@ pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<
 }
 ```
 
-The `create_program_address` function performs a set of hash operations over the seeds and `program_id`. These operations compute a key, then verify if the computed key lies on the Ed25519 elliptic curve or not. If a valid PDA is found (i.e. an address that is _off_ the curve), then the PDA is returned. Otherwise, an error is returned.
+The `create_program_address` function performs a set of hash operations over the
+seeds and `program_id`. These operations compute a key, then verify if the
+computed key lies on the Ed25519 elliptic curve or not. If a valid PDA is found
+(i.e. an address that is _off_ the curve), then the PDA is returned. Otherwise,
+an error is returned.
 
 ```rust
 pub fn create_program_address(
@@ -110,46 +152,105 @@ pub fn create_program_address(
 }
 ```
 
-In summary, the `find_program_address` function passes our input seeds and `program_id` to the `try_find_program_address` function. The `try_find_program_address` function adds a `bump_seed` (starting from 255) to our input seeds, then calls the `create_program_address` function until a valid PDA is found. Once found, both the PDA and the `bump_seed` are returned.
+In summary, the `find_program_address` function passes our input seeds and
+`program_id` to the `try_find_program_address` function. The
+`try_find_program_address` function adds a `bump_seed` (starting from 255) to
+our input seeds, then calls the `create_program_address` function until a valid
+PDA is found. Once found, both the PDA and the `bump_seed` are returned.
 
-Note that for the same input seeds, different valid bumps will generate different valid PDAs. The `bump_seed` returned by `find_program_address` will always be the first valid PDA found. Because the function starts with a `bump_seed` value of 255 and iterates downwards to zero, the `bump_seed` that ultimately gets returned will always be the largest valid 8-bit value possible. This `bump_seed` is commonly referred to as the "_canonical bump_". To avoid confusion, it's recommended to only use the canonical bump, and to _always validate every PDA passed into your program._
+Note that for the same input seeds, different valid bumps will generate
+different valid PDAs. The `bump_seed` returned by `find_program_address` will
+always be the first valid PDA found. Because the function starts with a
+`bump_seed` value of 255 and iterates downwards to zero, the `bump_seed` that
+ultimately gets returned will always be the largest valid 8-bit value possible.
+This `bump_seed` is commonly referred to as the "_canonical bump_". To avoid
+confusion, it's recommended to only use the canonical bump, and to _always
+validate every PDA passed into your program._
 
-One point to emphasize is that the `find_program_address` function only returns a Program Derived Address and the bump seed used to derive it. The `find_program_address` function does _not_ initialize a new account, nor is any PDA returned by the function necessarily associated with an account that stores data.
+One point to emphasize is that the `find_program_address` function only returns
+a Program Derived Address and the bump seed used to derive it. The
+`find_program_address` function does _not_ initialize a new account, nor is any
+PDA returned by the function necessarily associated with an account that stores
+data.
 
 ## Use PDA accounts to store data
 
-Since programs themselves are stateless, program state is managed through external accounts. Given that you can use seeds for mapping and that programs can sign on their behalf, using PDA accounts to store data related to the program is an extremely common design choice. While programs can invoke the System Program to create non-PDA accounts and use those to store data as well, PDAs tend to be the way to go.
+Since programs themselves are stateless, program state is managed through
+external accounts. Given that you can use seeds for mapping and that programs
+can sign on their behalf, using PDA accounts to store data related to the
+program is an extremely common design choice. While programs can invoke the
+System Program to create non-PDA accounts and use those to store data as well,
+PDAs tend to be the way to go.
 
-If you need a refresher on how to store data in PDAs, have a look at the [Create a Basic Program, Part 2 - State Management lesson](./program-state-management.md).
+If you need a refresher on how to store data in PDAs, have a look at the
+[Create a Basic Program, Part 2 - State Management lesson](./program-state-management.md).
 
 ## Map to data stored in PDA accounts
 
-Storing data in PDA accounts is only half of the equation. You also need a way to retrieve that data. We'll talk about two approaches:
+Storing data in PDA accounts is only half of the equation. You also need a way
+to retrieve that data. We'll talk about two approaches:
 
-1. Creating a PDA "map" account that stores the addresses of various accounts where data is stored
-2. Strategically using seeds to locate the appropriate PDA accounts and retrieve the necessary data
+1. Creating a PDA "map" account that stores the addresses of various accounts
+   where data is stored
+2. Strategically using seeds to locate the appropriate PDA accounts and retrieve
+   the necessary data
 
 ### Map to data using PDA "map" accounts
 
-One approach to organizing data storage is to store clusters of relevant data in their own PDAs and then to have a separate PDA account that stores a mapping of where all of the data is.
+One approach to organizing data storage is to store clusters of relevant data in
+their own PDAs and then to have a separate PDA account that stores a mapping of
+where all of the data is.
 
-For example, you might have a note-taking app whose backing program uses random seeds to generate PDA accounts and stores one note in each account. The program would also have a single global PDA "map" account that stores a mapping of users' public keys to the list of PDAs where their notes are stored. This map account would be derived using a static seed, e.g. "GLOBAL_MAPPING".
+For example, you might have a note-taking app whose backing program uses random
+seeds to generate PDA accounts and stores one note in each account. The program
+would also have a single global PDA "map" account that stores a mapping of
+users' public keys to the list of PDAs where their notes are stored. This map
+account would be derived using a static seed, e.g. "GLOBAL_MAPPING".
 
-When it comes time to retrieve a user's notes, you could then look at the map account, see the list of addresses associated with a user's public key, then retrieve the account for each of those addresses.
+When it comes time to retrieve a user's notes, you could then look at the map
+account, see the list of addresses associated with a user's public key, then
+retrieve the account for each of those addresses.
 
-While such a solution is perhaps more approachable for traditional web developers, it does come with some drawbacks that are particular to web3 development. Since the size of the mapping stored in the map account will grow over time, you'll either need to allocate more size than necessary to the account when you first create it, or you'll need to reallocate space for it every time a new note is created. On top of that, you'll eventually reach the account size limit of 10 megabytes.
+While such a solution is perhaps more approachable for traditional web
+developers, it does come with some drawbacks that are particular to web3
+development. Since the size of the mapping stored in the map account will grow
+over time, you'll either need to allocate more size than necessary to the
+account when you first create it, or you'll need to reallocate space for it
+every time a new note is created. On top of that, you'll eventually reach the
+account size limit of 10 megabytes.
 
-You could mitigate this issue to some degree by creating a separate map account for each user. For example, rather than having a single PDA map account for the entire program, you would construct a PDA map account per user. Each of these map accounts could be derived with the user's public key. The addresses for each note could then be stored inside the corresponding user's map account.
+You could mitigate this issue to some degree by creating a separate map account
+for each user. For example, rather than having a single PDA map account for the
+entire program, you would construct a PDA map account per user. Each of these
+map accounts could be derived with the user's public key. The addresses for each
+note could then be stored inside the corresponding user's map account.
 
-This approach reduces the size required for each map account, but ultimately still adds an unnecessary requirement to the process: having to read the information on the map account _before_ being able to find the accounts with the relevant note data.
+This approach reduces the size required for each map account, but ultimately
+still adds an unnecessary requirement to the process: having to read the
+information on the map account _before_ being able to find the accounts with the
+relevant note data.
 
-There may be times where using this approach makes sense for your application, but we don't recommend it as your "go to" strategy.
+There may be times where using this approach makes sense for your application,
+but we don't recommend it as your "go to" strategy.
 
 ### Map to data using PDA derivation
 
-If you're strategic about the seeds you use to derive PDAs, you can embed the required mappings into the seeds themselves. This is the natural evolution of the note-taking app example we just discussed. If you start to use the note creator's public key as a seed to create one map account per user, then why not use both the creator's public key and some other known piece of information to derive a PDA for the note itself?
+If you're strategic about the seeds you use to derive PDAs, you can embed the
+required mappings into the seeds themselves. This is the natural evolution of
+the note-taking app example we just discussed. If you start to use the note
+creator's public key as a seed to create one map account per user, then why not
+use both the creator's public key and some other known piece of information to
+derive a PDA for the note itself?
 
-Now, without talking about it explicitly, we’ve been mapping seeds to accounts this entire course. Think about the Movie Review program we've been built in previous lessons. This program uses a review creator's public key and the title of the movie they're reviewing to find the address that _should_ be used to store the review. This approach lets the program create a unique address for every new review while also making it easy to locate a review when needed. When you want to find a user's review of "Spiderman," you know that it is stored at the PDA account whose address can be derived using the user's public key and the text "Spiderman" as seeds.
+Now, without talking about it explicitly, we’ve been mapping seeds to accounts
+this entire course. Think about the Movie Review program we've been built in
+previous lessons. This program uses a review creator's public key and the title
+of the movie they're reviewing to find the address that _should_ be used to
+store the review. This approach lets the program create a unique address for
+every new review while also making it easy to locate a review when needed. When
+you want to find a user's review of "Spiderman," you know that it is stored at
+the PDA account whose address can be derived using the user's public key and the
+text "Spiderman" as seeds.
 
 ```rust
 let (pda, bump_seed) = Pubkey::find_program_address(&[
@@ -161,13 +262,20 @@ let (pda, bump_seed) = Pubkey::find_program_address(&[
 
 ### Associated token account addresses
 
-Another practical example of this type of mapping is how associated token account (ATA) addresses are determined. Tokens are often held in an ATA whose address was derived using a wallet address and the mint address of a specific token. The address for an ATA is found using the `get_associated_token_address` function which takes a `wallet_address` and `token_mint_address` as inputs.
+Another practical example of this type of mapping is how associated token
+account (ATA) addresses are determined. Tokens are often held in an ATA whose
+address was derived using a wallet address and the mint address of a specific
+token. The address for an ATA is found using the `get_associated_token_address`
+function which takes a `wallet_address` and `token_mint_address` as inputs.
 
 ```rust
 let associated_token_address = get_associated_token_address(&wallet_address, &token_mint_address);
 ```
 
-Under the hood, the associated token address is a PDA found using the `wallet_address`, `token_program_id`, and `token_mint_address` as seeds. This provides a deterministic way to find a token account associated with any wallet address for a specific token mint.
+Under the hood, the associated token address is a PDA found using the
+`wallet_address`, `token_program_id`, and `token_mint_address` as seeds. This
+provides a deterministic way to find a token account associated with any wallet
+address for a specific token mint.
 
 ```rust
 fn get_associated_token_address_and_bump_seed_internal(
@@ -187,7 +295,9 @@ fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-The mappings between seeds and PDA accounts that you use will be highly dependent on your specific program. While this isn't a lesson on system design or architecture, it's worth calling out a few guidelines:
+The mappings between seeds and PDA accounts that you use will be highly
+dependent on your specific program. While this isn't a lesson on system design
+or architecture, it's worth calling out a few guidelines:
 
 - Use seeds that will be known at the time of PDA derivation
 - Be thoughtful about what data is grouped together into a single account
@@ -196,35 +306,54 @@ The mappings between seeds and PDA accounts that you use will be highly dependen
 
 # Demo
 
-Let’s practice together with the Movie Review program we've worked on in previous lessons. No worries if you’re just jumping into this lesson without having done the previous lesson - it should be possible to follow along either way.
+Let’s practice together with the Movie Review program we've worked on in
+previous lessons. No worries if you’re just jumping into this lesson without
+having done the previous lesson - it should be possible to follow along either
+way.
 
-As a refresher, the Movie Review program lets users create movie reviews. These reviews are stored in an account using a PDA derived with the initializer’s public key and the title of the movie they are reviewing.
+As a refresher, the Movie Review program lets users create movie reviews. These
+reviews are stored in an account using a PDA derived with the initializer’s
+public key and the title of the movie they are reviewing.
 
-Previously, we finished implementing the ability to update a movie review in a secure manner. In this demo, we'll add the ability for users to comment on a movie review. We'll use building this feature as an opportunity to work through how to structure the comment storage using PDA accounts.
+Previously, we finished implementing the ability to update a movie review in a
+secure manner. In this demo, we'll add the ability for users to comment on a
+movie review. We'll use building this feature as an opportunity to work through
+how to structure the comment storage using PDA accounts.
 
 ### 1. Get the starter code
 
-To begin, you can find the starter code [here](https://github.com/Unboxed-Software/solana-movie-program/tree/starter) on the `starter` branch.
+To begin, you can find the starter
+code [here](https://github.com/Unboxed-Software/solana-movie-program/tree/starter)
+on the `starter` branch.
 
-If you've been following along with the Movie Review demos, you'll notice that this is the program we’ve built out so far. Previously, we used [Solana Playground](https://beta.solpg.io/) to write, build, and deploy our code. In this lesson, we’ll build and deploy the program locally.
+If you've been following along with the Movie Review demos, you'll notice that
+this is the program we’ve built out so far. Previously, we
+used [Solana Playground](https://beta.solpg.io/) to write, build, and deploy our
+code. In this lesson, we’ll build and deploy the program locally.
 
-Open the folder, then run `cargo-build-bpf` to build the program. The `cargo-build-bpf` command will output instruction to deploy the program.
+Open the folder, then run `cargo-build-bpf` to build the program. The
+`cargo-build-bpf` command will output instruction to deploy the program.
 
 ```sh
 cargo-build-bpf
 ```
 
-Deploy the program by copying the output of `cargo-build-bpf` and running the `solana program deploy` command.
+Deploy the program by copying the output of `cargo-build-bpf` and running the
+`solana program deploy` command.
 
 ```sh
 solana program deploy <PATH>
 ```
 
-You can test the program by using the movie review [frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews) and updating the program ID with the one you’ve just deployed. Make sure you use the `solution-update-reviews` branch.
+You can test the program by using the movie review
+[frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews)
+and updating the program ID with the one you’ve just deployed. Make sure you use
+the `solution-update-reviews` branch.
 
 ### 2. Plan out the account structure
 
-Adding comments means we need to make a few decisions about how to store the data associated with each comment. The criteria for a good structure here are:
+Adding comments means we need to make a few decisions about how to store the
+data associated with each comment. The criteria for a good structure here are:
 
 - Not overly complicated
 - Data is easily retrievable
@@ -235,34 +364,54 @@ To do this, we'll create two new account types:
 - Comment counter account
 - Comment account
 
-There will be one comment counter account per review and one comment account per comment. The comment counter account will be linked to a given review by using a review's address as a seed for finding the comment counter PDA. It will also use the static string "comment" as a seed.
+There will be one comment counter account per review and one comment account per
+comment. The comment counter account will be linked to a given review by using a
+review's address as a seed for finding the comment counter PDA. It will also use
+the static string "comment" as a seed.
 
-The comment account will be linked to a review in the same way. However, it will not include the "comment" string as a seed and will instead use the _actual comment count_ as a seed. That way the client can easily retrieve comments for a given review by doing the following:
+The comment account will be linked to a review in the same way. However, it will
+not include the "comment" string as a seed and will instead use the _actual
+comment count_ as a seed. That way the client can easily retrieve comments for a
+given review by doing the following:
 
-1. Read the data on the comment counter account to determine the number of comments on a review.
-2. Where `n` is the total number of comments on the review, loop `n` times. Each iteration of the loop will derive a PDA using the review address and the current number as seeds. The result is `n` number of PDAs, each of which is the address of an account that stores a comment.
+1. Read the data on the comment counter account to determine the number of
+   comments on a review.
+2. Where `n` is the total number of comments on the review, loop `n` times. Each
+   iteration of the loop will derive a PDA using the review address and the
+   current number as seeds. The result is `n` number of PDAs, each of which is
+   the address of an account that stores a comment.
 3. Fetch the accounts for each of the `n` PDAs and read the data stored in each.
 
-This ensures that every one of our accounts can be deterministically retrieved using data that is already known ahead of time.
+This ensures that every one of our accounts can be deterministically retrieved
+using data that is already known ahead of time.
 
 In order to implement these changes, we'll need to do the following:
 
 - Define structs to represent the comment counter and comment accounts
-- Update the existing `MovieAccountState` to contain a discriminator (more on this later)
+- Update the existing `MovieAccountState` to contain a discriminator (more on
+  this later)
 - Add an instruction variant to represent the `add_comment` instruction
-- Update the existing `add_movie_review` instruction processing function to include creating the comment counter account
+- Update the existing `add_movie_review` instruction processing function to
+  include creating the comment counter account
 - Create a new `add_comment` instruction processing function
 
 ### 3. Define `MovieCommentCounter` and `MovieComment` structs
 
-Recall that the `state.rs` file defines the structs our program uses to populate the data field of a new account.
+Recall that the `state.rs` file defines the structs our program uses to populate
+the data field of a new account.
 
 We’ll need to define two new structs to enable commenting.
 
-1. `MovieCommentCounter` - to store a counter for the number of comments associated with a review
+1. `MovieCommentCounter` - to store a counter for the number of comments
+   associated with a review
 2. `MovieComment` - to store data associated with each comment
 
-To start, let’s define the structs we’ll be using for our program. Note that we are adding a `discriminator` field to each struct, including the existing `MovieAccountState`. Since we now have multiple account types, we need a way to only fetch the account type we need from the client. This discriminator is a string that can be used to filter through accounts when we fetch our program accounts.
+To start, let’s define the structs we’ll be using for our program. Note that we
+are adding a `discriminator` field to each struct, including the existing
+`MovieAccountState`. Since we now have multiple account types, we need a way to
+only fetch the account type we need from the client. This discriminator is a
+string that can be used to filter through accounts when we fetch our program
+accounts.
 
 ```rust
 #[derive(BorshSerialize, BorshDeserialize)]
@@ -313,7 +462,12 @@ impl IsInitialized for MovieComment {
 }
 ```
 
-Since we've added a new `discriminator` field to our existing struct, the account size calculation needs to change. Let's use this as an opportunity to clean up some of our code a bit. We'll add an implementation for each of the three structs above that adds a constant `DISCRIMINATOR` and either a constant `SIZE` or function `get_account_size` so we can quickly get the size needed when initializing an account.
+Since we've added a new `discriminator` field to our existing struct, the
+account size calculation needs to change. Let's use this as an opportunity to
+clean up some of our code a bit. We'll add an implementation for each of the
+three structs above that adds a constant `DISCRIMINATOR` and either a constant
+`SIZE` or function `get_account_size` so we can quickly get the size needed when
+initializing an account.
 
 ```rust
 impl MovieAccountState {
@@ -342,11 +496,15 @@ impl MovieComment {
 }
 ```
 
-Now everywhere we need the discriminator or account size we can use this implementation and not risk unintentional typos.
+Now everywhere we need the discriminator or account size we can use this
+implementation and not risk unintentional typos.
 
 ### 4. Create `AddComment` instruction
 
-Recall that the `instruction.rs` file defines the instructions our program will accept and how to deserialize the data for each. We need to add a new instruction variant for adding comments. Let’s start by adding a new variant `AddComment` to the `MovieInstruction` enum.
+Recall that the `instruction.rs` file defines the instructions our program will
+accept and how to deserialize the data for each. We need to add a new
+instruction variant for adding comments. Let’s start by adding a new variant
+`AddComment` to the `MovieInstruction` enum.
 
 ```rust
 pub enum MovieInstruction {
@@ -366,7 +524,11 @@ pub enum MovieInstruction {
 }
 ```
 
-Next, let's create a `CommentPayload` struct to represent the instruction data associated with this new instruction. Most of the data we'll include in the account are public keys associated with accounts passed into the program, so the only thing we actually need here is a single field to represent the comment text.
+Next, let's create a `CommentPayload` struct to represent the instruction data
+associated with this new instruction. Most of the data we'll include in the
+account are public keys associated with accounts passed into the program, so the
+only thing we actually need here is a single field to represent the comment
+text.
 
 ```rust
 #[derive(BorshDeserialize)]
@@ -375,7 +537,9 @@ struct CommentPayload {
 }
 ```
 
-Now let’s update how we unpack the instruction data. Notice that we’ve moved the deserialization of instruction data into each matching case using the associated payload struct for each instruction.
+Now let’s update how we unpack the instruction data. Notice that we’ve moved the
+deserialization of instruction data into each matching case using the associated
+payload struct for each instruction.
 
 ```rust
 impl MovieInstruction {
@@ -409,7 +573,8 @@ impl MovieInstruction {
 }
 ```
 
-Lastly, let's update the `process_instruction` function in `processor.rs` to use the new instruction variant we've created.
+Lastly, let's update the `process_instruction` function in `processor.rs` to use
+the new instruction variant we've created.
 
 In `processor.rs`, bring into scope the new structs from `state.rs`.
 
@@ -417,7 +582,8 @@ In `processor.rs`, bring into scope the new structs from `state.rs`.
 use crate::state::{MovieAccountState, MovieCommentCounter, MovieComment};
 ```
 
-Then in `process_instruction` let’s match our deserialized `AddComment` instruction data to the `add_comment` function we’ll be implementing shortly.
+Then in `process_instruction` let’s match our deserialized `AddComment`
+instruction data to the `add_comment` function we’ll be implementing shortly.
 
 ```rust
 pub fn process_instruction(
@@ -443,11 +609,19 @@ pub fn process_instruction(
 
 ### 5. Update `add_movie_review` to create comment counter account
 
-Before we implement the `add_comment` function, we need to update the `add_movie_review` function to create the review's comment counter account.
+Before we implement the `add_comment` function, we need to update the
+`add_movie_review` function to create the review's comment counter account.
 
-Remember that this account will keep track of the total number of comments that exist for an associated review. It's address will be a PDA derived using the movie review address and the word “comment” as seeds. Note that how we store the counter is simply a design choice. We could also add a “counter” field to the original movie review account.
+Remember that this account will keep track of the total number of comments that
+exist for an associated review. It's address will be a PDA derived using the
+movie review address and the word “comment” as seeds. Note that how we store the
+counter is simply a design choice. We could also add a “counter” field to the
+original movie review account.
 
-Within the `add_movie_review` function, let’s add a `pda_counter` to represent the new counter account we’ll be initializing along with the movie review account. This means we now expect four accounts to be passed into the `add_movie_review` function through the `accounts` argument.
+Within the `add_movie_review` function, let’s add a `pda_counter` to represent
+the new counter account we’ll be initializing along with the movie review
+account. This means we now expect four accounts to be passed into
+the `add_movie_review` function through the `accounts` argument.
 
 ```rust
 let account_info_iter = &mut accounts.iter();
@@ -458,7 +632,9 @@ let pda_counter = next_account_info(account_info_iter)?;
 let system_program = next_account_info(account_info_iter)?;
 ```
 
-Next, there's a check to make sure `total_len` is less than 1000 bytes, but `total_len` is no longer accurate since we added the discriminator. Let's replace `total_len` with a call to `MovieAccountState::get_account_size`:
+Next, there's a check to make sure `total_len` is less than 1000 bytes, but
+`total_len` is no longer accurate since we added the discriminator. Let's
+replace `total_len` with a call to `MovieAccountState::get_account_size`:
 
 ```rust
 let account_len: usize = 1000;
@@ -469,9 +645,12 @@ if MovieAccountState::get_account_size(title.clone(), description.clone()) > acc
 }
 ```
 
-Note that this also needs to be updated in the `update_movie_review` function for that instruction to work properly.
+Note that this also needs to be updated in the `update_movie_review` function
+for that instruction to work properly.
 
-Once we’ve initialized the review account, we’ll also need to update the `account_data` with the new fields we specified in the `MovieAccountState` struct.
+Once we’ve initialized the review account, we’ll also need to update the
+`account_data` with the new fields we specified in the `MovieAccountState`
+struct.
 
 ```rust
 account_data.discriminator = MovieAccountState::DISCRIMINATOR.to_string();
@@ -482,15 +661,18 @@ account_data.description = description;
 account_data.is_initialized = true;
 ```
 
-Finally, let’s add the logic to initialize the counter account within the `add_movie_review` function. This means:
+Finally, let’s add the logic to initialize the counter account within the
+`add_movie_review` function. This means:
 
 1. Calculating the rent exemption amount for the counter account
-2. Deriving the counter PDA using the review address and the string "comment" as seeds
+2. Deriving the counter PDA using the review address and the string "comment" as
+   seeds
 3. Invoking the system program to create the account
 4. Set the starting counter value
 5. Serialize the account data and return from the function
 
-All of this should be added to the end of the `add_movie_review` function before the `Ok(())`.
+All of this should be added to the end of the `add_movie_review` function before
+the `Ok(())`.
 
 ```rust
 msg!("create comment counter");
@@ -539,16 +721,22 @@ counter_data.serialize(&mut &mut pda_counter.data.borrow_mut()[..])?;
 
 Now when a new review is created, two accounts are initialized:
 
-1. The first is the review account that stores the contents of the review. This is unchanged from the version of the program we started with.
+1. The first is the review account that stores the contents of the review. This
+   is unchanged from the version of the program we started with.
 2. The second account stores the counter for comments
 
 ### 6. Implement `add_comment`
 
-Finally, let’s implement our `add_comment` function to create new comment accounts.
+Finally, let’s implement our `add_comment` function to create new comment
+accounts.
 
-When a new comment is created for a review, we will increment the count on the comment counter PDA account and derive the PDA for the comment account using the review address and current count.
+When a new comment is created for a review, we will increment the count on the
+comment counter PDA account and derive the PDA for the comment account using the
+review address and current count.
 
-Like in other instruction processing functions, we'll start by iterating through accounts passed into the program. Then before we do anything else we need to deserialize the counter account so we have access to the current comment count:
+Like in other instruction processing functions, we'll start by iterating through
+accounts passed into the program. Then before we do anything else we need to
+deserialize the counter account so we have access to the current comment count:
 
 ```rust
 pub fn add_comment(
@@ -573,10 +761,12 @@ pub fn add_comment(
 }
 ```
 
-Now that we have access to the counter data, we can continue with the remaining steps:
+Now that we have access to the counter data, we can continue with the remaining
+steps:
 
 1. Calculate the rent exempt amount for the new comment account
-2. Derive the PDA for the comment account using the review address and the current comment count as seeds
+2. Derive the PDA for the comment account using the review address and the
+   current comment count as seeds
 3. Invoke the System Program to create the new comment account
 4. Set the appropriate values to the newly created account
 5. Serialize the account data and return from the function
@@ -652,21 +842,44 @@ pub fn add_comment(
 
 We're ready to build and deploy our program!
 
-Build the updated program by running `cargo-build-bpf`. Then deploy the program by running the `solana program deploy` command printed to the console.
+Build the updated program by running `cargo-build-bpf`. Then deploy the program
+by running the `solana program deploy` command printed to the console.
 
-You can test your program by submitting a transaction with the right instruction data. You can create your own script or feel free to use [this frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-add-comments). Be sure to use the `solution-add-comments` branch and replace the `MOVIE_REVIEW_PROGRAM_ID` in `utils/constants.ts` with your program's ID or the frontend won't work with your program.
+You can test your program by submitting a transaction with the right instruction
+data. You can create your own script or feel free to use
+[this frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-add-comments).
+Be sure to use the `solution-add-comments` branch and replace the
+`MOVIE_REVIEW_PROGRAM_ID` in `utils/constants.ts` with your program's ID or the
+frontend won't work with your program.
 
-Keep in mind that we made breaking changes to the review accounts (i.e. adding a discriminator). If you were to use the same program ID that you've used previously when deploying this program, none of the reviews you created previously will show on this frontend due to a data mismatch.
+Keep in mind that we made breaking changes to the review accounts (i.e. adding a
+discriminator). If you were to use the same program ID that you've used
+previously when deploying this program, none of the reviews you created
+previously will show on this frontend due to a data mismatch.
 
-If you need more time with this project to feel comfortable with these concepts, have a look at the [solution code](https://github.com/Unboxed-Software/solana-movie-program/tree/solution-add-comments) before continuing. Note that the solution code is on the `solution-add-comments` branch of the linked repository.
+If you need more time with this project to feel comfortable with these concepts,
+have a look at
+the [solution code](https://github.com/Unboxed-Software/solana-movie-program/tree/solution-add-comments)
+before continuing. Note that the solution code is on the `solution-add-comments`
+branch of the linked repository.
 
 # Challenge
 
-Now it’s your turn to build something independently! Go ahead and work with the Student Intro program that we've used in past lessons. The Student Intro program is a Solana program that lets students introduce themselves. This program takes a user's name and a short message as the `instruction_data` and creates an account to store the data on-chain. For this challenge you should:
+Now it’s your turn to build something independently! Go ahead and work with the
+Student Intro program that we've used in past lessons. The Student Intro program
+is a Solana program that lets students introduce themselves. This program takes
+a user's name and a short message as the `instruction_data` and creates an
+account to store the data on-chain. For this challenge you should:
 
 1. Add an instruction allowing other users to reply to an intro
 2. Build and deploy the program locally
 
-If you haven't been following along with past lessons or haven't saved your work from before, feel free to use the starter code on the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-student-intro-program/tree/starter).
+If you haven't been following along with past lessons or haven't saved your work
+from before, feel free to use the starter code on the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-student-intro-program/tree/starter).
 
-Try to do this independently if you can! If you get stuck though, feel free to reference the [solution code](https://github.com/Unboxed-Software/solana-student-intro-program/tree/solution-add-replies). Note that the solution code is on the `solution-add-replies` branch and that your code may look slightly different.
+Try to do this independently if you can! If you get stuck though, feel free to
+reference the
+[solution code](https://github.com/Unboxed-Software/solana-student-intro-program/tree/solution-add-replies).
+Note that the solution code is on the `solution-add-replies` branch and that
+your code may look slightly different.

--- a/developers/courses/solana-course/content/program-security.md
+++ b/developers/courses/solana-course/content/program-security.md
@@ -1,12 +1,12 @@
 ---
 title: Create a Basic Program, Part 3 - Basic Security and Validation
 objectives:
-- Explain the importance of "thinking like an attacker"
-- Understand basic security practices
-- Perform owner checks
-- Perform signer checks
-- Validate accounts passed into the program
-- Perform basic data validation
+  - Explain the importance of "thinking like an attacker"
+  - Understand basic security practices
+  - Perform owner checks
+  - Perform signer checks
+  - Validate accounts passed into the program
+  - Perform basic data validation
 ---
 
 # TL;DR
@@ -29,9 +29,9 @@ Remember, **you have no control over the transactions that will be sent to your 
 
 [Neodyme](https://workshop.neodyme.io/) gave a presentation at Breakpoint 2021 entitled "Think Like An Attacker: Bringing Smart Contracts to Their Break(ing) Point." If there's one thing you take away from this lesson, it's that you should think like an attacker.
 
-In this lesson, of course, we cannot cover everything that could possibly go wrong with your programs. Ultimately, every program will have different security risks associated with it. While understanding common pitfalls is *essential* to engineering good programs, it is *insufficient* for deploying secure ones. In order to have the broadest security coverage possible, you have to approach your code with the right mindset.
+In this lesson, of course, we cannot cover everything that could possibly go wrong with your programs. Ultimately, every program will have different security risks associated with it. While understanding common pitfalls is _essential_ to engineering good programs, it is _insufficient_ for deploying secure ones. In order to have the broadest security coverage possible, you have to approach your code with the right mindset.
 
-As Neodyme mentioned in their presentation, the right mindset requires moving from the question "Is this broken?" to "How do I break this?" This is the first and most essential step in understanding what your code *actually does* as opposed to what you wrote it to do.
+As Neodyme mentioned in their presentation, the right mindset requires moving from the question "Is this broken?" to "How do I break this?" This is the first and most essential step in understanding what your code _actually does_ as opposed to what you wrote it to do.
 
 ### All programs can be broken
 
@@ -170,13 +170,13 @@ This is always important to keep in mind, but especially so when dealing with an
 
 To avoid integer overflow and underflow, either:
 
-1. Have logic in place that ensures overflow or underflow *cannot* happen or
+1. Have logic in place that ensures overflow or underflow _cannot_ happen or
 2. Use checked math like `checked_add` instead of `+`
-    ```rust
-    let first_int: u8 = 5;
-    let second_int: u8 = 255;
-    let sum = first_int.checked_add(second_int);
-    ```
+   ```rust
+   let first_int: u8 = 5;
+   let second_int: u8 = 255;
+   let sum = first_int.checked_add(second_int);
+   ```
 
 # Demo
 
@@ -190,7 +190,7 @@ Just as before, we'll be using [Solana Playground](https://beta.solpg.io/) to w
 
 To begin, you can find the starter code [here](https://beta.solpg.io/62b552f3f6273245aca4f5c9). If you've been following along with the Movie Review demos, you'll notice that we've refactored our program.
 
-The refactored starter code is almost the same as what it was before. Since `lib.rs` was getting rather large and unwieldy, we've separated its code into 3 files: `lib.rs`, `entrypoint.rs`, and `processor.rs`. `lib.rs` now *only* registers the code's modules, `entrypoint.rs` *only* defines and sets the program's entrypoint, and `processor.rs` handles the program logic for processing instructions. We've also added an `error.rs` file where we'll be defining custom errors. The complete file structure is as follows:
+The refactored starter code is almost the same as what it was before. Since `lib.rs` was getting rather large and unwieldy, we've separated its code into 3 files: `lib.rs`, `entrypoint.rs`, and `processor.rs`. `lib.rs` now _only_ registers the code's modules, `entrypoint.rs` _only_ defines and sets the program's entrypoint, and `processor.rs` handles the program logic for processing instructions. We've also added an `error.rs` file where we'll be defining custom errors. The complete file structure is as follows:
 
 - **lib.rs** - register modules
 - **entrypoint.rs -** entry point to the program
@@ -204,11 +204,13 @@ In addition to some changes to file structure, we've updated a small amount of c
 Since we'll be allowing updates to movie reviews, we also changed `account_len` in the `add_movie_review` function (now in `processor.rs`). Instead of calculating the size of the review and setting the account length to only as large as it needs to be, we're simply going to allocate 1000 bytes to each review account. This way, we don’t have to worry about reallocating size or re-calculating rent when a user updates their movie review.
 
 We went from this:
+
 ```rust
 let account_len: usize = 1 + 1 + (4 + title.len()) + (4 + description.len());
 ```
 
 To this:
+
 ```rust
 let account_len: usize = 1000;
 ```
@@ -705,7 +707,7 @@ pub fn update_movie_review(
 
 ## 7. Build and upgrade
 
-We're ready to build and upgrade our program! You can test your program by submitting a transaction with the right instruction data. For that, feel free to use this [frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews).  Remember, to make sure you're testing the right program you'll need to replace `MOVIE_REVIEW_PROGRAM_ID` with your program ID in `Form.tsx` and `MovieCoordinator.ts`.
+We're ready to build and upgrade our program! You can test your program by submitting a transaction with the right instruction data. For that, feel free to use this [frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews). Remember, to make sure you're testing the right program you'll need to replace `MOVIE_REVIEW_PROGRAM_ID` with your program ID in `Form.tsx` and `MovieCoordinator.ts`.
 
 If you need more time with this project to feel comfortable with these concepts, have a look at the [solution code](https://beta.solpg.io/62c8c6dbf6273245aca4f5e7) before continuing.
 

--- a/developers/courses/solana-course/content/program-security.md
+++ b/developers/courses/solana-course/content/program-security.md
@@ -12,26 +12,54 @@ objectives:
 # TL;DR
 
 - **Thinking like an attacker** means asking "How do I break this?"
-- Perform **owner checks** to ensure that the provided account is owned by the public key you expect, e.g. ensuring that an account you expect to be a PDA is owned by `program_id`
-- Perform **signer checks** to ensure that any account modification has been signed by the right party or parties
-- **Account validation** entails ensuring that provided accounts are the accounts you expect them to be, e.g. deriving PDAs with the expected seeds to make sure the address matches the provided account
-- **Data validation** entails ensuring that any provided data meets the criteria required by the program
+- Perform **owner checks** to ensure that the provided account is owned by the
+  public key you expect, e.g. ensuring that an account you expect to be a PDA is
+  owned by `program_id`
+- Perform **signer checks** to ensure that any account modification has been
+  signed by the right party or parties
+- **Account validation** entails ensuring that provided accounts are the
+  accounts you expect them to be, e.g. deriving PDAs with the expected seeds to
+  make sure the address matches the provided account
+- **Data validation** entails ensuring that any provided data meets the criteria
+  required by the program
 
 # Overview
 
-In the last two lessons we worked through building a Movie Review program together. The end result is pretty cool! It's exciting to get something working in a new development environment.
+In the last two lessons we worked through building a Movie Review program
+together. The end result is pretty cool! It's exciting to get something working
+in a new development environment.
 
-Proper program development, however, doesn't end at "get it working." It's important to think through the possible failure points in your code in order to mitigate them. Failure points are where undesirable behavior in your code could potentially occur. Whether the undesirable behavior happens due to users interacting with your program in unexpected ways or bad actors intentionally trying to exploit your program, anticipating failure points is essential to secure program development.
+Proper program development, however, doesn't end at "get it working." It's
+important to think through the possible failure points in your code in order to
+mitigate them. Failure points are where undesirable behavior in your code could
+potentially occur. Whether the undesirable behavior happens due to users
+interacting with your program in unexpected ways or bad actors intentionally
+trying to exploit your program, anticipating failure points is essential to
+secure program development.
 
-Remember, **you have no control over the transactions that will be sent to your program once it’s deployed**. You can only control how your program handles them. While this lesson is far from a comprehensive overview of program security, we'll cover some of the basic pitfalls to look out for.
+Remember, **you have no control over the transactions that will be sent to your
+program once it’s deployed**. You can only control how your program handles
+them. While this lesson is far from a comprehensive overview of program
+security, we'll cover some of the basic pitfalls to look out for.
 
 ## Think like an attacker
 
-[Neodyme](https://workshop.neodyme.io/) gave a presentation at Breakpoint 2021 entitled "Think Like An Attacker: Bringing Smart Contracts to Their Break(ing) Point." If there's one thing you take away from this lesson, it's that you should think like an attacker.
+[Neodyme](https://workshop.neodyme.io/) gave a presentation at Breakpoint 2021
+entitled "Think Like An Attacker: Bringing Smart Contracts to Their Break(ing)
+Point." If there's one thing you take away from this lesson, it's that you
+should think like an attacker.
 
-In this lesson, of course, we cannot cover everything that could possibly go wrong with your programs. Ultimately, every program will have different security risks associated with it. While understanding common pitfalls is _essential_ to engineering good programs, it is _insufficient_ for deploying secure ones. In order to have the broadest security coverage possible, you have to approach your code with the right mindset.
+In this lesson, of course, we cannot cover everything that could possibly go
+wrong with your programs. Ultimately, every program will have different security
+risks associated with it. While understanding common pitfalls is _essential_ to
+engineering good programs, it is _insufficient_ for deploying secure ones. In
+order to have the broadest security coverage possible, you have to approach your
+code with the right mindset.
 
-As Neodyme mentioned in their presentation, the right mindset requires moving from the question "Is this broken?" to "How do I break this?" This is the first and most essential step in understanding what your code _actually does_ as opposed to what you wrote it to do.
+As Neodyme mentioned in their presentation, the right mindset requires moving
+from the question "Is this broken?" to "How do I break this?" This is the first
+and most essential step in understanding what your code _actually does_ as
+opposed to what you wrote it to do.
 
 ### All programs can be broken
 
@@ -39,17 +67,36 @@ It's not a question of "if."
 
 Rather, it's a question of "how much effort and dedication would it take."
 
-Our job as developers is to close as many holes as possible and increase the effort and dedication required to break our code. For example, in the Movie Review program we built together over the last two lessons, we wrote code to create new accounts to store movie reviews. If we take a closer look at the code, however, we'll notice how the program also facilitates a lot of unintentional behavior we could easily catch by asking "How do I break this?" We'll dig into some of these problems and how to fix them in this lesson, but remember that memorizing a few pitfalls isn't sufficient. It's up to you to change your mindset toward security.
+Our job as developers is to close as many holes as possible and increase the
+effort and dedication required to break our code. For example, in the Movie
+Review program we built together over the last two lessons, we wrote code to
+create new accounts to store movie reviews. If we take a closer look at the
+code, however, we'll notice how the program also facilitates a lot of
+unintentional behavior we could easily catch by asking "How do I break this?"
+We'll dig into some of these problems and how to fix them in this lesson, but
+remember that memorizing a few pitfalls isn't sufficient. It's up to you to
+change your mindset toward security.
 
 ## Error handling
 
-Before we dive into some of the common security pitfalls and how to avoid them, it's important to know how to use errors in your program. While your code can handle some issues gracefully, other issues will require that your program stop execution and return a program error.
+Before we dive into some of the common security pitfalls and how to avoid them,
+it's important to know how to use errors in your program. While your code can
+handle some issues gracefully, other issues will require that your program stop
+execution and return a program error.
 
 ### How to create errors
 
-While the `solana_program` crate provides a `ProgramError` enum with a list of generic errors we can use, it will often be useful to create your own. Your custom errors will be able to provide more context and detail while you're debugging your code.
+While the `solana_program` crate provides a `ProgramError` enum with a list of
+generic errors we can use, it will often be useful to create your own. Your
+custom errors will be able to provide more context and detail while you're
+debugging your code.
 
-We can define our own errors by creating an enum type listing the errors we want to use. For example, the `NoteError` contains variants `Forbidden` and `InvalidLength`. The enum is made into a Rust `Error` type by using the `derive` attribute macro to implement the `Error` trait from the `thiserror` library. Each error type also has its own `#[error("...")]` notation. This lets you provide an error message for each particular error type.
+We can define our own errors by creating an enum type listing the errors we want
+to use. For example, the `NoteError` contains variants `Forbidden` and
+`InvalidLength`. The enum is made into a Rust `Error` type by using the `derive`
+attribute macro to implement the `Error` trait from the `thiserror` library.
+Each error type also has its own `#[error("...")]` notation. This lets you
+provide an error message for each particular error type.
 
 ```rust
 use solana_program::{program_error::ProgramError};
@@ -67,7 +114,11 @@ pub enum NoteError {
 
 ### How to return errors
 
-The compiler expects errors returned by the program to be of type `ProgramError` from the `solana_program` crate. That means we won't be able to return our custom error unless we have a way to convert it into this type. The following implementation handles conversion between our custom error and the `ProgramError` type.
+The compiler expects errors returned by the program to be of type `ProgramError`
+from the `solana_program` crate. That means we won't be able to return our
+custom error unless we have a way to convert it into this type. The following
+implementation handles conversion between our custom error and the
+`ProgramError` type.
 
 ```rust
 impl From<NoteError> for ProgramError {
@@ -77,7 +128,8 @@ impl From<NoteError> for ProgramError {
 }
 ```
 
-To return the custom error from the program, simply use the `into()` method to convert the error into an instance of `ProgramError`.
+To return the custom error from the program, simply use the `into()` method to
+convert the error into an instance of `ProgramError`.
 
 ```rust
 if pda != *note_pda.key {
@@ -87,20 +139,33 @@ if pda != *note_pda.key {
 
 ## Basic security checks
 
-While these won't comprehensively secure your program, there are a few security checks you can keep in mind to fill in some of the larger gaps in your code:
+While these won't comprehensively secure your program, there are a few security
+checks you can keep in mind to fill in some of the larger gaps in your code:
 
 - Ownership checks - used to verify that an account is owned by the program
 - Signer checks - used to verify that an account has signed a transaction
-- General Account Validation - used to verify that an account is the expected account
+- General Account Validation - used to verify that an account is the expected
+  account
 - Data Validation - used to verify the inputs provided by a user
 
 ### Ownership checks
 
-An ownership check verifies that an account is owned by the expected public key. Let's use the note-taking app example that we've referenced in previous lessons. In this app, users can create, update, and delete notes that are stored by the program in PDA accounts.
+An ownership check verifies that an account is owned by the expected public key.
+Let's use the note-taking app example that we've referenced in previous lessons.
+In this app, users can create, update, and delete notes that are stored by the
+program in PDA accounts.
 
-When a user invokes the `update` instruction, they also provide a `pda_account`. We presume the provided `pda_account` is for the particular note they want to update, but the user can input any instruction data they want. They could even potentially send data which matches the data format of a note account but was not also created by the note-taking program. This security vulnerability is one potential way to introduce malicious code.
+When a user invokes the `update` instruction, they also provide a `pda_account`.
+We presume the provided `pda_account` is for the particular note they want to
+update, but the user can input any instruction data they want. They could even
+potentially send data which matches the data format of a note account but was
+not also created by the note-taking program. This security vulnerability is one
+potential way to introduce malicious code.
 
-The simplest way to avoid this problem is to always check that the owner of an account is the public key you expect it to be. In this case, we expect the note account to be a PDA account owned by the program itself. When this is not the case, we can report it as an error accordingly.
+The simplest way to avoid this problem is to always check that the owner of an
+account is the public key you expect it to be. In this case, we expect the note
+account to be a PDA account owned by the program itself. When this is not the
+case, we can report it as an error accordingly.
 
 ```rust
 if note_pda.owner != program_id {
@@ -108,11 +173,18 @@ if note_pda.owner != program_id {
 }
 ```
 
-As a side note, using PDAs whenever possible is more secure than trusting externally-owned accounts, even if they are owned by the transaction signer. The only accounts that the program has complete control over are PDA accounts, making them the most secure.
+As a side note, using PDAs whenever possible is more secure than trusting
+externally-owned accounts, even if they are owned by the transaction signer. The
+only accounts that the program has complete control over are PDA accounts,
+making them the most secure.
 
 ### Signer checks
 
-A signer check simply verifies that the right parties have signed a transaction. In the note-taking app, for example, we would want to verify that the note creator signed the transaction before we process the `update` instruction. Otherwise, anyone can update another user's notes by simply passing in the user's public key as the initializer.
+A signer check simply verifies that the right parties have signed a transaction.
+In the note-taking app, for example, we would want to verify that the note
+creator signed the transaction before we process the `update` instruction.
+Otherwise, anyone can update another user's notes by simply passing in the
+user's public key as the initializer.
 
 ```rust
 if !initializer.is_signer {
@@ -123,9 +195,18 @@ if !initializer.is_signer {
 
 ### General account validation
 
-In addition to checking the signers and owners of accounts, it's important to ensure that the provided accounts are what your code expects them to be. For example, you would want to validate that a provided PDA account's address can be derived with the expected seeds. This ensures that it is the account you expect it to be.
+In addition to checking the signers and owners of accounts, it's important to
+ensure that the provided accounts are what your code expects them to be. For
+example, you would want to validate that a provided PDA account's address can be
+derived with the expected seeds. This ensures that it is the account you expect
+it to be.
 
-In the note-taking app example, that would mean ensuring that you can derive a matching PDA using the note creator's public key and the ID as seeds (that's what we're assuming was used when creating the note). That way a user couldn't accidentally pass in a PDA account for the wrong note or, more importantly, that the user isn't passing in a PDA account that represents somebody else's note entirely.
+In the note-taking app example, that would mean ensuring that you can derive a
+matching PDA using the note creator's public key and the ID as seeds (that's
+what we're assuming was used when creating the note). That way a user couldn't
+accidentally pass in a PDA account for the wrong note or, more importantly, that
+the user isn't passing in a PDA account that represents somebody else's note
+entirely.
 
 ```rust
 let (pda, bump_seed) = Pubkey::find_program_address(&[note_creator.key.as_ref(), id.as_bytes().as_ref(),], program_id);
@@ -138,9 +219,13 @@ if pda != *note_pda.key {
 
 ## Data validation
 
-Similar to validating accounts, you should also validate any data provided by the client.
+Similar to validating accounts, you should also validate any data provided by
+the client.
 
-For example, you may have a game program where a user can allocate character attribute points to various categories. You may have a maximum limit in each category of 100, in which case you would want to verify that the existing allocation of points plus the new allocation doesn't exceed the maximum.
+For example, you may have a game program where a user can allocate character
+attribute points to various categories. You may have a maximum limit in each
+category of 100, in which case you would want to verify that the existing
+allocation of points plus the new allocation doesn't exceed the maximum.
 
 ```rust
 if character.agility + new_agility > 100 {
@@ -149,7 +234,8 @@ if character.agility + new_agility > 100 {
 }
 ```
 
-Or, the character may have an allowance of attribute points they can allocate and you want to make sure they don't exceed that allowance.
+Or, the character may have an allowance of attribute points they can allocate
+and you want to make sure they don't exceed that allowance.
 
 ```rust
 if attribute_allowance < new_agility {
@@ -158,15 +244,29 @@ if attribute_allowance < new_agility {
 }
 ```
 
-Without these checks, program behavior would differ from what you expect. In some cases, however, it's more than just an issue of undefined behavior. Sometimes failure to validate data can result in security loopholes that are financially devastating.
+Without these checks, program behavior would differ from what you expect. In
+some cases, however, it's more than just an issue of undefined behavior.
+Sometimes failure to validate data can result in security loopholes that are
+financially devastating.
 
-For example, imagine that the character referenced in these examples is an NFT. Further, imagine that the program allows the NFT to be staked to earn token rewards proportional to the NFTs number of attribute points. Failure to implement these data validation checks would allow a bad actor to assign an obscenely high number of attribute points and quickly drain your treasury of all the rewards that were meant to be spread more evenly amongst a larger pool of stakers.
+For example, imagine that the character referenced in these examples is an NFT.
+Further, imagine that the program allows the NFT to be staked to earn token
+rewards proportional to the NFTs number of attribute points. Failure to
+implement these data validation checks would allow a bad actor to assign an
+obscenely high number of attribute points and quickly drain your treasury of all
+the rewards that were meant to be spread more evenly amongst a larger pool of
+stakers.
 
 ### Integer overflow and underflow
 
-Rust integers have fixed sizes. This means they can only support a specific range of numbers. An arithmetic operation that results in a higher or lower value than what is supported by the range will cause the resulting value to wrap around. For example, a `u8` only supports numbers 0-255, so the result of addition that would be 256 would actually be 0, 257 would be 1, etc.
+Rust integers have fixed sizes. This means they can only support a specific
+range of numbers. An arithmetic operation that results in a higher or lower
+value than what is supported by the range will cause the resulting value to wrap
+around. For example, a `u8` only supports numbers 0-255, so the result of
+addition that would be 256 would actually be 0, 257 would be 1, etc.
 
-This is always important to keep in mind, but especially so when dealing with any code that represents true value, such as depositing and withdrawing tokens.
+This is always important to keep in mind, but especially so when dealing with
+any code that represents true value, such as depositing and withdrawing tokens.
 
 To avoid integer overflow and underflow, either:
 
@@ -180,17 +280,34 @@ To avoid integer overflow and underflow, either:
 
 # Demo
 
-Let’s practice together with the Movie Review program we've worked on in previous lessons. No worries if you’re just jumping into this lesson without having done the previous lesson - it should be possible to follow along either way.
+Let’s practice together with the Movie Review program we've worked on in
+previous lessons. No worries if you’re just jumping into this lesson without
+having done the previous lesson - it should be possible to follow along either
+way.
 
-As a refresher, the Movie Review program lets users store movie reviews in PDA accounts. Last lesson, we finished implementing the basic functionality of adding a movie review. Now, we'll add some security checks to the functionality we've already created and add the ability to update a movie review in a secure manner.
+As a refresher, the Movie Review program lets users store movie reviews in PDA
+accounts. Last lesson, we finished implementing the basic functionality of
+adding a movie review. Now, we'll add some security checks to the functionality
+we've already created and add the ability to update a movie review in a secure
+manner.
 
-Just as before, we'll be using [Solana Playground](https://beta.solpg.io/) to write, build, and deploy our code.
+Just as before, we'll be using [Solana Playground](https://beta.solpg.io/) to
+write, build, and deploy our code.
 
 ## 1. Get the starter code
 
-To begin, you can find the starter code [here](https://beta.solpg.io/62b552f3f6273245aca4f5c9). If you've been following along with the Movie Review demos, you'll notice that we've refactored our program.
+To begin, you can find the starter code
+[here](https://beta.solpg.io/62b552f3f6273245aca4f5c9). If you've been following
+along with the Movie Review demos, you'll notice that we've refactored our
+program.
 
-The refactored starter code is almost the same as what it was before. Since `lib.rs` was getting rather large and unwieldy, we've separated its code into 3 files: `lib.rs`, `entrypoint.rs`, and `processor.rs`. `lib.rs` now _only_ registers the code's modules, `entrypoint.rs` _only_ defines and sets the program's entrypoint, and `processor.rs` handles the program logic for processing instructions. We've also added an `error.rs` file where we'll be defining custom errors. The complete file structure is as follows:
+The refactored starter code is almost the same as what it was before. Since
+`lib.rs` was getting rather large and unwieldy, we've separated its code into 3
+files: `lib.rs`, `entrypoint.rs`, and `processor.rs`. `lib.rs` now _only_
+registers the code's modules, `entrypoint.rs` _only_ defines and sets the
+program's entrypoint, and `processor.rs` handles the program logic for
+processing instructions. We've also added an `error.rs` file where we'll be
+defining custom errors. The complete file structure is as follows:
 
 - **lib.rs** - register modules
 - **entrypoint.rs -** entry point to the program
@@ -199,9 +316,16 @@ The refactored starter code is almost the same as what it was before. Since `lib
 - **state.rs -** serialize and deserialize state
 - **error.rs -** custom program errors
 
-In addition to some changes to file structure, we've updated a small amount of code that will let this demo be more focused on security without having you write unnecessary boiler plate.
+In addition to some changes to file structure, we've updated a small amount of
+code that will let this demo be more focused on security without having you
+write unnecessary boiler plate.
 
-Since we'll be allowing updates to movie reviews, we also changed `account_len` in the `add_movie_review` function (now in `processor.rs`). Instead of calculating the size of the review and setting the account length to only as large as it needs to be, we're simply going to allocate 1000 bytes to each review account. This way, we don’t have to worry about reallocating size or re-calculating rent when a user updates their movie review.
+Since we'll be allowing updates to movie reviews, we also changed `account_len`
+in the `add_movie_review` function (now in `processor.rs`). Instead of
+calculating the size of the review and setting the account length to only as
+large as it needs to be, we're simply going to allocate 1000 bytes to each
+review account. This way, we don’t have to worry about reallocating size or
+re-calculating rent when a user updates their movie review.
 
 We went from this:
 
@@ -215,13 +339,21 @@ To this:
 let account_len: usize = 1000;
 ```
 
-The [realloc](https://docs.rs/solana-sdk/latest/solana_sdk/account_info/struct.AccountInfo.html#method.realloc) method was just recently enabled by Solana Labs which allows you to dynamically change the size of your accounts. We will not be using this method for this demo, but it’s something to be aware of.
+The [realloc](https://docs.rs/solana-sdk/latest/solana_sdk/account_info/struct.AccountInfo.html#method.realloc) method
+was just recently enabled by Solana Labs which allows you to dynamically change
+the size of your accounts. We will not be using this method for this demo, but
+it’s something to be aware of.
 
-Finally, we've also implemented some additional functionality for our `MovieAccountState` struct in `state.rs` using the `impl` keyword.
+Finally, we've also implemented some additional functionality for our
+`MovieAccountState` struct in `state.rs` using the `impl` keyword.
 
-For our movie reviews, we want the ability to check whether an account has already been initialized. To do this, we create an `is_initialized` function that checks the `is_initialized` field on the `MovieAccountState` struct.
+For our movie reviews, we want the ability to check whether an account has
+already been initialized. To do this, we create an `is_initialized` function
+that checks the `is_initialized` field on the `MovieAccountState` struct.
 
-`Sealed` is Solana's version of Rust's `Sized` trait. This simply specifies that `MovieAccountState` has a known size and provides for some compiler optimizations.
+`Sealed` is Solana's version of Rust's `Sized` trait. This simply specifies that
+`MovieAccountState` has a known size and provides for some compiler
+optimizations.
 
 ```rust
 // inside state.rs
@@ -234,18 +366,24 @@ impl IsInitialized for MovieAccountState {
 }
 ```
 
-Before moving on, make sure you have a solid grasp on the current state of the program. Look through the code and spend some time thinking through any spots that are confusing to you. It may be helpful to compare the starter code to the [solution code from the previous lesson](https://beta.solpg.io/62b23597f6273245aca4f5b4).
+Before moving on, make sure you have a solid grasp on the current state of the
+program. Look through the code and spend some time thinking through any spots
+that are confusing to you. It may be helpful to compare the starter code to the
+[solution code from the previous lesson](https://beta.solpg.io/62b23597f6273245aca4f5b4).
 
 ## 2. Custom Errors
 
-Let's begin by writing our custom program errors. We'll need errors that we can use in the following situations:
+Let's begin by writing our custom program errors. We'll need errors that we can
+use in the following situations:
 
-- The update instruction has been invoked on an account that hasn't been initialized yet
+- The update instruction has been invoked on an account that hasn't been
+  initialized yet
 - The provided PDA doesn't match the expected or derived PDA
 - The input data is larger than the program allows
 - The rating provided does not fall in the 1-5 range
 
-The starter code includes an empty `error.rs` file. Open that file and add errors for each of the above cases.
+The starter code includes an empty `error.rs` file. Open that file and add
+errors for each of the above cases.
 
 ```rust
 // inside error.rs
@@ -275,9 +413,12 @@ impl From<ReviewError> for ProgramError {
 }
 ```
 
-Note that in addition to adding the error cases, we also added the implementation that lets us convert our error into a `ProgramError` type as needed.
+Note that in addition to adding the error cases, we also added the
+implementation that lets us convert our error into a `ProgramError` type as
+needed.
 
-Before moving on, let’s bring `ReviewError` into scope in the `processor.rs`. We will be using these errors shortly when we add our security checks.
+Before moving on, let’s bring `ReviewError` into scope in the `processor.rs`. We
+will be using these errors shortly when we add our security checks.
 
 ```rust
 // inside processor.rs
@@ -286,11 +427,15 @@ use crate::error::ReviewError;
 
 ## 3. Add security checks to `add_movie_review`
 
-Now that we have errors to use, let's implement some security checks to our `add_movie_review` function.
+Now that we have errors to use, let's implement some security checks to our
+`add_movie_review` function.
 
 ### Signer check
 
-The first thing we should do is ensure that the `initializer` of a review is also a signer on the transaction. This ensures that you can't submit movie reviews impersonating somebody else. We'll put this check right after iterating through the accounts.
+The first thing we should do is ensure that the `initializer` of a review is
+also a signer on the transaction. This ensures that you can't submit movie
+reviews impersonating somebody else. We'll put this check right after iterating
+through the accounts.
 
 ```rust
 let account_info_iter = &mut accounts.iter();
@@ -307,7 +452,11 @@ if !initializer.is_signer {
 
 ### Account validation
 
-Next, let's make sure the `pda_account` passed in by the user is the `pda` we expect. Recall we derived the `pda` for a movie review using the `initializer` and `title` as seeds. Within our instruction we’ll derive the `pda` again and then check if it matches the `pda_account`. If the addresses do not match, we’ll return our custom `InvalidPDA` error.
+Next, let's make sure the `pda_account` passed in by the user is the `pda` we
+expect. Recall we derived the `pda` for a movie review using the `initializer`
+and `title` as seeds. Within our instruction we’ll derive the `pda` again and
+then check if it matches the `pda_account`. If the addresses do not match, we’ll
+return our custom `InvalidPDA` error.
 
 ```rust
 // Derive PDA and check that it matches client
@@ -323,7 +472,9 @@ if pda != *pda_account.key {
 
 Now let's perform some data validation.
 
-We'll start by making sure `rating` falls within the 1 to 5 scale. If the rating provided by the user outside of this range, we’ll return our custom `InvalidRating` error.
+We'll start by making sure `rating` falls within the 1 to 5 scale. If the rating
+provided by the user outside of this range, we’ll return our custom
+`InvalidRating` error.
 
 ```rust
 if rating > 5 || rating < 1 {
@@ -332,7 +483,9 @@ if rating > 5 || rating < 1 {
 }
 ```
 
-Next, let’s check that the content of the review does not exceed the 1000 bytes we’ve allocated for the account. If the size exceeds 1000 bytes, we’ll return our custom `InvalidDataLength` error.
+Next, let’s check that the content of the review does not exceed the 1000 bytes
+we’ve allocated for the account. If the size exceeds 1000 bytes, we’ll return
+our custom `InvalidDataLength` error.
 
 ```rust
 let total_len: usize = 1 + 1 + (4 + title.len()) + (4 + description.len());
@@ -342,7 +495,9 @@ if total_len > 1000 {
 }
 ```
 
-Lastly, let's checking if the account has already been initialized by calling the `is_initialized` function we implemented for our `MovieAccountState`. If the account already exists, then we will return an error.
+Lastly, let's checking if the account has already been initialized by calling
+the `is_initialized` function we implemented for our `MovieAccountState`. If the
+account already exists, then we will return an error.
 
 ```rust
 if account_data.is_initialized() {
@@ -438,9 +593,12 @@ pub fn add_movie_review(
 
 ## 4. Support movie review updates in `MovieInstruction`
 
-Now that `add_movie_review` is more secure, let's turn our attention to supporting the ability to update a movie review.
+Now that `add_movie_review` is more secure, let's turn our attention to
+supporting the ability to update a movie review.
 
-Let’s begin by updating `instruction.rs`. We’ll start by adding an `UpdateMovieReview` variant to `MovieInstruction` that includes embedded data for the new title, rating, and description.
+Let’s begin by updating `instruction.rs`. We’ll start by adding an
+`UpdateMovieReview` variant to `MovieInstruction` that includes embedded data
+for the new title, rating, and description.
 
 ```rust
 // inside instruction.rs
@@ -458,9 +616,11 @@ pub enum MovieInstruction {
 }
 ```
 
-The payload struct can stay the same since aside from the variant type, the instruction data is the same as what we used for `AddMovieReview`.
+The payload struct can stay the same since aside from the variant type, the
+instruction data is the same as what we used for `AddMovieReview`.
 
-Lastly, in the `unpack` function we need to add `UpdateMovieReview` to the match statement.
+Lastly, in the `unpack` function we need to add `UpdateMovieReview` to the match
+statement.
 
 ```rust
 // inside instruction.rs
@@ -485,7 +645,9 @@ impl MovieInstruction {
 
 ## 5. Define `update_movie_review` function
 
-Now that we can unpack our `instruction_data` and determine which instruction of the program to run, we can add `UpdateMovieReview` to the match statement in the `process_instruction` function in the `processor.rs` file.
+Now that we can unpack our `instruction_data` and determine which instruction of
+the program to run, we can add `UpdateMovieReview` to the match statement in
+the `process_instruction` function in the `processor.rs` file.
 
 ```rust
 // inside processor.rs
@@ -509,7 +671,8 @@ pub fn process_instruction(
 }
 ```
 
-Next, we can define the new `update_movie_review` function. The definition should have the same parameters as the definition of `add_movie_review`.
+Next, we can define the new `update_movie_review` function. The definition
+should have the same parameters as the definition of `add_movie_review`.
 
 ```rust
 pub fn update_movie_review(
@@ -525,9 +688,12 @@ pub fn update_movie_review(
 
 ## 6. Implement `update_movie_review` function
 
-All that's left now is to fill in the logic for updating a movie review. Only let's make it secure from the start.
+All that's left now is to fill in the logic for updating a movie review. Only
+let's make it secure from the start.
 
-Just like the `add_movie_review` function, let's start by iterating through the accounts. The only accounts we'll need are the first two: `initializer` and `pda_account`.
+Just like the `add_movie_review` function, let's start by iterating through the
+accounts. The only accounts we'll need are the first two: `initializer` and
+`pda_account`.
 
 ```rust
 pub fn update_movie_review(
@@ -551,7 +717,9 @@ pub fn update_movie_review(
 
 ### Ownership Check
 
-Before we continue, let's implement some basic security checks. We'll start with an ownership check on for `pda_account` to verify that it is owned by our program. If it isn't, we'll return an `InvalidOwner` error.
+Before we continue, let's implement some basic security checks. We'll start with
+an ownership check on for `pda_account` to verify that it is owned by our
+program. If it isn't, we'll return an `InvalidOwner` error.
 
 ```rust
 if pda_account.owner != program_id {
@@ -561,7 +729,11 @@ if pda_account.owner != program_id {
 
 ### Signer Check
 
-Next, let’s perform a signer check to verify that the `initializer` of the update instruction has also signed the transaction. Since we are updating the data for a movie review, we want to ensure that the original `initializer` of the review has approved the changes by signing the transaction. If the `initializer` did not sign the transaction, we’ll return an error.
+Next, let’s perform a signer check to verify that the `initializer` of the
+update instruction has also signed the transaction. Since we are updating the
+data for a movie review, we want to ensure that the original `initializer` of
+the review has approved the changes by signing the transaction. If the
+`initializer` did not sign the transaction, we’ll return an error.
 
 ```rust
 if !initializer.is_signer {
@@ -572,7 +744,10 @@ if !initializer.is_signer {
 
 ### Account Validation
 
-Next, let’s check that the `pda_account` passed in by the user is the PDA we expect by deriving the PDA using `initializer` and `title` as seeds. If the addresses do not match, we’ll return our custom `InvalidPDA` error. We'll implement this the same way we did in the `add_movie_review` function.
+Next, let’s check that the `pda_account` passed in by the user is the PDA we
+expect by deriving the PDA using `initializer` and `title` as seeds. If the
+addresses do not match, we’ll return our custom `InvalidPDA` error. We'll
+implement this the same way we did in the `add_movie_review` function.
 
 ```rust
 // Derive PDA and check that it matches client
@@ -586,7 +761,9 @@ if pda != *pda_account.key {
 
 ### Unpack `pda_account` and perform data validation
 
-Now that our code ensures we can trust the passed in accounts, let's unpack the `pda_account` and perform some data validation. We'll start by unpacking `pda_account` and assigning it to a mutable variable `account_data`.
+Now that our code ensures we can trust the passed in accounts, let's unpack the
+`pda_account` and perform some data validation. We'll start by unpacking
+`pda_account` and assigning it to a mutable variable `account_data`.
 
 ```rust
 msg!("unpacking state account");
@@ -594,7 +771,10 @@ let mut account_data = try_from_slice_unchecked::<MovieAccountState>(&pda_accoun
 msg!("borrowed account data");
 ```
 
-Now that we have access to the account and its fields, the first thing we need to do is verify that the account has already been initialized. An uninitialized account can't be updated so the program should return our custom `UninitializedAccount` error.
+Now that we have access to the account and its fields, the first thing we need
+to do is verify that the account has already been initialized. An uninitialized
+account can't be updated so the program should return our custom
+`UninitializedAccount` error.
 
 ```rust
 if !account_data.is_initialized() {
@@ -603,7 +783,12 @@ if !account_data.is_initialized() {
 }
 ```
 
-Next, we need to validate the `rating`, `title`, and `description` data just like in the `add_movie_review` function. We want to limit the `rating` to a scale of 1 to 5 and limit the overall size of the review to be fewer than 1000 bytes. If the rating provided by the user outside of this range, then we’ll return our custom `InvalidRating` error. If the review is too long, then we'll return our custom `InvalidDataLength` error.
+Next, we need to validate the `rating`, `title`, and `description` data just
+like in the `add_movie_review` function. We want to limit the `rating` to a
+scale of 1 to 5 and limit the overall size of the review to be fewer than 1000
+bytes. If the rating provided by the user outside of this range, then we’ll
+return our custom `InvalidRating` error. If the review is too long, then we'll
+return our custom `InvalidDataLength` error.
 
 ```rust
 if rating > 5 || rating < 1 {
@@ -620,7 +805,9 @@ if total_len > 1000 {
 
 ### Update the movie review account
 
-Now that we've implemented all of the security checks, we can finally update the movie review account by updating `account_data` and re-serializing it. At that point, we can return `Ok` from our program.
+Now that we've implemented all of the security checks, we can finally update the
+movie review account by updating `account_data` and re-serializing it. At that
+point, we can return `Ok` from our program.
 
 ```rust
 account_data.rating = rating;
@@ -631,7 +818,9 @@ account_data.serialize(&mut &mut pda_account.data.borrow_mut()[..])?;
 Ok(())
 ```
 
-All together, the `update_movie_review` function should look something like the code snippet below. We've included some additional logging for clarity in debugging.
+All together, the `update_movie_review` function should look something like the
+code snippet below. We've included some additional logging for clarity in
+debugging.
 
 ```rust
 pub fn update_movie_review(
@@ -707,19 +896,41 @@ pub fn update_movie_review(
 
 ## 7. Build and upgrade
 
-We're ready to build and upgrade our program! You can test your program by submitting a transaction with the right instruction data. For that, feel free to use this [frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews). Remember, to make sure you're testing the right program you'll need to replace `MOVIE_REVIEW_PROGRAM_ID` with your program ID in `Form.tsx` and `MovieCoordinator.ts`.
+We're ready to build and upgrade our program! You can test your program by
+submitting a transaction with the right instruction data. For that, feel free to
+use this
+[frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews).
+Remember, to make sure you're testing the right program you'll need to replace
+`MOVIE_REVIEW_PROGRAM_ID` with your program ID in `Form.tsx` and
+`MovieCoordinator.ts`.
 
-If you need more time with this project to feel comfortable with these concepts, have a look at the [solution code](https://beta.solpg.io/62c8c6dbf6273245aca4f5e7) before continuing.
+If you need more time with this project to feel comfortable with these concepts,
+have a look at the
+[solution code](https://beta.solpg.io/62c8c6dbf6273245aca4f5e7) before
+continuing.
 
 # Challenge
 
-Now it’s your turn to build something independently by building on top of the Student Intro program that you've used in previous lessons. If you haven't been following along or haven't saved your code from before, feel free to use [this starter code](https://beta.solpg.io/62b11ce4f6273245aca4f5b2).
+Now it’s your turn to build something independently by building on top of the
+Student Intro program that you've used in previous lessons. If you haven't been
+following along or haven't saved your code from before, feel free to use
+[this starter code](https://beta.solpg.io/62b11ce4f6273245aca4f5b2).
 
-The Student Intro program is a Solana Program that lets students introduce themselves. The program takes a user's name and a short message as the instruction_data and creates an account to store the data on-chain.
+The Student Intro program is a Solana Program that lets students introduce
+themselves. The program takes a user's name and a short message as the
+instruction_data and creates an account to store the data on-chain.
 
-Using what you've learned in this lesson, try applying what you've learned to the Student Intro Program. The program should:
+Using what you've learned in this lesson, try applying what you've learned to
+the Student Intro Program. The program should:
 
 1. Add an instruction allowing students to update their message
 2. Implement the basic security checks we've learned in this lesson
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://beta.solpg.io/62c9120df6273245aca4f5e8). Note that your code may look slightly different than the solution code depending on the checks you implement and the errors you write. Once you complete Module 3, we'd love to know more about your experience! Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%203), so that we can continue to improve the course.
+Try to do this independently if you can! But if you get stuck, feel free to
+reference the [solution code](https://beta.solpg.io/62c9120df6273245aca4f5e8).
+Note that your code may look slightly different than the solution code depending
+on the checks you implement and the errors you write. Once you complete Module
+3, we'd love to know more about your experience! Feel free to share some quick
+feedback
+[here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%203), so
+that we can continue to improve the course.

--- a/developers/courses/solana-course/content/program-state-management.md
+++ b/developers/courses/solana-course/content/program-state-management.md
@@ -1,11 +1,11 @@
 ---
 title: Create a Basic Program, Part 2 - State Management
 objectives:
-- Describe the process of creating a new account using a Program Derived Address (PDA)
-- Use seeds to derive a PDA
-- Use the space required by an account to calculate the amount of rent (in lamports) a user must allocate
-- Use a Cross Program Invocation (CPI) to initialize an account with a PDA as the address of the new account
-- Explain how to update the data stored on a new account
+  - Describe the process of creating a new account using a Program Derived Address (PDA)
+  - Use seeds to derive a PDA
+  - Use the space required by an account to calculate the amount of rent (in lamports) a user must allocate
+  - Use a Cross Program Invocation (CPI) to initialize an account with a PDA as the address of the new account
+  - Explain how to update the data stored on a new account
 ---
 
 # TL;DR
@@ -96,7 +96,7 @@ let rent_lamports = rent.minimum_balance(account_len);
 
 ### Program Derived Addresses (PDA)
 
-Before creating an account, we also need to have an address to assign the account. For program owned accounts, this will be a program derived address (PDA) found using the `find_program_address` function. 
+Before creating an account, we also need to have an address to assign the account. For program owned accounts, this will be a program derived address (PDA) found using the `find_program_address` function.
 
 As the name implies, PDAs are derived using the program ID (address of the program creating the account) and an optional list of “seeds”. Optional seeds are additional inputs used in the `find_program_address` function to derive the PDA. The function used to derive PDAs will return the same address every time when given the same inputs. This gives us the ability to create any number of PDA accounts and a deterministic way to find each account.
 
@@ -263,7 +263,7 @@ pub struct MovieAccountState {
     pub is_initialized: bool,
     pub rating: u8,
     pub title: String,
-    pub description: String  
+    pub description: String
 }
 ```
 
@@ -399,7 +399,6 @@ Using what you've learned in this lesson, build out this program. In addition to
 1. Create a separate account for each student
 2. Store `is_initialized` as a boolean, `name` as a string, and `msg` as a string in each account
 
-You can test your program by building the [frontend](https://github.com/Unboxed-Software/solana-student-intros-frontend) we created in the [Page, Order, and Filter Custom Account Data lesson](./paging-ordering-filtering-data.md). Remember to replace the program ID in the frontend code with the one you've deployed. 
+You can test your program by building the [frontend](https://github.com/Unboxed-Software/solana-student-intros-frontend) we created in the [Page, Order, and Filter Custom Account Data lesson](./paging-ordering-filtering-data.md). Remember to replace the program ID in the frontend code with the one you've deployed.
 
 Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://beta.solpg.io/62b11ce4f6273245aca4f5b2).
-

--- a/developers/courses/solana-course/content/program-state-management.md
+++ b/developers/courses/solana-course/content/program-state-management.md
@@ -1,40 +1,66 @@
 ---
 title: Create a Basic Program, Part 2 - State Management
 objectives:
-  - Describe the process of creating a new account using a Program Derived Address (PDA)
+  - Describe the process of creating a new account using a Program Derived
+    Address (PDA)
   - Use seeds to derive a PDA
-  - Use the space required by an account to calculate the amount of rent (in lamports) a user must allocate
-  - Use a Cross Program Invocation (CPI) to initialize an account with a PDA as the address of the new account
+  - Use the space required by an account to calculate the amount of rent (in
+    lamports) a user must allocate
+  - Use a Cross Program Invocation (CPI) to initialize an account with a PDA as
+    the address of the new account
   - Explain how to update the data stored on a new account
 ---
 
 # TL;DR
 
 - Program state is stored in other accounts rather than in the program itself
-- A Program Derived Address (PDA) is derived from a program ID and an optional list of seeds. Once derived, PDAs are subsequently used as the address for a storage account.
-- Creating an account requires that we calculate the space required and the corresponding rent to allocate for the new account
-- Creating a new account requires a Cross Program Invocation (CPI) to the `create_account` instruction on the System Program
-- Updating the data field on an account requires that we serialize (convert to byte array) the data into the account
+- A Program Derived Address (PDA) is derived from a program ID and an optional
+  list of seeds. Once derived, PDAs are subsequently used as the address for a
+  storage account.
+- Creating an account requires that we calculate the space required and the
+  corresponding rent to allocate for the new account
+- Creating a new account requires a Cross Program Invocation (CPI) to the
+  `create_account` instruction on the System Program
+- Updating the data field on an account requires that we serialize (convert to
+  byte array) the data into the account
 
 # Overview
 
-Solana maintains speed, efficiency, and extensibility in part by making programs stateless. Rather than having state stored on the program itself, programs use Solana's account model to read state from and write state to separate PDA accounts.
+Solana maintains speed, efficiency, and extensibility in part by making programs
+stateless. Rather than having state stored on the program itself, programs use
+Solana's account model to read state from and write state to separate PDA
+accounts.
 
-While this is an extremely flexible model, it's also a paradigm that can be difficult to work in if its unfamiliar. But don't worry! We'll start simple in this lesson and work up to more complex programs in the next module.
+While this is an extremely flexible model, it's also a paradigm that can be
+difficult to work in if its unfamiliar. But don't worry! We'll start simple in
+this lesson and work up to more complex programs in the next module.
 
-In this lesson we'll learn the basics of state management for a Solana program, including representing state as a Rust type, creating accounts using Program Derived Addresses, and serializing account data.
+In this lesson we'll learn the basics of state management for a Solana program,
+including representing state as a Rust type, creating accounts using Program
+Derived Addresses, and serializing account data.
 
 ## Program state
 
-All Solana accounts have a `data` field that holds a byte array. This makes accounts as flexible as files on a computer. You can store literally anything in an account (so long as the account has the storage space for it).
+All Solana accounts have a `data` field that holds a byte array. This makes
+accounts as flexible as files on a computer. You can store literally anything in
+an account (so long as the account has the storage space for it).
 
-Just as files in a traditional filesystem conform to specific data formats like PDF or MP3, the data stored in a Solana account needs to follow some kind of pattern so that the data can be retrieved and deserialized into something usable.
+Just as files in a traditional filesystem conform to specific data formats like
+PDF or MP3, the data stored in a Solana account needs to follow some kind of
+pattern so that the data can be retrieved and deserialized into something
+usable.
 
 ### Represent state as a Rust type
 
-When writing a program in Rust, we typically create this "format" by defining a Rust data type. If you went through the [first part of this lesson](basic-program-pt-1.md), this is very similar to what we did when we created an enum to represent discrete instructions.
+When writing a program in Rust, we typically create this "format" by defining a
+Rust data type. If you went through the
+[first part of this lesson](basic-program-pt-1.md), this is very similar to what
+we did when we created an enum to represent discrete instructions.
 
-While this type should reflect the structure of your data, for most use cases a simple struct is sufficient. For example, a note-taking program that stores notes in separate accounts would likely have data for a title, body, and maybe an ID of some kind. We could create a struct to represent that as follows:
+While this type should reflect the structure of your data, for most use cases a
+simple struct is sufficient. For example, a note-taking program that stores
+notes in separate accounts would likely have data for a title, body, and maybe
+an ID of some kind. We could create a struct to represent that as follows:
 
 ```rust
 struct NoteState {
@@ -46,9 +72,15 @@ struct NoteState {
 
 ### Using Borsh for serialization and deserialization
 
-Just as with instruction data, we need a mechanism for converting from our Rust data type to a byte array, and vice versa. **Serialization** is the process of converting an object into a byte array. **Deserialization** is the process of reconstructing an object from a byte array.
+Just as with instruction data, we need a mechanism for converting from our Rust
+data type to a byte array, and vice versa. **Serialization** is the process of
+converting an object into a byte array. **Deserialization** is the process of
+reconstructing an object from a byte array.
 
-We'll continue to use Borsh for serialization and deserialization. In Rust, we can use the `borsh` crate to get access to the `BorshSerialize` and `BorshDeserialize` traits. We can then apply those traits using the `derive` attribute macro.
+We'll continue to use Borsh for serialization and deserialization. In Rust, we
+can use the `borsh` crate to get access to the `BorshSerialize` and
+`BorshDeserialize` traits. We can then apply those traits using the `derive`
+attribute macro.
 
 ```rust
 use borsh::{BorshSerialize, BorshDeserialize};
@@ -61,11 +93,13 @@ struct NoteState {
 }
 ```
 
-These traits will provide methods on `NoteState` that we can use to serialize and deserialize the data as needed.
+These traits will provide methods on `NoteState` that we can use to serialize
+and deserialize the data as needed.
 
 ## Creating accounts
 
-Before we can update the data field of an account, we have to first create that account.
+Before we can update the data field of an account, we have to first create that
+account.
 
 To create a new account within our program we must:
 
@@ -75,15 +109,33 @@ To create a new account within our program we must:
 
 ### Space and rent
 
-Recall that storing data on the Solana network requires users to allocate rent in the form of lamports. The amount of rent required by a new account depends on the amount of space you would like allocated to that account. That means we need to know before creating the account how much space to allocate.
+Recall that storing data on the Solana network requires users to allocate rent
+in the form of lamports. The amount of rent required by a new account depends on
+the amount of space you would like allocated to that account. That means we need
+to know before creating the account how much space to allocate.
 
-Note that rent is more like a deposit. All the lamports allocated for rent can be fully refunded when an account is closed. Additionally, all new accounts are now required to be [rent-exempt](https://twitter.com/jacobvcreech/status/1524790032938287105), meaning lamports are not deducted from the account over time. An account is considered rent-exempt if it holds at least 2 years worth of rent. In other words, accounts are stored on-chain permanently until the owner closes the account and withdraws the rent.
+Note that rent is more like a deposit. All the lamports allocated for rent can
+be fully refunded when an account is closed. Additionally, all new accounts are
+now required to be
+[rent-exempt](https://twitter.com/jacobvcreech/status/1524790032938287105),
+meaning lamports are not deducted from the account over time. An account is
+considered rent-exempt if it holds at least 2 years worth of rent. In other
+words, accounts are stored on-chain permanently until the owner closes the
+account and withdraws the rent.
 
-In our note-taking app example, the `NoteState` struct specifies three fields that need to be stored in an account: `title`, `body`, and `id`. To calculate the size the account needs to be, you would simply add up the size required to store the data in each field.
+In our note-taking app example, the `NoteState` struct specifies three fields
+that need to be stored in an account: `title`, `body`, and `id`. To calculate
+the size the account needs to be, you would simply add up the size required to
+store the data in each field.
 
-For dynamic data, like strings, Borsh adds an additional 4 bytes at the beginning to store the length of that particular field. That means `title` and `body` are each 4 bytes plus their respective sizes. The `id` field is a 64-bit integer, or 8 bytes.
+For dynamic data, like strings, Borsh adds an additional 4 bytes at the
+beginning to store the length of that particular field. That means `title` and
+`body` are each 4 bytes plus their respective sizes. The `id` field is a 64-bit
+integer, or 8 bytes.
 
-You can add up those lengths and then calculate the rent required for that amount of space using the `minimum_balance` function from the `rent` module of the `solana_program` crate.
+You can add up those lengths and then calculate the rent required for that
+amount of space using the `minimum_balance` function from the `rent` module of
+the `solana_program` crate.
 
 ```rust
 // Calculate account size required for struct NoteState
@@ -96,13 +148,31 @@ let rent_lamports = rent.minimum_balance(account_len);
 
 ### Program Derived Addresses (PDA)
 
-Before creating an account, we also need to have an address to assign the account. For program owned accounts, this will be a program derived address (PDA) found using the `find_program_address` function.
+Before creating an account, we also need to have an address to assign the
+account. For program owned accounts, this will be a program derived address
+(PDA) found using the `find_program_address` function.
 
-As the name implies, PDAs are derived using the program ID (address of the program creating the account) and an optional list of “seeds”. Optional seeds are additional inputs used in the `find_program_address` function to derive the PDA. The function used to derive PDAs will return the same address every time when given the same inputs. This gives us the ability to create any number of PDA accounts and a deterministic way to find each account.
+As the name implies, PDAs are derived using the program ID (address of the
+program creating the account) and an optional list of “seeds”. Optional seeds
+are additional inputs used in the `find_program_address` function to derive the
+PDA. The function used to derive PDAs will return the same address every time
+when given the same inputs. This gives us the ability to create any number of
+PDA accounts and a deterministic way to find each account.
 
-In addition to the seeds you provide for deriving a PDA, the `find_program_address` function will provide one additional "bump seed." What makes PDAs unique from other Solana account addresses is that they do not have a corresponding secret key. This ensures that only the program that owns the address can sign on behalf of the PDA. When the `find_program_address` function attempts to derive a PDA using the provided seeds, it passes in the number 255 as the "bump seed." If the resulting address is invalid (i.e. has a corresponding secret key), then the function decreases the bump seed by 1 and derives a new PDA with that bump seed. Once a valid PDA is found, the function returns both the PDA and the bump that was used to derive the PDA.
+In addition to the seeds you provide for deriving a PDA, the
+`find_program_address` function will provide one additional "bump seed." What
+makes PDAs unique from other Solana account addresses is that they do not have a
+corresponding secret key. This ensures that only the program that owns the
+address can sign on behalf of the PDA. When the `find_program_address` function
+attempts to derive a PDA using the provided seeds, it passes in the number 255
+as the "bump seed." If the resulting address is invalid (i.e. has a
+corresponding secret key), then the function decreases the bump seed by 1 and
+derives a new PDA with that bump seed. Once a valid PDA is found, the function
+returns both the PDA and the bump that was used to derive the PDA.
 
-For our note-taking program, we will use the note creator's public key and the ID as the optional seeds to derive the PDA. Deriving the PDA this way allows us to deterministically find the account for each note.
+For our note-taking program, we will use the note creator's public key and the
+ID as the optional seeds to derive the PDA. Deriving the PDA this way allows us
+to deterministically find the account for each note.
 
 ```rust
 let (note_pda_account, bump_seed) = Pubkey::find_program_address(&[note_creator.key.as_ref(), id.as_bytes().as_ref(),], program_id);
@@ -110,7 +180,12 @@ let (note_pda_account, bump_seed) = Pubkey::find_program_address(&[note_creator.
 
 ### Cross Program Invocation (CPI)
 
-Once we’ve calculated the rent required for our account and found a valid PDA to assign as the address of the new account, we are finally ready to create the account. Creating a new account within our program requires a Cross Program Invocation (CPI). A CPI is when one program invokes an instruction on another program. To create a new account within our program, we will invoke the `create_account` instruction on the system program.
+Once we’ve calculated the rent required for our account and found a valid PDA to
+assign as the address of the new account, we are finally ready to create the
+account. Creating a new account within our program requires a Cross Program
+Invocation (CPI). A CPI is when one program invokes an instruction on another
+program. To create a new account within our program, we will invoke the
+`create_account` instruction on the system program.
 
 CPIs can be done using either `invoke` or `invoke_signed`.
 
@@ -129,9 +204,17 @@ pub fn invoke_signed(
 ) -> ProgramResult
 ```
 
-For this lesson we will use `invoke_signed`. Unlike a regular signature where a private key is used to sign, `invoke_signed` uses the optional seeds, bump seed, and program ID to derive a PDA and sign an instruction. This is done by comparing the derived PDA against all accounts passed into the instruction. If any of the accounts match the PDA, then the signer field for that account is set to true.
+For this lesson we will use `invoke_signed`. Unlike a regular signature where a
+private key is used to sign, `invoke_signed` uses the optional seeds, bump seed,
+and program ID to derive a PDA and sign an instruction. This is done by
+comparing the derived PDA against all accounts passed into the instruction. If
+any of the accounts match the PDA, then the signer field for that account is set
+to true.
 
-A program can securely sign transactions this way because `invoke_signed` generates the PDA used for signing with the program ID of the program invoking the instruction. Therefore, it is not possible for one program to generate a matching PDA to sign for an account with a PDA derived using another program ID.
+A program can securely sign transactions this way because `invoke_signed`
+generates the PDA used for signing with the program ID of the program invoking
+the instruction. Therefore, it is not possible for one program to generate a
+matching PDA to sign for an account with a PDA derived using another program ID.
 
 ```rust
 invoke_signed(
@@ -152,13 +235,22 @@ invoke_signed(
 
 ## Serializing and deserializing account data
 
-Once we've created a new account, we need to access and update the account's data field. This means deserializing its byte array into an instance of the type we created, updating the fields on that instance, then serializing that instance back into a byte array.
+Once we've created a new account, we need to access and update the account's
+data field. This means deserializing its byte array into an instance of the type
+we created, updating the fields on that instance, then serializing that instance
+back into a byte array.
 
 ### Deserialize account data
 
-The first step to updating an account's data is to deserialize its `data` byte array into its Rust type. You can do this by first borrowing the data field on the account. This allows you to access the data without taking ownership.
+The first step to updating an account's data is to deserialize its `data` byte
+array into its Rust type. You can do this by first borrowing the data field on
+the account. This allows you to access the data without taking ownership.
 
-You can then use the `try_from_slice_unchecked` function to deserialize the data field of the borrowed account using the format of the type you created to represent the data. This gives you an instance of your Rust type so you can easily update fields using dot notation. If we were to do this with the note-taking app example we've been using, it would look like this:
+You can then use the `try_from_slice_unchecked` function to deserialize the data
+field of the borrowed account using the format of the type you created to
+represent the data. This gives you an instance of your Rust type so you can
+easily update fields using dot notation. If we were to do this with the
+note-taking app example we've been using, it would look like this:
 
 ```rust
 let mut account_data = try_from_slice_unchecked::<NoteState>(note_pda_account.data.borrow()).unwrap();
@@ -170,25 +262,44 @@ account_data.id = id;
 
 ### Serialize account data
 
-Once the Rust instance representing the account's data has been updated with the appropriate values, you can "save" the data on the account.
+Once the Rust instance representing the account's data has been updated with the
+appropriate values, you can "save" the data on the account.
 
-This is done with the `serialize` function on the instance of the Rust type you created. You'll need to pass in a mutable reference to the account data. The syntax here is tricky, so don't worry if you don't understand it completely. Borrowing and references are two of the toughest concepts in Rust.
+This is done with the `serialize` function on the instance of the Rust type you
+created. You'll need to pass in a mutable reference to the account data. The
+syntax here is tricky, so don't worry if you don't understand it completely.
+Borrowing and references are two of the toughest concepts in Rust.
 
 ```rust
 account_data.serialize(&mut &mut note_pda_account.data.borrow_mut()[..])?;
 ```
 
-The above example converts the `account_data` object to a byte array and sets it to the `data` property on `note_pda_account`. This effectively saves the updated `account_data` variable to the data field of the new account. Now when a user fetches the `note_pda_account` and deserializes the data, it will display the updated data we’ve serialized into the account.
+The above example converts the `account_data` object to a byte array and sets it
+to the `data` property on `note_pda_account`. This effectively saves the updated
+`account_data` variable to the data field of the new account. Now when a user
+fetches the `note_pda_account` and deserializes the data, it will display the
+updated data we’ve serialized into the account.
 
 ## Iterators
 
-You may have noticed in the previous examples that we referenced `note_creator` and didn't show where that came from.
+You may have noticed in the previous examples that we referenced `note_creator`
+and didn't show where that came from.
 
-To get access to this and other accounts, we use an [Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html). An iterator is a Rust trait used to give sequential access to each element in a collection of values. Iterators are used in Solana programs to safely iterate over the list of accounts passed into the program entry point through the `accounts` argument.
+To get access to this and other accounts, we use an
+[Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html). An iterator
+is a Rust trait used to give sequential access to each element in a collection
+of values. Iterators are used in Solana programs to safely iterate over the list
+of accounts passed into the program entry point through the `accounts` argument.
 
 ### Rust iterator
 
-The iterator pattern allows you to perform some task on a sequence of items. The `iter()` method creates an iterator object that references a collection. An iterator is responsible for the logic of iterating over each item and determining when the sequence has finished. In Rust, iterators are lazy, meaning they have no effect until you call methods that consume the iterator to use it up. Once you've created an iterator, you must call the `next()` function on it to get the next item.
+The iterator pattern allows you to perform some task on a sequence of items. The
+`iter()` method creates an iterator object that references a collection. An
+iterator is responsible for the logic of iterating over each item and
+determining when the sequence has finished. In Rust, iterators are lazy, meaning
+they have no effect until you call methods that consume the iterator to use it
+up. Once you've created an iterator, you must call the `next()` function on it
+to get the next item.
 
 ```rust
 let v1 = vec![1, 2, 3];
@@ -205,13 +316,26 @@ let second_item = v1_iter.next();
 
 ### Solana accounts iterator
 
-Recall that the `AccountInfo` for all accounts required by an instruction are passing through a single `accounts` argument. In order to parse through the accounts and use them within our instruction, we will need to create an iterator with a mutable reference to the `accounts`.
+Recall that the `AccountInfo` for all accounts required by an instruction are
+passing through a single `accounts` argument. In order to parse through the
+accounts and use them within our instruction, we will need to create an iterator
+with a mutable reference to the `accounts`.
 
-At that point, instead of using the iterator directly, we pass it to the `next_account_info` function from the `account_info` module provided by the `solana_program` crate.
+At that point, instead of using the iterator directly, we pass it to the
+`next_account_info` function from the `account_info` module provided by the
+`solana_program` crate.
 
-For example, the instruction to create a new note in a note-taking program would at minimum require the accounts for the user creating the note, a PDA to store the note, and the `system_program` to initialize a new account. All three accounts would be passed into the program entry point through the `accounts` argument. An iterator of `accounts` is then used to separate out the `AccountInfo` associated with each account to process the instruction.
+For example, the instruction to create a new note in a note-taking program would
+at minimum require the accounts for the user creating the note, a PDA to store
+the note, and the `system_program` to initialize a new account. All three
+accounts would be passed into the program entry point through the `accounts`
+argument. An iterator of `accounts` is then used to separate out the
+`AccountInfo` associated with each account to process the instruction.
 
-Note that `&mut` means a mutable reference to the `accounts` argument. You can read more about references in Rust [here](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html) and the `mut` keyword [here](https://doc.rust-lang.org/std/keyword.mut.html).
+Note that `&mut` means a mutable reference to the `accounts` argument. You can
+read more about references in Rust
+[here](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html) and
+the `mut` keyword [here](https://doc.rust-lang.org/std/keyword.mut.html).
 
 ```rust
 // Get Account iterator
@@ -225,15 +349,27 @@ let system_program = next_account_info(account_info_iter)?;
 
 # Demo
 
-This overview covered a lot of new concepts. Let’s practice them together by continuing to work on the Movie Review program from the last lesson. No worries if you’re just jumping into this lesson without having done the previous lesson - it should be possible to follow along either way. We'll be using the [Solana Playground](https://beta.solpg.io) to write, build, and deploy our code.
+This overview covered a lot of new concepts. Let’s practice them together by
+continuing to work on the Movie Review program from the last lesson. No worries
+if you’re just jumping into this lesson without having done the previous
+lesson - it should be possible to follow along either way. We'll be using the
+[Solana Playground](https://beta.solpg.io) to write, build, and deploy our code.
 
-As a refresher, we are building a Solana program which lets users review movies. Last lesson, we deserialized the instruction data passed in by the user but we have not yet stored this data in an account. Let’s now update our program to create new accounts to store the user’s movie review.
+As a refresher, we are building a Solana program which lets users review movies.
+Last lesson, we deserialized the instruction data passed in by the user but we
+have not yet stored this data in an account. Let’s now update our program to
+create new accounts to store the user’s movie review.
 
 ### 1. Get the starter code
 
-If you didn’t complete the demo from the last lesson or just want to make sure that you didn’t miss anything, you can reference the starter code [here](https://beta.solpg.io/6295b25b0e6ab1eb92d947f7).
+If you didn’t complete the demo from the last lesson or just want to make sure
+that you didn’t miss anything, you can reference the starter code
+[here](https://beta.solpg.io/6295b25b0e6ab1eb92d947f7).
 
-Our program currently includes the `instruction.rs` file we use to deserialize the `instruction_data` passed into the program entry point. We have also completed `lib.rs` file to the point where we can print our deserialized instruction data to the program log using the `msg!` macro.
+Our program currently includes the `instruction.rs` file we use to deserialize
+the `instruction_data` passed into the program entry point. We have also
+completed `lib.rs` file to the point where we can print our deserialized
+instruction data to the program log using the `msg!` macro.
 
 ### 2. Create struct to represent account data
 
@@ -241,7 +377,8 @@ Let’s begin by creating a new file named `state.rs`.
 
 This file will:
 
-1. Define the struct our program uses to populate the data field of a new account
+1. Define the struct our program uses to populate the data field of a new
+   account
 2. Add `BorshSerialize` and `BorshDeserialize` traits to this struct
 
 First, let’s bring into scope everything we’ll need from the `borsh` crate.
@@ -250,7 +387,9 @@ First, let’s bring into scope everything we’ll need from the `borsh` crate.
 use borsh::{BorshSerialize, BorshDeserialize};
 ```
 
-Next, let’s create our `MovieAccountState` struct. This struct will define the parameters that each new movie review account will store in its data field. Our `MovieAccountState` struct will require the following parameters:
+Next, let’s create our `MovieAccountState` struct. This struct will define the
+parameters that each new movie review account will store in its data field. Our
+`MovieAccountState` struct will require the following parameters:
 
 - `is_initialized` - shows whether or not the account has been initialized
 - `rating` - user’s rating of the movie
@@ -269,7 +408,10 @@ pub struct MovieAccountState {
 
 ### 3. Update `lib.rs`
 
-Next, let’s update our `lib.rs` file. First, we’ll bring into scope everything we will need to complete our Movie Review program. You can read more about the details each item we are using from the `solana_program` crate [here](https://docs.rs/solana-program/latest/solana_program/).
+Next, let’s update our `lib.rs` file. First, we’ll bring into scope everything
+we will need to complete our Movie Review program. You can read more about the
+details each item we are using from the `solana_program` crate
+[here](https://docs.rs/solana-program/latest/solana_program/).
 
 ```rust
 use solana_program::{
@@ -294,7 +436,11 @@ use borsh::BorshSerialize;
 
 ### 4. Iterate through `accounts`
 
-Next, let’s continue building out our `add_movie_review` function. Recall that an array of accounts is passed into the `add_movie_review` function through a single `accounts` argument. To process our instruction, we will need to iterate through `accounts` and assign the `AccountInfo` for each account to its own variable.
+Next, let’s continue building out our `add_movie_review` function. Recall that
+an array of accounts is passed into the `add_movie_review` function through a
+single `accounts` argument. To process our instruction, we will need to iterate
+through `accounts` and assign the `AccountInfo` for each account to its own
+variable.
 
 ```rust
 // Get Account iterator
@@ -308,9 +454,16 @@ let system_program = next_account_info(account_info_iter)?;
 
 ### 5. Derive PDA
 
-Next, within our `add_movie_review` function, let’s independently derive the PDA we expect the user to have passed in. We'll need to provide the bump seed for the derivation later, so even though `pda_account` should reference the same account, we still need to call `find_program_address`.
+Next, within our `add_movie_review` function, let’s independently derive the PDA
+we expect the user to have passed in. We'll need to provide the bump seed for
+the derivation later, so even though `pda_account` should reference the same
+account, we still need to call `find_program_address`.
 
-Note that we derive the PDA for each new account using the initializer’s public key and the movie title as optional seeds. Setting up the PDA this way restricts each user to only one review for any one movie title. However, it still allows the same user to review movies with different titles and different users to review movies with the same title.
+Note that we derive the PDA for each new account using the initializer’s public
+key and the movie title as optional seeds. Setting up the PDA this way restricts
+each user to only one review for any one movie title. However, it still allows
+the same user to review movies with different titles and different users to
+review movies with the same title.
 
 ```rust
 // Derive PDA and check that it matches client
@@ -319,9 +472,14 @@ let (pda, bump_seed) = Pubkey::find_program_address(&[initializer.key.as_ref(), 
 
 ### 6. Calculate space and rent
 
-Next, let’s calculate the rent that our new account will need. Recall that rent is the amount of lamports a user must allocate to an account for storing data on the Solana network. To calculate rent, we must first calculate the amount of space our new account requires.
+Next, let’s calculate the rent that our new account will need. Recall that rent
+is the amount of lamports a user must allocate to an account for storing data on
+the Solana network. To calculate rent, we must first calculate the amount of
+space our new account requires.
 
-The `MovieAccountState` struct has four fields. We will allocate 1 byte each for `rating` and `is_initialized`. For both `title` and `description` we will allocate space equal to 4 bytes plus the length of the string.
+The `MovieAccountState` struct has four fields. We will allocate 1 byte each for
+`rating` and `is_initialized`. For both `title` and `description` we will
+allocate space equal to 4 bytes plus the length of the string.
 
 ```rust
 // Calculate account size required
@@ -334,7 +492,12 @@ let rent_lamports = rent.minimum_balance(account_len);
 
 ### 7. Create new account
 
-Once we’ve calculated the rent and verified the PDA, we are ready to create our new account. In order to create a new account, we must call the `create_account` instruction from the system program. We do this with a Cross Program Invocation (CPI) using the `invoke_signed` function. We use `invoke_signed` because we are creating the account using a PDA and need the Movie Review program to “sign” the instruction.
+Once we’ve calculated the rent and verified the PDA, we are ready to create our
+new account. In order to create a new account, we must call the `create_account`
+instruction from the system program. We do this with a Cross Program Invocation
+(CPI) using the `invoke_signed` function. We use `invoke_signed` because we are
+creating the account using a PDA and need the Movie Review program to “sign” the
+instruction.
 
 ```rust
 // Create the account
@@ -355,7 +518,10 @@ msg!("PDA created: {}", pda);
 
 ### 8. Update account data
 
-Now that we’ve created a new account, we are ready to update the data field of the new account using the format of the `MovieAccountState` struct from our `state.rs` file. We first deserialize the account data from `pda_account` using `try_from_slice_unchecked`, then set the values of each field.
+Now that we’ve created a new account, we are ready to update the data field of
+the new account using the format of the `MovieAccountState` struct from our
+`state.rs` file. We first deserialize the account data from `pda_account` using
+`try_from_slice_unchecked`, then set the values of each field.
 
 ```rust
 msg!("unpacking state account");
@@ -368,7 +534,8 @@ account_data.description = description;
 account_data.is_initialized = true;
 ```
 
-Lastly, we serialize the updated `account_data` into the data field of our `pda_account`.
+Lastly, we serialize the updated `account_data` into the data field of our
+`pda_account`.
 
 ```rust
 msg!("serializing account");
@@ -382,23 +549,49 @@ We're ready to build and deploy our program!
 
 ![Gif Build and Deploy Program](../assets/movie-review-pt2-build-deploy.gif)
 
-You can test your program by submitting a transaction with the right instruction data. For that, feel free to use [this script](https://github.com/Unboxed-Software/solana-movie-client) or [the frontend](https://github.com/Unboxed-Software/solana-movie-frontend) we built in the [Deserialize Custom Instruction Data lesson](deserialize-custom-data.md). In both cases, make sure you copy and paste the program ID for your program into the appropriate area of the source code to make sure you're testing the right program.
+You can test your program by submitting a transaction with the right instruction
+data. For that, feel free to use
+[this script](https://github.com/Unboxed-Software/solana-movie-client) or
+[the frontend](https://github.com/Unboxed-Software/solana-movie-frontend) we
+built in the
+[Deserialize Custom Instruction Data lesson](deserialize-custom-data.md). In
+both cases, make sure you copy and paste the program ID for your program into
+the appropriate area of the source code to make sure you're testing the right
+program.
 
-If you use the frontend, simply replace the `MOVIE_REVIEW_PROGRAM_ID` in both the `MovieList.tsx` and `Form.tsx` components with the address of the program you’ve deployed. Then run the frontend, submit a view, and refresh the browser to see the review.
+If you use the frontend, simply replace the `MOVIE_REVIEW_PROGRAM_ID` in both
+the `MovieList.tsx` and `Form.tsx` components with the address of the program
+you’ve deployed. Then run the frontend, submit a view, and refresh the browser
+to see the review.
 
-If you need more time with this project to feel comfortable with these concepts, have a look at the [solution code](https://beta.solpg.io/62b23597f6273245aca4f5b4) before continuing.
+If you need more time with this project to feel comfortable with these concepts,
+have a look at the
+[solution code](https://beta.solpg.io/62b23597f6273245aca4f5b4) before
+continuing.
 
 # Challenge
 
-Now it’s your turn to build something independently. Equipped with the concepts intoduced in this lesson, you now know everything you'll need to recreate the entirety of the Student Intro program from Module 1.
+Now it’s your turn to build something independently. Equipped with the concepts
+intoduced in this lesson, you now know everything you'll need to recreate the
+entirety of the Student Intro program from Module 1.
 
-The Student Intro program is a Solana Program that lets students introduce themselves. The program takes a user's name and a short message as the `instruction_data` and creates an account to store the data on-chain.
+The Student Intro program is a Solana Program that lets students introduce
+themselves. The program takes a user's name and a short message as the
+`instruction_data` and creates an account to store the data on-chain.
 
-Using what you've learned in this lesson, build out this program. In addition to taking a name a short message as instruction data, the program should:
+Using what you've learned in this lesson, build out this program. In addition to
+taking a name a short message as instruction data, the program should:
 
 1. Create a separate account for each student
-2. Store `is_initialized` as a boolean, `name` as a string, and `msg` as a string in each account
+2. Store `is_initialized` as a boolean, `name` as a string, and `msg` as a
+   string in each account
 
-You can test your program by building the [frontend](https://github.com/Unboxed-Software/solana-student-intros-frontend) we created in the [Page, Order, and Filter Custom Account Data lesson](./paging-ordering-filtering-data.md). Remember to replace the program ID in the frontend code with the one you've deployed.
+You can test your program by building the
+[frontend](https://github.com/Unboxed-Software/solana-student-intros-frontend)
+we created in the
+[Page, Order, and Filter Custom Account Data lesson](./paging-ordering-filtering-data.md).
+Remember to replace the program ID in the frontend code with the one you've
+deployed.
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://beta.solpg.io/62b11ce4f6273245aca4f5b2).
+Try to do this independently if you can! But if you get stuck, feel free to
+reference the [solution code](https://beta.solpg.io/62b11ce4f6273245aca4f5b2).

--- a/developers/courses/solana-course/content/reinitialization-attacks.md
+++ b/developers/courses/solana-course/content/reinitialization-attacks.md
@@ -3,31 +3,52 @@ title: Reinitialization Attacks
 objectives:
   - Explain security risks associated with a reinitialization vulnerability
   - Use long-form Rust check if an account has already been initialized
-  - Using Anchor’s `init` constraint to initialize accounts, which automatically sets an account discriminator that is checked to prevent the reinitialization of an account
+  - Using Anchor’s `init` constraint to initialize accounts, which automatically
+    sets an account discriminator that is checked to prevent the
+    reinitialization of an account
 ---
 
 # TL;DR
 
-- Use an account discriminator or initialization flag to check whether an account has already been initialized to prevent an account from being reinitialized and overriding existing account data.
-- To prevent account reinitialization in plain Rust, initialize accounts with an `is_initialized` flag and check if it has already been set to true when initializing an account
+- Use an account discriminator or initialization flag to check whether an
+  account has already been initialized to prevent an account from being
+  reinitialized and overriding existing account data.
+- To prevent account reinitialization in plain Rust, initialize accounts with an
+  `is_initialized` flag and check if it has already been set to true when
+  initializing an account
   ```rust
   if account.is_initialized {
       return Err(ProgramError::AccountAlreadyInitialized.into());
   }
   ```
-- To simplify this, use Anchor’s `init` constraint to create an account via a CPI to the system program and sets its discriminator
+- To simplify this, use Anchor’s `init` constraint to create an account via a
+  CPI to the system program and sets its discriminator
 
 # Overview
 
-Initialization refers to setting the data of a new account for the first time. When initializing a new account, you should implement a way to check if the account has already been initialized. Without an appropriate check, an existing account could be reinitialized and have existing data overwritten.
+Initialization refers to setting the data of a new account for the first time.
+When initializing a new account, you should implement a way to check if the
+account has already been initialized. Without an appropriate check, an existing
+account could be reinitialized and have existing data overwritten.
 
-Note that initializing an account and creating an account are two separate instructions. Creating an account requires invoking the `create_account` instruction on the System Program which specifies the space required for the account, the rent in lamports allocated to the account, and the program owner of the account. Initialization is an instruction that sets the data of a newly created account. Creating and initializing an account can be combined into a single transaction.
+Note that initializing an account and creating an account are two separate
+instructions. Creating an account requires invoking the `create_account`
+instruction on the System Program which specifies the space required for the
+account, the rent in lamports allocated to the account, and the program owner of
+the account. Initialization is an instruction that sets the data of a newly
+created account. Creating and initializing an account can be combined into a
+single transaction.
 
 ### Missing Initialization Check
 
-In the example below, there are no checks on the `user` account. The `initialize` instruction deserializes the data of the `user` account as a `User` account type, sets the `authority` field, and serializes the updated account data to the `user` account.
+In the example below, there are no checks on the `user` account. The
+`initialize` instruction deserializes the data of the `user` account as a `User`
+account type, sets the `authority` field, and serializes the updated account
+data to the `user` account.
 
-Without checks on the `user` account, the same account could be passed into the `initialize` instruction a second time by another party to overwrite the existing `authority` stored on the account data.
+Without checks on the `user` account, the same account could be passed into the
+`initialize` instruction a second time by another party to overwrite the
+existing `authority` stored on the account data.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -63,7 +84,9 @@ pub struct User {
 
 ### Add `is_initialized` check
 
-One approach to fix this is to add an additional `is_initialized` field to the `User` account type and use it as a flag to check if an account has already been initialized.
+One approach to fix this is to add an additional `is_initialized` field to the
+`User` account type and use it as a flag to check if an account has already been
+initialized.
 
 ```jsx
 if user.is_initialized {
@@ -71,7 +94,11 @@ if user.is_initialized {
 }
 ```
 
-By including a check within the `initialize` instruction, the `user` account would only be initialized if the `is_initialized` field has not yet been set to true. If the `is_initialized` field was already set, the transaction would fail, thereby avoiding the scenario where an attacker could replace the account authority with their own public key.
+By including a check within the `initialize` instruction, the `user` account
+would only be initialized if the `is_initialized` field has not yet been set to
+true. If the `is_initialized` field was already set, the transaction would fail,
+thereby avoiding the scenario where an attacker could replace the account
+authority with their own public key.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -114,11 +141,21 @@ pub struct User {
 
 ### Use Anchor’s `init` constraint
 
-Anchor provides an `init` constraint that can be used with the `#[account(...)]` attribute to initialize an account. The `init` constraint creates the account via a CPI to the system program and sets the account discriminator.
+Anchor provides an `init` constraint that can be used with the `#[account(...)]`
+attribute to initialize an account. The `init` constraint creates the account
+via a CPI to the system program and sets the account discriminator.
 
-The `init` constraint must be used in combination with the `payer` and `space` constraints. The `payer` specifies the account paying for the initialization of the new account. The `space` specifies the amount of space the new account requires, which determines the amount of lamports that must be allocated to the account. The first 8 bytes of data is set as a discriminator that Anchor automatically adds to identify the account type.
+The `init` constraint must be used in combination with the `payer` and `space`
+constraints. The `payer` specifies the account paying for the initialization of
+the new account. The `space` specifies the amount of space the new account
+requires, which determines the amount of lamports that must be allocated to the
+account. The first 8 bytes of data is set as a discriminator that Anchor
+automatically adds to identify the account type.
 
-Most importantly for this lesson, the `init` constraint ensures that this instruction can only be called once per account, so you can set the initial state of the account in the instruction logic and not have to worry about an attacker trying to reinitialize the account.
+Most importantly for this lesson, the `init` constraint ensures that this
+instruction can only be called once per account, so you can set the initial
+state of the account in the instruction logic and not have to worry about an
+attacker trying to reinitialize the account.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -152,28 +189,47 @@ pub struct User {
 
 ### Anchor’s `init_if_needed` constraint
 
-It’s worth noting that Anchor has an `init_if_needed` constraint. This constraint should be used very cautiously. In fact, it is blocked behind a feature flag so that you are forced to be intentional about using it.
+It’s worth noting that Anchor has an `init_if_needed` constraint. This
+constraint should be used very cautiously. In fact, it is blocked behind a
+feature flag so that you are forced to be intentional about using it.
 
-The `init_if_needed` constraint does the same thing as the `init` constraint, only if the account has already been initialized the instruction will still run.
+The `init_if_needed` constraint does the same thing as the `init` constraint,
+only if the account has already been initialized the instruction will still run.
 
-Given this, it’s ****\*****extremely****\***** important that when you use this constraint you include checks to avoid resetting the account to its initial state.
+Given this, it’s \***\*\*\*\***extremely\***\*\*\*\*** important that when you
+use this constraint you include checks to avoid resetting the account to its
+initial state.
 
-For example, if the account stores an `authority` field that gets set in the instruction using the `init_if_needed` constraint, you need checks that ensure that no attacker could call the instruction after it has already been initialized and have the `authority` field set again.
+For example, if the account stores an `authority` field that gets set in the
+instruction using the `init_if_needed` constraint, you need checks that ensure
+that no attacker could call the instruction after it has already been
+initialized and have the `authority` field set again.
 
-In most cases, it’s safer to have a separate instruction for initializing account data.
+In most cases, it’s safer to have a separate instruction for initializing
+account data.
 
 # Demo
 
-For this demo we’ll create a simple program that does nothing but initialize accounts. We’ll include two instructions:
+For this demo we’ll create a simple program that does nothing but initialize
+accounts. We’ll include two instructions:
 
 - `insecure_initialization` - initializes an account that can be reinitialized
-- `recommended_initialization` - initialize an account using Anchor’s `init` constraint
+- `recommended_initialization` - initialize an account using Anchor’s `init`
+  constraint
 
 ### 1. Starter
 
-To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-reinitialization-attacks/tree/starter). The starter code includes a program with one instruction and the boilerplate setup for the test file.
+To get started, download the starter code from the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-reinitialization-attacks/tree/starter).
+The starter code includes a program with one instruction and the boilerplate
+setup for the test file.
 
-The `insecure_initialization` instruction initializes a new `user` account that stores the public key of an `authority`. In this instruction, the account is expected to be allocated client-side, then passed into the program instruction. Once passed into the program, there are no checks to see if the `user` account's initial state has already been set. This means the same account can be passed in a second time to override the `authority` stored on an existing `user` account.
+The `insecure_initialization` instruction initializes a new `user` account that
+stores the public key of an `authority`. In this instruction, the account is
+expected to be allocated client-side, then passed into the program instruction.
+Once passed into the program, there are no checks to see if the `user` account's
+initial state has already been set. This means the same account can be passed in
+a second time to override the `authority` stored on an existing `user` account.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -209,9 +265,14 @@ pub struct User {
 
 ### 2. Test `insecure_initialization` instruction
 
-The test file includes the setup to create an account by invoking the system program and then invokes the `insecure_initialization` instruction twice using the same account.
+The test file includes the setup to create an account by invoking the system
+program and then invokes the `insecure_initialization` instruction twice using
+the same account.
 
-Since there are no checks the verify that the account data has not already been initialized, the `insecure_initialization` instruction will complete successfully both times, despite the second invocation providing a _different_ authority account.
+Since there are no checks the verify that the account data has not already been
+initialized, the `insecure_initialization` instruction will complete
+successfully both times, despite the second invocation providing a _different_
+authority account.
 
 ```tsx
 import * as anchor from "@project-serum/anchor";
@@ -292,11 +353,19 @@ initialization
 
 ### 3. Add `recommended_initialization` instruction
 
-Let's create a new instruction called `recommended_initialization` that fixes this problem. Unlike the previous insecure instruction, this instruction should handle both the creation and initialization of the user's account using Anchor's `init` constraint.
+Let's create a new instruction called `recommended_initialization` that fixes
+this problem. Unlike the previous insecure instruction, this instruction should
+handle both the creation and initialization of the user's account using Anchor's
+`init` constraint.
 
-This constraint instructs the program to create the account via a CPI to the system program, so the account no longer needs to be created client-side. The constraint also sets the account discriminator. Your instruction logic can then set the account's initial state.
+This constraint instructs the program to create the account via a CPI to the
+system program, so the account no longer needs to be created client-side. The
+constraint also sets the account discriminator. Your instruction logic can then
+set the account's initial state.
 
-By doing this, you ensure that any subsequent invocation of the same instruction with the same user account will fail rather than reset the account's initial state.
+By doing this, you ensure that any subsequent invocation of the same instruction
+with the same user account will fail rather than reset the account's initial
+state.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -326,7 +395,9 @@ pub struct Checked<'info> {
 
 ### 4. Test `recommended_initialization` instruction
 
-To test the `recommended_initialization` instruction, we’ll invoke the instruction twice just like before. This time, we expect the transaction to fail when we try to initialize the same account a second time.
+To test the `recommended_initialization` instruction, we’ll invoke the
+instruction twice just like before. This time, we expect the transaction to fail
+when we try to initialize the same account a second time.
 
 ```tsx
 describe("initialization", () => {
@@ -363,7 +434,9 @@ describe("initialization", () => {
 })
 ```
 
-Run `anchor test` and to see that the second transaction which tries to initialize the same account twice will now return an error stating the account address is already in use.
+Run `anchor test` and to see that the second transaction which tries to
+initialize the same account twice will now return an error stating the account
+address is already in use.
 
 ```bash
 'Program CpozUgSwe9FPLy9BLNhY2LTGqLUk1nirUkMMA5RmDw6t invoke [1]',
@@ -375,14 +448,24 @@ Run `anchor test` and to see that the second transaction which tries to initiali
 'Program CpozUgSwe9FPLy9BLNhY2LTGqLUk1nirUkMMA5RmDw6t failed: custom program error: 0x0'
 ```
 
-If you use Anchor's `init` constraint, that's usually all you need to protect against reinitialization attacks! Remember, just because the fix for these security exploits is simple doesn't mean it isn't important. Every time your initialize an account, make sure you're either using the `init` constraint or have some other check in place to avoid resetting an existing account's initial state.
+If you use Anchor's `init` constraint, that's usually all you need to protect
+against reinitialization attacks! Remember, just because the fix for these
+security exploits is simple doesn't mean it isn't important. Every time your
+initialize an account, make sure you're either using the `init` constraint or
+have some other check in place to avoid resetting an existing account's initial
+state.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [this repository](https://github.com/Unboxed-Software/solana-reinitialization-attacks/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[this repository](https://github.com/Unboxed-Software/solana-reinitialization-attacks/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that instructions are properly protected against reinitialization attacks.
+Take some time to review at least one program and ensure that instructions are
+properly protected against reinitialization attacks.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/reinitialization-attacks.md
+++ b/developers/courses/solana-course/content/reinitialization-attacks.md
@@ -1,9 +1,9 @@
 ---
 title: Reinitialization Attacks
 objectives:
-- Explain security risks associated with a reinitialization vulnerability
-- Use long-form Rust check if an account has already been initialized
-- Using Anchor’s `init` constraint to initialize accounts, which automatically sets an account discriminator that is checked to prevent the reinitialization of an account
+  - Explain security risks associated with a reinitialization vulnerability
+  - Use long-form Rust check if an account has already been initialized
+  - Using Anchor’s `init` constraint to initialize accounts, which automatically sets an account discriminator that is checked to prevent the reinitialization of an account
 ---
 
 # TL;DR
@@ -156,7 +156,7 @@ It’s worth noting that Anchor has an `init_if_needed` constraint. This constra
 
 The `init_if_needed` constraint does the same thing as the `init` constraint, only if the account has already been initialized the instruction will still run.
 
-Given this, it’s *********extremely********* important that when you use this constraint you include checks to avoid resetting the account to its initial state.
+Given this, it’s ****\*****extremely****\***** important that when you use this constraint you include checks to avoid resetting the account to its initial state.
 
 For example, if the account stores an `authority` field that gets set in the instruction using the `init_if_needed` constraint, you need checks that ensure that no attacker could call the instruction after it has already been initialized and have the `authority` field set again.
 
@@ -171,7 +171,7 @@ For this demo we’ll create a simple program that does nothing but initialize a
 
 ### 1. Starter
 
-To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-reinitialization-attacks/tree/starter). The starter code includes a program with one instruction and the boilerplate setup for the test file. 
+To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-reinitialization-attacks/tree/starter). The starter code includes a program with one instruction and the boilerplate setup for the test file.
 
 The `insecure_initialization` instruction initializes a new `user` account that stores the public key of an `authority`. In this instruction, the account is expected to be allocated client-side, then passed into the program instruction. Once passed into the program, there are no checks to see if the `user` account's initial state has already been set. This means the same account can be passed in a second time to override the `authority` stored on an existing `user` account.
 
@@ -209,27 +209,27 @@ pub struct User {
 
 ### 2. Test `insecure_initialization` instruction
 
-The test file includes the setup to create an account by invoking the system program and then invokes the `insecure_initialization` instruction twice using the same account. 
+The test file includes the setup to create an account by invoking the system program and then invokes the `insecure_initialization` instruction twice using the same account.
 
-Since there are no checks the verify that the account data has not already been initialized, the `insecure_initialization` instruction will complete successfully both times, despite the second invocation providing a *different* authority account.
+Since there are no checks the verify that the account data has not already been initialized, the `insecure_initialization` instruction will complete successfully both times, despite the second invocation providing a _different_ authority account.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
-import { expect } from "chai"
-import { Initialization } from "../target/types/initialization"
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { expect } from "chai";
+import { Initialization } from "../target/types/initialization";
 
 describe("initialization", () => {
-  const provider = anchor.AnchorProvider.env()
-  anchor.setProvider(provider)
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
 
-  const program = anchor.workspace.Initialization as Program<Initialization>
+  const program = anchor.workspace.Initialization as Program<Initialization>;
 
-  const wallet = anchor.workspace.Initialization.provider.wallet
-  const walletTwo = anchor.web3.Keypair.generate()
+  const wallet = anchor.workspace.Initialization.provider.wallet;
+  const walletTwo = anchor.web3.Keypair.generate();
 
-  const userInsecure = anchor.web3.Keypair.generate()
-  const userRecommended = anchor.web3.Keypair.generate()
+  const userInsecure = anchor.web3.Keypair.generate();
+  const userRecommended = anchor.web3.Keypair.generate();
 
   before(async () => {
     const tx = new anchor.web3.Transaction().add(
@@ -238,25 +238,25 @@ describe("initialization", () => {
         newAccountPubkey: userInsecure.publicKey,
         space: 32,
         lamports: await provider.connection.getMinimumBalanceForRentExemption(
-          32
+          32,
         ),
         programId: program.programId,
-      })
-    )
+      }),
+    );
 
     await anchor.web3.sendAndConfirmTransaction(provider.connection, tx, [
       wallet.payer,
       userInsecure,
-    ])
+    ]);
 
     await provider.connection.confirmTransaction(
       await provider.connection.requestAirdrop(
         walletTwo.publicKey,
-        1 * anchor.web3.LAMPORTS_PER_SOL
+        1 * anchor.web3.LAMPORTS_PER_SOL,
       ),
-      "confirmed"
-    )
-  })
+      "confirmed",
+    );
+  });
 
   it("Insecure init", async () => {
     await program.methods
@@ -264,8 +264,8 @@ describe("initialization", () => {
       .accounts({
         user: userInsecure.publicKey,
       })
-      .rpc()
-  })
+      .rpc();
+  });
 
   it("Re-invoke insecure init with different auth", async () => {
     const tx = await program.methods
@@ -274,12 +274,12 @@ describe("initialization", () => {
         user: userInsecure.publicKey,
         authority: walletTwo.publicKey,
       })
-      .transaction()
+      .transaction();
     await anchor.web3.sendAndConfirmTransaction(provider.connection, tx, [
       walletTwo,
-    ])
-  })
-})
+    ]);
+  });
+});
 ```
 
 Run `anchor test` to see that both transactions will complete successfully.
@@ -326,7 +326,7 @@ pub struct Checked<'info> {
 
 ### 4. Test `recommended_initialization` instruction
 
-To test the `recommended_initialization` instruction, we’ll invoke the instruction twice just like before. This time, we expect the transaction to fail when we try to initialize the same account a second time. 
+To test the `recommended_initialization` instruction, we’ll invoke the instruction twice just like before. This time, we expect the transaction to fail when we try to initialize the same account a second time.
 
 ```tsx
 describe("initialization", () => {

--- a/developers/courses/solana-course/content/rust-macros.md
+++ b/developers/courses/solana-course/content/rust-macros.md
@@ -8,44 +8,76 @@ objectives:
 
 # TL;DR
 
-- **Procedural macros** are a special kind of Rust macro that allow the programmer to generate code at compile time based on custom input.
-- In the Anchor framework, procedural macros are used to generate code that reduces the amount of boilerplate required when writing Solana programs.
-- An **Abstract Syntax Tree (AST)** is a representation of the syntax and structure of the input code that is passed to a procedural macro. When creating a macro, you use elements of the AST like tokens and items to generate the appropriate code.
-- A **Token** is the smallest unit of source code that can be parsed by the compiler in Rust.
-- An **Item** is a declaration that defines something that can be used in a Rust program, such as a struct, an enum, a trait, a function, or a method.
-- A **TokenStream** is a sequence of tokens that represents a piece of source code, and can be passed to a procedural macro to allow it to access and manipulate the individual tokens in the code.
+- **Procedural macros** are a special kind of Rust macro that allow the
+  programmer to generate code at compile time based on custom input.
+- In the Anchor framework, procedural macros are used to generate code that
+  reduces the amount of boilerplate required when writing Solana programs.
+- An **Abstract Syntax Tree (AST)** is a representation of the syntax and
+  structure of the input code that is passed to a procedural macro. When
+  creating a macro, you use elements of the AST like tokens and items to
+  generate the appropriate code.
+- A **Token** is the smallest unit of source code that can be parsed by the
+  compiler in Rust.
+- An **Item** is a declaration that defines something that can be used in a Rust
+  program, such as a struct, an enum, a trait, a function, or a method.
+- A **TokenStream** is a sequence of tokens that represents a piece of source
+  code, and can be passed to a procedural macro to allow it to access and
+  manipulate the individual tokens in the code.
 
 # Overview
 
-In Rust, a macro is a piece of code that you can write once and then "expand" to generate code at compile time. This can be useful when you need to generate code that is repetitive or complex, or when you want to use the same code in multiple places in your program.
+In Rust, a macro is a piece of code that you can write once and then "expand" to
+generate code at compile time. This can be useful when you need to generate code
+that is repetitive or complex, or when you want to use the same code in multiple
+places in your program.
 
-There are two different types of macros: declarative macros and procedural macros.
+There are two different types of macros: declarative macros and procedural
+macros.
 
-- Declarative macros are defined using the `macro_rules!` macro, which allows you to match against patterns of code and generate code based on the matching pattern.
-- Procedural macros in Rust are defined using Rust code and operate on the abstract syntax tree (AST) of the input TokenStream, which allows them to manipulate and generate code at a finer level of detail.
+- Declarative macros are defined using the `macro_rules!` macro, which allows
+  you to match against patterns of code and generate code based on the matching
+  pattern.
+- Procedural macros in Rust are defined using Rust code and operate on the
+  abstract syntax tree (AST) of the input TokenStream, which allows them to
+  manipulate and generate code at a finer level of detail.
 
-In this lesson, we'll focus on procedural macros, which are commonly used in the Anchor framework.
+In this lesson, we'll focus on procedural macros, which are commonly used in the
+Anchor framework.
 
 ## Rust concepts
 
-Before we dig into macros, specifically, let's talk about some of the important terminology, concepts, and tools we'll be using throughout the lesson.
+Before we dig into macros, specifically, let's talk about some of the important
+terminology, concepts, and tools we'll be using throughout the lesson.
 
 ### Token
 
-In the context of Rust programming, a [token](https://doc.rust-lang.org/reference/tokens.html) is a basic element of the language syntax like an identifier or literal value. Tokens represent the smallest unit of source code that are recognized by the Rust compiler, and they are used to build up more complex expressions and statements in a program.
+In the context of Rust programming, a
+[token](https://doc.rust-lang.org/reference/tokens.html) is a basic element of
+the language syntax like an identifier or literal value. Tokens represent the
+smallest unit of source code that are recognized by the Rust compiler, and they
+are used to build up more complex expressions and statements in a program.
 
 Examples of Rust tokens include:
 
-- [Keywords](https://doc.rust-lang.org/reference/keywords.html), such as `fn`, `let`, and `match`, are reserved words in the Rust language that have special meanings.
-- [Identifiers](https://doc.rust-lang.org/reference/identifiers.html), such as variable and function names, are used to refer to values and functions.
-- [Punctuation](https://doc.rust-lang.org/reference/tokens.html#punctuation) marks, such as `{`, `}`, and `;`, are used to structure and delimit blocks of code.
-- [Literals](https://doc.rust-lang.org/reference/tokens.html#literals), such as numbers and strings, represent constant values in a Rust program.
+- [Keywords](https://doc.rust-lang.org/reference/keywords.html), such as `fn`,
+  `let`, and `match`, are reserved words in the Rust language that have special
+  meanings.
+- [Identifiers](https://doc.rust-lang.org/reference/identifiers.html), such as
+  variable and function names, are used to refer to values and functions.
+- [Punctuation](https://doc.rust-lang.org/reference/tokens.html#punctuation)
+  marks, such as `{`, `}`, and `;`, are used to structure and delimit blocks of
+  code.
+- [Literals](https://doc.rust-lang.org/reference/tokens.html#literals), such as
+  numbers and strings, represent constant values in a Rust program.
 
-You can read more about Rust tokens [here](https://doc.rust-lang.org/reference/tokens.html).
+You can read more about Rust tokens
+[here](https://doc.rust-lang.org/reference/tokens.html).
 
 ### Item
 
-Items are named, self-contained pieces of code in Rust. They provide a way to group related code together and give it a name by which the group can be referenced. This allows you to reuse and organize your code in a modular way.
+Items are named, self-contained pieces of code in Rust. They provide a way to
+group related code together and give it a name by which the group can be
+referenced. This allows you to reuse and organize your code in a modular way.
 
 There are several different kinds of items, such as:
 
@@ -56,13 +88,18 @@ There are several different kinds of items, such as:
 - Modules
 - Macros
 
-You can read more about Rust items [here](https://doc.rust-lang.org/reference/items.html).
+You can read more about Rust items
+[here](https://doc.rust-lang.org/reference/items.html).
 
 ### Token Streams
 
-The `TokenStream` type is a data type that represents a sequence of tokens. This type is defined in the `proc_macro` crate and is surfaced as a way for you write macros based on other code in the codebase.
+The `TokenStream` type is a data type that represents a sequence of tokens. This
+type is defined in the `proc_macro` crate and is surfaced as a way for you write
+macros based on other code in the codebase.
 
-When defining a procedural macro, the macro input is passed to the macro as a `TokenStream`, which can then be parsed and transformed as needed. The resulting `TokenStream` can then be expanded into the final code output by the macro.
+When defining a procedural macro, the macro input is passed to the macro as a
+`TokenStream`, which can then be parsed and transformed as needed. The resulting
+`TokenStream` can then be expanded into the final code output by the macro.
 
 ```rust
 use proc_macro::TokenStream;
@@ -75,13 +112,23 @@ pub fn my_macro(input: TokenStream) -> TokenStream {
 
 ### Abstract syntax tree
 
-In the context of a Rust procedural macro, an abstract syntax tree (AST) is a data structure that represents the hierarchical structure of the input tokens and their meaning in the Rust language. It's typically used as an intermediate representation of the input that can be easily processed and transformed by the procedural macro.
+In the context of a Rust procedural macro, an abstract syntax tree (AST) is a
+data structure that represents the hierarchical structure of the input tokens
+and their meaning in the Rust language. It's typically used as an intermediate
+representation of the input that can be easily processed and transformed by the
+procedural macro.
 
-The macro can use the AST to analyze the input code and make changes to it, such as adding or removing tokens, or transforming the meaning of the code in some way. It can then use this transformed AST to generate new code, which can be returned as the output of the proc macro.
+The macro can use the AST to analyze the input code and make changes to it, such
+as adding or removing tokens, or transforming the meaning of the code in some
+way. It can then use this transformed AST to generate new code, which can be
+returned as the output of the proc macro.
 
 ### The `syn` crate
 
-The `syn` crate is available to help parse a token stream into an AST that macro code can traverse and manipulate. When a procedural macro is invoked in a Rust program, the macro function is called with the a token stream as the input. Parsing this input is the first step to virtually any macro.
+The `syn` crate is available to help parse a token stream into an AST that macro
+code can traverse and manipulate. When a procedural macro is invoked in a Rust
+program, the macro function is called with the a token stream as the input.
+Parsing this input is the first step to virtually any macro.
 
 Take as an example a proc macro that you invoke using `my_macro!`as follows:
 
@@ -89,7 +136,8 @@ Take as an example a proc macro that you invoke using `my_macro!`as follows:
 my_macro!("hello, world");
 ```
 
-When the above code is executed, the Rust compiler passes the input tokens (`"hello, world"`) as a `TokenStream` to the `my_macro` proc macro.
+When the above code is executed, the Rust compiler passes the input tokens
+(`"hello, world"`) as a `TokenStream` to the `my_macro` proc macro.
 
 ```rust
 use proc_macro::TokenStream;
@@ -103,7 +151,11 @@ pub fn my_macro(input: TokenStream) -> TokenStream {
 }
 ```
 
-Inside the proc macro, the code uses the `parse_macro_input!` macro from the `syn` crate to parse the input `TokenStream` into an abstract syntax tree (AST). Specifically, this example parses it as an instance of `LitStr` that represents a string literal in Rust. The `eprintln!` macro is then used to print the `LitStr` AST for debugging purposes.
+Inside the proc macro, the code uses the `parse_macro_input!` macro from the
+`syn` crate to parse the input `TokenStream` into an abstract syntax tree (AST).
+Specifically, this example parses it as an instance of `LitStr` that represents
+a string literal in Rust. The `eprintln!` macro is then used to print the
+`LitStr` AST for debugging purposes.
 
 ```rust
 LitStr {
@@ -116,13 +168,20 @@ LitStr {
 }
 ```
 
-The output of the `eprintln!` macro shows the structure of the `LitStr` AST that was generated from the input tokens. It shows the string literal value (`"hello, world"`) and other metadata about the token, such as its kind (`Str`), suffix (`None`), and span.
+The output of the `eprintln!` macro shows the structure of the `LitStr` AST that
+was generated from the input tokens. It shows the string literal value
+(`"hello, world"`) and other metadata about the token, such as its kind (`Str`),
+suffix (`None`), and span.
 
 ### The `quote` crate
 
-Another important crate is the `quote` crate. This crate is pivotal in the code generation portion of the macro.
+Another important crate is the `quote` crate. This crate is pivotal in the code
+generation portion of the macro.
 
-Once a proc macro has finished analyzing and transforming the AST, it can use the `quote` crate or a similar code generation library to convert the AST back into a token stream. After that, it returns the `TokenStream`, which the Rust compiler uses to replace the original stream in the source code.
+Once a proc macro has finished analyzing and transforming the AST, it can use
+the `quote` crate or a similar code generation library to convert the AST back
+into a token stream. After that, it returns the `TokenStream`, which the Rust
+compiler uses to replace the original stream in the source code.
 
 Take the below example of `my_macro`:
 
@@ -142,29 +201,43 @@ pub fn my_macro(input: TokenStream) -> TokenStream {
 }
 ```
 
-This example uses the `quote!` macro to generate a new `TokenStream` consisting of a `println!` macro call with the `LitStr` AST as its argument.
+This example uses the `quote!` macro to generate a new `TokenStream` consisting
+of a `println!` macro call with the `LitStr` AST as its argument.
 
-Note that the `quote!` macro generates a `TokenStream` of type `proc_macro2::TokenStream`. To return this `TokenStream` to the Rust compiler, you need to use the `.into()` method to convert it to `proc_macro::TokenStream`. The Rust compiler will then use this `TokenStream` to replace the original proc macro call in the source code.
+Note that the `quote!` macro generates a `TokenStream` of type
+`proc_macro2::TokenStream`. To return this `TokenStream` to the Rust compiler,
+you need to use the `.into()` method to convert it to `proc_macro::TokenStream`.
+The Rust compiler will then use this `TokenStream` to replace the original proc
+macro call in the source code.
 
 ```text
 The input is: hello, world
 ```
 
-This allows you to create procedural macros that perform powerful code generation and metaprogramming tasks.
+This allows you to create procedural macros that perform powerful code
+generation and metaprogramming tasks.
 
 ## Procedural Macro
 
-Procedural macros in Rust are a powerful way to extend the language and create custom syntax. These macros are written in Rust and are compiled along with the rest of the code. There are three types of procedural macros:
+Procedural macros in Rust are a powerful way to extend the language and create
+custom syntax. These macros are written in Rust and are compiled along with the
+rest of the code. There are three types of procedural macros:
 
 - Function-like macros - `custom!(...)`
 - Derive macros - `#[derive(CustomDerive)]`
 - Attribute macros - `#[CustomAttribute]`
 
-This section will discuss the three types of procedural macros and provide an example implementation of one. The process of writing a procedural macro is consistent across all three types, so the example provided can be adapted to the other types.
+This section will discuss the three types of procedural macros and provide an
+example implementation of one. The process of writing a procedural macro is
+consistent across all three types, so the example provided can be adapted to the
+other types.
 
 ### Function-like macros
 
-Function-like procedural macros are the simplest of the three types of procedural macros. These macros are defined using a function preceded by the `#[proc_macro]` attribute. The function must take a `TokenStream` as input and return a new `TokenStream` as output to replace the original code.
+Function-like procedural macros are the simplest of the three types of
+procedural macros. These macros are defined using a function preceded by the
+`#[proc_macro]` attribute. The function must take a `TokenStream` as input and
+return a new `TokenStream` as output to replace the original code.
 
 ```rust
 #[proc_macro]
@@ -173,17 +246,23 @@ pub fn my_macro(input: TokenStream) -> TokenStream {
 }
 ```
 
-These macros are invoked using the name of the function followed by the `!` operator. They can be used in various places in a Rust program, such as in expressions, statements, and function definitions.
+These macros are invoked using the name of the function followed by the `!`
+operator. They can be used in various places in a Rust program, such as in
+expressions, statements, and function definitions.
 
 ```rust
 my_macro!(input);
 ```
 
-Function-like procedural macros are best suited for simple code generation tasks that require only a single input and output stream. They are easy to understand and use, and they provide a straightforward way to generate code at compile time.
+Function-like procedural macros are best suited for simple code generation tasks
+that require only a single input and output stream. They are easy to understand
+and use, and they provide a straightforward way to generate code at compile
+time.
 
 ### Attribute macros
 
-Attribute macros define new attributes that are attached to items in a Rust program such as functions and structs.
+Attribute macros define new attributes that are attached to items in a Rust
+program such as functions and structs.
 
 ```rust
 #[my_macro]
@@ -192,7 +271,10 @@ fn my_function() {
 }
 ```
 
-Attribute macros are defined with a function preceded by the `#[proc_macro_attribute]` attribute. The function requires two token streams as input and returns a single `TokenStream` as output that replaces the original item with an arbitrary number of new items.
+Attribute macros are defined with a function preceded by the
+`#[proc_macro_attribute]` attribute. The function requires two token streams as
+input and returns a single `TokenStream` as output that replaces the original
+item with an arbitrary number of new items.
 
 ```rust
 #[proc_macro_attribute]
@@ -201,7 +283,9 @@ pub fn my_macro(attr: TokenStream, input: TokenStream) -> TokenStream {
 }
 ```
 
-The first token stream input represents attribute arguments. The second token stream is the rest of the item that the attribute is attached to, including any other attributes that may be present.
+The first token stream input represents attribute arguments. The second token
+stream is the rest of the item that the attribute is attached to, including any
+other attributes that may be present.
 
 ```rust
 #[my_macro(arg1, arg2)]
@@ -210,11 +294,16 @@ fn my_function() {
 }
 ```
 
-For example, an attribute macro could process the arguments passed to the attribute to enable or disable certain features, and then use the second token stream to modify the original item in some way. By having access to both token streams, attribute macros can provide greater flexibility and functionality compared to using only a single token stream.
+For example, an attribute macro could process the arguments passed to the
+attribute to enable or disable certain features, and then use the second token
+stream to modify the original item in some way. By having access to both token
+streams, attribute macros can provide greater flexibility and functionality
+compared to using only a single token stream.
 
 ### Derive macros
 
-Derive macros are invoked using the `#[derive]` attribute on a struct, enum, or union are typically used to automatically implement traits for the input types.
+Derive macros are invoked using the `#[derive]` attribute on a struct, enum, or
+union are typically used to automatically implement traits for the input types.
 
 ```rust
 #[derive(MyMacro)]
@@ -223,9 +312,15 @@ struct Input {
 }
 ```
 
-Derive macros are defined with a function preceded by the `#[proc_macro_derive]` attribute. They're limited to generating code for structs, enums, and unions. They take a single token stream as input and return a single token stream as output.
+Derive macros are defined with a function preceded by the `#[proc_macro_derive]`
+attribute. They're limited to generating code for structs, enums, and unions.
+They take a single token stream as input and return a single token stream as
+output.
 
-Unlike the other procedural macros, the returned token stream doesn't replace the original code. Rather, the returned token stream gets appended to the module or block that the original item belongs to. This allows developers to extend the functionality of the original item without modifying the original code.
+Unlike the other procedural macros, the returned token stream doesn't replace
+the original code. Rather, the returned token stream gets appended to the module
+or block that the original item belongs to. This allows developers to extend the
+functionality of the original item without modifying the original code.
 
 ```rust
 #[proc_macro_derive(MyMacro)]
@@ -234,7 +329,9 @@ pub fn my_macro(input: TokenStream) -> TokenStream {
 }
 ```
 
-In addition to implementing traits, derive macros can define helper attributes. Helper attributes can be used in the scope of the item that the derive macro is applied to and customize the code generation process.
+In addition to implementing traits, derive macros can define helper attributes.
+Helper attributes can be used in the scope of the item that the derive macro is
+applied to and customize the code generation process.
 
 ```rust
 #[proc_macro_derive(MyMacro, attributes(helper))]
@@ -243,7 +340,9 @@ pub fn my_macro(body: TokenStream) -> TokenStream {
 }
 ```
 
-Helper attributes are inert, which means they do not have any effect on their own, and their only purpose is to be used as input to the derive macro that defined them.
+Helper attributes are inert, which means they do not have any effect on their
+own, and their only purpose is to be used as input to the derive macro that
+defined them.
 
 ```rust
 #[derive(MyMacro)]
@@ -253,11 +352,15 @@ struct Input {
 }
 ```
 
-For example, a derive macro could define a helper attribute to perform additional operations depending on the presence of the attribute. This allows developers to further extend the functionality of derive macros and customize the code they generate in a more flexible way.
+For example, a derive macro could define a helper attribute to perform
+additional operations depending on the presence of the attribute. This allows
+developers to further extend the functionality of derive macros and customize
+the code they generate in a more flexible way.
 
 ### Example of a procedural macro
 
-This example shows how to use a derive procedural macro to automatically generate an implementation of a `describe()` method for a struct.
+This example shows how to use a derive procedural macro to automatically
+generate an implementation of a `describe()` method for a struct.
 
 ```rust
 use example_macro::Describe;
@@ -273,13 +376,16 @@ fn main() {
 }
 ```
 
-The `describe()` method will print a description of the struct's fields to the console.
+The `describe()` method will print a description of the struct's fields to the
+console.
 
 ```text
 MyStruct is a struct with these named fields: my_string, my_number.
 ```
 
-The first step is to define the procedural macro using the using the `#[proc_macro_derive]` attribute. The input `TokenStream` is parsed using the `parse_macro_input!()` macro to extract the struct's identifier and data.
+The first step is to define the procedural macro using the using the
+`#[proc_macro_derive]` attribute. The input `TokenStream` is parsed using the
+`parse_macro_input!()` macro to extract the struct's identifier and data.
 
 ```rust
 use proc_macro::{self, TokenStream};
@@ -293,13 +399,18 @@ pub fn describe_struct(input: TokenStream) -> TokenStream {
 }
 ```
 
-The next step is to use the `match` keyword to perform pattern matching on the `data` value to extract the names of the fields in the struct.
+The next step is to use the `match` keyword to perform pattern matching on the
+`data` value to extract the names of the fields in the struct.
 
-The first `match` has two arms: one for the `syn::Data::Struct` variant, and one for the "catch-all" `_` arm that handles all other variants of `syn::Data`.
+The first `match` has two arms: one for the `syn::Data::Struct` variant, and one
+for the "catch-all" `_` arm that handles all other variants of `syn::Data`.
 
-The second `match` has two arms as well: one for the `syn::Fields::Named` variant, and one for the "catch-all" `_` arm that handles all other variants of `syn::Fields`.
+The second `match` has two arms as well: one for the `syn::Fields::Named`
+variant, and one for the "catch-all" `_` arm that handles all other variants of
+`syn::Fields`.
 
-The `#(#idents), *` syntax specifies that the `idents` iterator will be "expanded" to create a comma-separated list of the elements in the iterator.
+The `#(#idents), *` syntax specifies that the `idents` iterator will be
+"expanded" to create a comma-separated list of the elements in the iterator.
 
 ```rust
 use proc_macro::{self, TokenStream};
@@ -327,11 +438,15 @@ pub fn describe_struct(input: TokenStream) -> TokenStream {
 }
 ```
 
-The last step is to implement a `describe()` method for a struct. The `expanded` variable is defined using the `quote!` macro and the `impl` keyword to create an implementation for the struct name stored in the `#ident` variable.
+The last step is to implement a `describe()` method for a struct. The `expanded`
+variable is defined using the `quote!` macro and the `impl` keyword to create an
+implementation for the struct name stored in the `#ident` variable.
 
-This implementation defines the `describe()` method that uses the `println!` macro to print the name of the struct and its field names.
+This implementation defines the `describe()` method that uses the `println!`
+macro to print the name of the struct and its field names.
 
-Finally, the `expanded` variable is converted into a `TokenStream` using the `into()` method.
+Finally, the `expanded` variable is converted into a `TokenStream` using the
+`into()` method.
 
 ```rust
 use proc_macro::{self, TokenStream};
@@ -368,7 +483,9 @@ pub fn describe(input: TokenStream) -> TokenStream {
 }
 ```
 
-Now, when the `#[derive(Describe)]` attribute is added to a struct, the Rust compiler automatically generates an implementation of the `describe()` method that can be called to print the name of the struct and the names of its fields.
+Now, when the `#[derive(Describe)]` attribute is added to a struct, the Rust
+compiler automatically generates an implementation of the `describe()` method
+that can be called to print the name of the struct and the names of its fields.
 
 ```rust
 #[derive(Describe)]
@@ -378,7 +495,9 @@ struct MyStruct {
 }
 ```
 
-The `cargo expand` command from the `cargo-expand` crate can be used to expand Rust code that uses procedural macros. For example, the code for the `MyStruct` struct generated using the the `#[derive(Describe)]` attribute looks like this:
+The `cargo expand` command from the `cargo-expand` crate can be used to expand
+Rust code that uses procedural macros. For example, the code for the `MyStruct`
+struct generated using the the `#[derive(Describe)]` attribute looks like this:
 
 ```rust
 struct MyStruct {
@@ -406,17 +525,23 @@ impl MyStruct {
 
 ## Anchor procedural macros
 
-Procedural macros are the magic behind the Anchor library that is commonly used in Solana development. Anchor macros allow for more succinct code, common security checks, and more. Let's go through a few examples of how Anchor uses procedural macros.
+Procedural macros are the magic behind the Anchor library that is commonly used
+in Solana development. Anchor macros allow for more succinct code, common
+security checks, and more. Let's go through a few examples of how Anchor uses
+procedural macros.
 
 ### Function-like macro
 
-The `declare_id` macro shows how function-like macros are used in Anchor. This macro takes in a string of characters representing a program's ID as input and converts it into a `Pubkey` type that can be used in the Anchor program.
+The `declare_id` macro shows how function-like macros are used in Anchor. This
+macro takes in a string of characters representing a program's ID as input and
+converts it into a `Pubkey` type that can be used in the Anchor program.
 
 ```rust
 declare_id!("G839pmstFmKKGEVXRGnauXxFgzucvELrzuyk6gHTiK7a");
 ```
 
-The `declare_id` macro is defined using the `#[proc_macro]` attribute, indicating that it's a function-like proc macro.
+The `declare_id` macro is defined using the `#[proc_macro]` attribute,
+indicating that it's a function-like proc macro.
 
 ```rust
 #[proc_macro]
@@ -428,11 +553,19 @@ pub fn declare_id(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 ### Derive macro
 
-The `#[derive(Accounts)]` is an example of just one of many derive macros that are used in Anchor.
+The `#[derive(Accounts)]` is an example of just one of many derive macros that
+are used in Anchor.
 
-The `#[derive(Accounts)]` macro generates code that implements the `Accounts` trait for the given struct. This trait does a number of things, including validating and deserializing the accounts passed into an instruction. This allows the struct to be used as a list of accounts required by an instruction in an Anchor program.
+The `#[derive(Accounts)]` macro generates code that implements the `Accounts`
+trait for the given struct. This trait does a number of things, including
+validating and deserializing the accounts passed into an instruction. This
+allows the struct to be used as a list of accounts required by an instruction in
+an Anchor program.
 
-Any constraints specified on fields by the `#[account(..)]` attribute are applied during deserialization. The `#[instruction(..)]` attribute can also be added to specify the instruction's arguments and make them accessible to the macro.
+Any constraints specified on fields by the `#[account(..)]` attribute are
+applied during deserialization. The `#[instruction(..)]` attribute can also be
+added to specify the instruction's arguments and make them accessible to the
+macro.
 
 ```rust
 #[derive(Accounts)]
@@ -446,7 +579,11 @@ pub struct Initialize<'info> {
 }
 ```
 
-This macro is defined using the `proc_macro_derive` attribute, which allows it to be used as a derive macro that can be applied to a struct. The line `#[proc_macro_derive(Accounts, attributes(account, instruction))]` indicates that this is a derive macro that processes `account` and `instruction` helper attributes.
+This macro is defined using the `proc_macro_derive` attribute, which allows it
+to be used as a derive macro that can be applied to a struct. The line
+`#[proc_macro_derive(Accounts, attributes(account, instruction))]` indicates
+that this is a derive macro that processes `account` and `instruction` helper
+attributes.
 
 ```rust
 #[proc_macro_derive(Accounts, attributes(account, instruction))]
@@ -459,7 +596,9 @@ pub fn derive_anchor_deserialize(item: TokenStream) -> TokenStream {
 
 ### Attribute macro `#[program]`
 
-The `#[program]` attribute macro is an example of an attribute macro used in the Anchor to define the module containing instruction handlers for a Solana program.
+The `#[program]` attribute macro is an example of an attribute macro used in the
+Anchor to define the module containing instruction handlers for a Solana
+program.
 
 ```rust
 #[program]
@@ -472,7 +611,8 @@ pub mod my_program {
 }
 ```
 
-In this case, the `#[program]` attribute is applied to a module, and it is used to specify that the module contains instruction handlers for a Solana program.
+In this case, the `#[program]` attribute is applied to a module, and it is used
+to specify that the module contains instruction handlers for a Solana program.
 
 ```rust
 #[proc_macro_attribute]
@@ -486,17 +626,26 @@ pub fn program(
 }
 ```
 
-Overall, the use of proc macros in Anchor greatly reduces the amount of repetitive code that Solana developers have to write. By reducing the amount of boilerplate code, developers can focus on their program's core functionality and avoid mistakes caused by manual repetition. This ultimately results in a faster and more efficient development process.
+Overall, the use of proc macros in Anchor greatly reduces the amount of
+repetitive code that Solana developers have to write. By reducing the amount of
+boilerplate code, developers can focus on their program's core functionality and
+avoid mistakes caused by manual repetition. This ultimately results in a faster
+and more efficient development process.
 
 # Demo
 
-Let's practice this by creating a new derive macro! Our new macro will let us automatically generate instruction logic for updating each field on an account in an Anchor program.
+Let's practice this by creating a new derive macro! Our new macro will let us
+automatically generate instruction logic for updating each field on an account
+in an Anchor program.
 
 ### 1. Starter
 
-To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/anchor-custom-macro/tree/starter).
+To get started, download the starter code from the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/anchor-custom-macro/tree/starter).
 
-The starter code includes a simple Anchor program that allows you to initialize and update a `Config` account. This is similar to what we did with the [Environment Variables lesson](./env-variables.md).
+The starter code includes a simple Anchor program that allows you to initialize
+and update a `Config` account. This is similar to what we did with the
+[Environment Variables lesson](./env-variables.md).
 
 The account in question is structured as follows:
 
@@ -516,15 +665,26 @@ impl Config {
 }
 ```
 
-The `programs/admin/src/lib.rs` file contains the program entrypoint with the definitions of the program's instructions. Currently, the program has instructions to initialize this account and then one instruction per account field for updating the field.
+The `programs/admin/src/lib.rs` file contains the program entrypoint with the
+definitions of the program's instructions. Currently, the program has
+instructions to initialize this account and then one instruction per account
+field for updating the field.
 
-The `programs/admin/src/admin_config` directory contains the program's instruction logic and state. Take a look through each of these files. You'll notice that instruction logic for each field is effectively duplicated for each instruction.
+The `programs/admin/src/admin_config` directory contains the program's
+instruction logic and state. Take a look through each of these files. You'll
+notice that instruction logic for each field is effectively duplicated for each
+instruction.
 
-The goal of this demo is to implement a procedural macro that will allow us to replace all of the instruction logic functions and automatically generate functions for each instruction.
+The goal of this demo is to implement a procedural macro that will allow us to
+replace all of the instruction logic functions and automatically generate
+functions for each instruction.
 
 ### 2. Set up the custom macro declaration
 
-Let's get started by creating a separate crate for our custom macro. In the project's root directory, run `cargo new custom-macro`. This will create a new `custom-macro` directory with its own `Cargo.toml`. Update the new `Cargo.toml` file to be the following:
+Let's get started by creating a separate crate for our custom macro. In the
+project's root directory, run `cargo new custom-macro`. This will create a new
+`custom-macro` directory with its own `Cargo.toml`. Update the new `Cargo.toml`
+file to be the following:
 
 ```text
 [package]
@@ -542,11 +702,14 @@ proc-macro2 = "0.4"
 anchor-lang = "0.25.0"
 ```
 
-The `proc-macro = true` line defines this crate as containing a procedural macro. The dependencies are all crates we'll be using to create our derive macro.
+The `proc-macro = true` line defines this crate as containing a procedural
+macro. The dependencies are all crates we'll be using to create our derive
+macro.
 
 Next, change `src/main.rs` to `src/lib.rs`.
 
-Next, update the project root's `Cargo.toml` file's `members` field to include `"custom-macro"`:
+Next, update the project root's `Cargo.toml` file's `members` field to include
+`"custom-macro"`:
 
 ```text
 [workspace]
@@ -556,7 +719,11 @@ members = [
 ]
 ```
 
-Now our crate is set up and ready to go. But before we move on, let's create one more crate at the root level that we can use to test out our macro as we create it. Use `cargo new custom-macro-test` at the project root. Then update the newly created `Cargo.toml` to add `anchor-lang` and the `custom-macro` crates as dependencies:
+Now our crate is set up and ready to go. But before we move on, let's create one
+more crate at the root level that we can use to test out our macro as we create
+it. Use `cargo new custom-macro-test` at the project root. Then update the newly
+created `Cargo.toml` to add `anchor-lang` and the `custom-macro` crates as
+dependencies:
 
 ```text
 [package]
@@ -569,7 +736,8 @@ anchor-lang = "0.25.0"
 custom-macro = { path = "../custom-macro" }
 ```
 
-Next, update the root project's `Cargo.toml` to include the new `custom-macro-test` crate as before:
+Next, update the root project's `Cargo.toml` to include the new
+`custom-macro-test` crate as before:
 
 ```text
 [workspace]
@@ -580,7 +748,8 @@ members = [
 ]
 ```
 
-Finally, replace the code in `custom-macro-test/src/main.rs` with the following code. We'll use this later for testing:
+Finally, replace the code in `custom-macro-test/src/main.rs` with the following
+code. We'll use this later for testing:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -597,7 +766,12 @@ pub struct Config {
 
 ### 3. Define the custom macro
 
-Now, in the `custom-macro/src/lib.rs` file, let's add our new macro's declaration. In this file, we’ll use the `parse_macro_input!` macro to parse the input `TokenStream` and extract the `ident` and `data` fields from a `DeriveInput` struct. Then, we’ll use the `eprintln!` macro to print the values of `ident` and `data`. For now, we will use `TokenStream::new()` to return an empty `TokenStream`.
+Now, in the `custom-macro/src/lib.rs` file, let's add our new macro's
+declaration. In this file, we’ll use the `parse_macro_input!` macro to parse the
+input `TokenStream` and extract the `ident` and `data` fields from a
+`DeriveInput` struct. Then, we’ll use the `eprintln!` macro to print the values
+of `ident` and `data`. For now, we will use `TokenStream::new()` to return an
+empty `TokenStream`.
 
 ```rust
 use proc_macro::TokenStream;
@@ -615,15 +789,24 @@ pub fn instruction_builder(input: TokenStream) -> TokenStream {
 }
 ```
 
-Let's test what this prints. To do this, you first need to install the `cargo-expand` command by running `cargo install cargo-expand`. You'll also need to install the nightly version of Rust by running `rustup install nightly`.
+Let's test what this prints. To do this, you first need to install the
+`cargo-expand` command by running `cargo install cargo-expand`. You'll also need
+to install the nightly version of Rust by running `rustup install nightly`.
 
-Once you've done this, you can see the output of the code described above by navigating to the `custom-macro-test` directory and running `cargo expand`.
+Once you've done this, you can see the output of the code described above by
+navigating to the `custom-macro-test` directory and running `cargo expand`.
 
-This command expands macros in the crate. Since the `main.rs` file uses the newly created `InstructionBuilder` macro, this will print the syntax tree for the `ident` and `data` of the struct to the console. Once you have confirmed that the input `TokenStream` is parsing correctly, feel free to remove the `eprintln!` statements.
+This command expands macros in the crate. Since the `main.rs` file uses the
+newly created `InstructionBuilder` macro, this will print the syntax tree for
+the `ident` and `data` of the struct to the console. Once you have confirmed
+that the input `TokenStream` is parsing correctly, feel free to remove the
+`eprintln!` statements.
 
 ### 4. Get the struct's fields
 
-Next, let’s use `match` statements to get the named fields from the `data` of the struct. Then we'll use the `eprintln!` macro to print the values of the fields.
+Next, let’s use `match` statements to get the named fields from the `data` of
+the struct. Then we'll use the `eprintln!` macro to print the values of the
+fields.
 
 ```rust
 use proc_macro::TokenStream;
@@ -648,11 +831,16 @@ pub fn instruction_builder(input: TokenStream) -> TokenStream {
 }
 ```
 
-Once again, use `cargo expand` in the terminal to see the output of this code. Once you have confirmed that the fields are being extracted and printed correctly, you can remove the `eprintln!` statement.
+Once again, use `cargo expand` in the terminal to see the output of this code.
+Once you have confirmed that the fields are being extracted and printed
+correctly, you can remove the `eprintln!` statement.
 
 ### 5. Build update instructions
 
-Next, let’s iterate over the fields of the struct and generate an update instruction for each field. The instruction will be generated using the `quote!` macro and will include the field's name and type, as well as a new function name for the update instruction.
+Next, let’s iterate over the fields of the struct and generate an update
+instruction for each field. The instruction will be generated using the `quote!`
+macro and will include the field's name and type, as well as a new function name
+for the update instruction.
 
 ```rust
 use proc_macro::TokenStream;
@@ -691,7 +879,11 @@ pub fn instruction_builder(input: TokenStream) -> TokenStream {
 
 ### 6. Return new `TokenStream`
 
-Lastly, let’s use the `quote!` macro to generate an implementation for the struct with the name specified by the `ident` variable. The implementation includes the update instructions that were generated for each field in the struct. The generated code is then converted to a `TokenStream` using the `into()` method and returned as the result of the macro.
+Lastly, let’s use the `quote!` macro to generate an implementation for the
+struct with the name specified by the `ident` variable. The implementation
+includes the update instructions that were generated for each field in the
+struct. The generated code is then converted to a `TokenStream` using the
+`into()` method and returned as the result of the macro.
 
 ```rust
 use proc_macro::TokenStream;
@@ -733,7 +925,9 @@ pub fn instruction_builder(input: TokenStream) -> TokenStream {
 }
 ```
 
-To verify that the macro is generating the correct code, use the `cargo expand` command to see the expanded form of the macro. The output of this look like the following:
+To verify that the macro is generating the correct code, use the `cargo expand`
+command to see the expanded form of the macro. The output of this look like the
+following:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -779,7 +973,9 @@ impl Config {
 
 ### 7. Update the program to use your new macro
 
-To use the new macro to generate update instructions for the `Config` struct, first add the `custom-macro` crate as a dependency to the program in its `Cargo.toml`:
+To use the new macro to generate update instructions for the `Config` struct,
+first add the `custom-macro` crate as a dependency to the program in its
+`Cargo.toml`:
 
 ```text
 [dependencies]
@@ -787,7 +983,8 @@ anchor-lang = "0.25.0"
 custom-macro = { path = "../../custom-macro" }
 ```
 
-Then, navigate to the `state.rs` file in the Anchor program and update it with the following code:
+Then, navigate to the `state.rs` file in the Anchor program and update it with
+the following code:
 
 ```rust
 use crate::admin_update::UpdateAdminAccount;
@@ -808,7 +1005,9 @@ impl Config {
 }
 ```
 
-Next, navigate to the `admin_update.rs` file and delete the existing update instructions. This should leave only the `UpdateAdminAccount` context struct in the file.
+Next, navigate to the `admin_update.rs` file and delete the existing update
+instructions. This should leave only the `UpdateAdminAccount` context struct in
+the file.
 
 ```rust
 use crate::state::Config;
@@ -825,7 +1024,8 @@ pub struct UpdateAdminAccount<'info> {
 }
 ```
 
-Next, update `lib.rs` in the Anchor program to use the update instructions generated by the `InstructionBuilder` macro.
+Next, update `lib.rs` in the Anchor program to use the update instructions
+generated by the `InstructionBuilder` macro.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -860,7 +1060,9 @@ pub mod admin {
 }
 ```
 
-Lastly, navigate to the `admin` directory and run `anchor test` to verify that the update instructions generated by the `InstructionBuilder` macro are working correctly.
+Lastly, navigate to the `admin` directory and run `anchor test` to verify that
+the update instructions generated by the `InstructionBuilder` macro are working
+correctly.
 
 ```
   admin
@@ -874,10 +1076,18 @@ Lastly, navigate to the `admin` directory and run `anchor test` to verify that t
   5 passing (2s)
 ```
 
-Nice work! At this point, you can create procedural macros to help in your development process. We encourage you to make the most of the Rust language and use macros where they make sense. But even if you don't, knowing how they work helps to understand what's happening with Anchor under the hood.
+Nice work! At this point, you can create procedural macros to help in your
+development process. We encourage you to make the most of the Rust language and
+use macros where they make sense. But even if you don't, knowing how they work
+helps to understand what's happening with Anchor under the hood.
 
-If you need to spend more time with the solution code, feel free to reference the `solution` branch of [the repository](https://github.com/Unboxed-Software/anchor-custom-macro/tree/solution).
+If you need to spend more time with the solution code, feel free to reference
+the `solution` branch of
+[the repository](https://github.com/Unboxed-Software/anchor-custom-macro/tree/solution).
 
 # Challenge
 
-To solidify what you've learned, go ahead and create another procedural macro on your own. Think about code you've written that could be reduced or improved by a macro and try it out! Since this is still practice, it's okay if it doesn't work out the way you want or expect. Just jump in and experiment!
+To solidify what you've learned, go ahead and create another procedural macro on
+your own. Think about code you've written that could be reduced or improved by a
+macro and try it out! Since this is still practice, it's okay if it doesn't work
+out the way you want or expect. Just jump in and experiment!

--- a/developers/courses/solana-course/content/rust-macros.md
+++ b/developers/courses/solana-course/content/rust-macros.md
@@ -1,19 +1,19 @@
 ---
 title: Rust Procedural Macros
 objectives:
-- Create and use **Procedural Macros** in Rust
-- Explain and work with a Rust Abstract Syntax Tree (AST)
-- Describe how procedural macros are used in the Anchor framework
+  - Create and use **Procedural Macros** in Rust
+  - Explain and work with a Rust Abstract Syntax Tree (AST)
+  - Describe how procedural macros are used in the Anchor framework
 ---
 
 # TL;DR
 
--   **Procedural macros** are a special kind of Rust macro that allow the programmer to generate code at compile time based on custom input.
--   In the Anchor framework, procedural macros are used to generate code that reduces the amount of boilerplate required when writing Solana programs.
--   An **Abstract Syntax Tree (AST)** is a representation of the syntax and structure of the input code that is passed to a procedural macro. When creating a macro, you use elements of the AST like tokens and items to generate the appropriate code.
--   A **Token** is the smallest unit of source code that can be parsed by the compiler in Rust.
--   An **Item** is a declaration that defines something that can be used in a Rust program, such as a struct, an enum, a trait, a function, or a method.
--   A **TokenStream** is a sequence of tokens that represents a piece of source code, and can be passed to a procedural macro to allow it to access and manipulate the individual tokens in the code.
+- **Procedural macros** are a special kind of Rust macro that allow the programmer to generate code at compile time based on custom input.
+- In the Anchor framework, procedural macros are used to generate code that reduces the amount of boilerplate required when writing Solana programs.
+- An **Abstract Syntax Tree (AST)** is a representation of the syntax and structure of the input code that is passed to a procedural macro. When creating a macro, you use elements of the AST like tokens and items to generate the appropriate code.
+- A **Token** is the smallest unit of source code that can be parsed by the compiler in Rust.
+- An **Item** is a declaration that defines something that can be used in a Rust program, such as a struct, an enum, a trait, a function, or a method.
+- A **TokenStream** is a sequence of tokens that represents a piece of source code, and can be passed to a procedural macro to allow it to access and manipulate the individual tokens in the code.
 
 # Overview
 
@@ -21,8 +21,8 @@ In Rust, a macro is a piece of code that you can write once and then "expand" to
 
 There are two different types of macros: declarative macros and procedural macros.
 
--   Declarative macros are defined using the `macro_rules!` macro, which allows you to match against patterns of code and generate code based on the matching pattern.
--   Procedural macros in Rust are defined using Rust code and operate on the abstract syntax tree (AST) of the input TokenStream, which allows them to manipulate and generate code at a finer level of detail.
+- Declarative macros are defined using the `macro_rules!` macro, which allows you to match against patterns of code and generate code based on the matching pattern.
+- Procedural macros in Rust are defined using Rust code and operate on the abstract syntax tree (AST) of the input TokenStream, which allows them to manipulate and generate code at a finer level of detail.
 
 In this lesson, we'll focus on procedural macros, which are commonly used in the Anchor framework.
 
@@ -36,10 +36,10 @@ In the context of Rust programming, a [token](https://doc.rust-lang.org/referenc
 
 Examples of Rust tokens include:
 
--   [Keywords](https://doc.rust-lang.org/reference/keywords.html), such as `fn`, `let`, and `match`, are reserved words in the Rust language that have special meanings.
--   [Identifiers](https://doc.rust-lang.org/reference/identifiers.html), such as variable and function names, are used to refer to values and functions.
--   [Punctuation](https://doc.rust-lang.org/reference/tokens.html#punctuation) marks, such as `{`, `}`, and `;`, are used to structure and delimit blocks of code.
--   [Literals](https://doc.rust-lang.org/reference/tokens.html#literals), such as numbers and strings, represent constant values in a Rust program.
+- [Keywords](https://doc.rust-lang.org/reference/keywords.html), such as `fn`, `let`, and `match`, are reserved words in the Rust language that have special meanings.
+- [Identifiers](https://doc.rust-lang.org/reference/identifiers.html), such as variable and function names, are used to refer to values and functions.
+- [Punctuation](https://doc.rust-lang.org/reference/tokens.html#punctuation) marks, such as `{`, `}`, and `;`, are used to structure and delimit blocks of code.
+- [Literals](https://doc.rust-lang.org/reference/tokens.html#literals), such as numbers and strings, represent constant values in a Rust program.
 
 You can read more about Rust tokens [here](https://doc.rust-lang.org/reference/tokens.html).
 
@@ -49,12 +49,12 @@ Items are named, self-contained pieces of code in Rust. They provide a way to gr
 
 There are several different kinds of items, such as:
 
--   Functions
--   Structs
--   Enums
--   Traits
--   Modules
--   Macros
+- Functions
+- Structs
+- Enums
+- Traits
+- Modules
+- Macros
 
 You can read more about Rust items [here](https://doc.rust-lang.org/reference/items.html).
 
@@ -156,9 +156,9 @@ This allows you to create procedural macros that perform powerful code generatio
 
 Procedural macros in Rust are a powerful way to extend the language and create custom syntax. These macros are written in Rust and are compiled along with the rest of the code. There are three types of procedural macros:
 
--   Function-like macros - `custom!(...)`
--   Derive macros - `#[derive(CustomDerive)]`
--   Attribute macros - `#[CustomAttribute]`
+- Function-like macros - `custom!(...)`
+- Derive macros - `#[derive(CustomDerive)]`
+- Attribute macros - `#[CustomAttribute]`
 
 This section will discuss the three types of procedural macros and provide an example implementation of one. The process of writing a procedural macro is consistent across all three types, so the example provided can be adapted to the other types.
 

--- a/developers/courses/solana-course/content/security-intro.md
+++ b/developers/courses/solana-course/content/security-intro.md
@@ -4,19 +4,38 @@ objectives:
   - understand how to approach the Program Security Module
 ---
 
-The goal of this module is to expose you to a wide variety of common security exploits that are unique to Solana development. We’ve heavily modeled this module off a public GitHub repository call Sealevel Attacks created by the great Armani Ferrante.
+The goal of this module is to expose you to a wide variety of common security
+exploits that are unique to Solana development. We’ve heavily modeled this
+module off a public GitHub repository call Sealevel Attacks created by the great
+Armani Ferrante.
 
-You might be thinking: “didn’t we have a security lesson in module 3?” Yes, we most certainly did. We wanted to make sure that anyone deploying programs to Mainnet right out of the gates had at least a basic understanding of security. And if that’s you then hopefully the fundamental principles you learned in that lesson have led to you avoiding some common Solana exploits on your own.
+You might be thinking: “didn’t we have a security lesson in module 3?” Yes, we
+most certainly did. We wanted to make sure that anyone deploying programs to
+Mainnet right out of the gates had at least a basic understanding of security.
+And if that’s you then hopefully the fundamental principles you learned in that
+lesson have led to you avoiding some common Solana exploits on your own.
 
 This module is meant to build on top of that lesson with two goals in mind:
 
-1. To expand your awareness of the Solana programming model and the areas where you need to focus to close up security loopholes in your programs
-2. To show you the array of tools provided by Anchor to help you keep your programs secure
+1. To expand your awareness of the Solana programming model and the areas where
+   you need to focus to close up security loopholes in your programs
+2. To show you the array of tools provided by Anchor to help you keep your
+   programs secure
 
-If you went through the Basic Security lesson, the first few lessons should seem familiar. They largely cover topics we discussed in that lesson. After that, some of the attacks may seem new. We encourage you to go through all of them.
+If you went through the Basic Security lesson, the first few lessons should seem
+familiar. They largely cover topics we discussed in that lesson. After that,
+some of the attacks may seem new. We encourage you to go through all of them.
 
-The last thing to call out is that there are a lot more lessons in this module than in prior modules. And the lessons aren't dependent on each other in the same ways, so you can bounce around a bit more if you'd like.
+The last thing to call out is that there are a lot more lessons in this module
+than in prior modules. And the lessons aren't dependent on each other in the
+same ways, so you can bounce around a bit more if you'd like.
 
-Originally, we were going to have more, shorter lessons in this module. And while they might be shorter than average, they aren't much shorter. It turns out that even though each of the security vulnerabilities is "simple," there's a lot to discuss. So each lesson may have a little bit less prose and more code snippets, making it easy for readers to choose how in depth to go. But, ultimately, each lesson is still as fully-fledged as they have been before so that you can really get a solid grasp on each of the discussed security risks.
+Originally, we were going to have more, shorter lessons in this module. And
+while they might be shorter than average, they aren't much shorter. It turns out
+that even though each of the security vulnerabilities is "simple," there's a lot
+to discuss. So each lesson may have a little bit less prose and more code
+snippets, making it easy for readers to choose how in depth to go. But,
+ultimately, each lesson is still as fully-fledged as they have been before so
+that you can really get a solid grasp on each of the discussed security risks.
 
 As always, we appreciate feedback. Good luck digging in!

--- a/developers/courses/solana-course/content/security-intro.md
+++ b/developers/courses/solana-course/content/security-intro.md
@@ -1,7 +1,7 @@
 ---
 title: How to approach the Program Security module
 objectives:
-- understand how to approach the Program Security Module
+  - understand how to approach the Program Security Module
 ---
 
 The goal of this module is to expose you to a wide variety of common security exploits that are unique to Solana development. We’ve heavily modeled this module off a public GitHub repository call Sealevel Attacks created by the great Armani Ferrante.

--- a/developers/courses/solana-course/content/serialize-instruction-data.md
+++ b/developers/courses/solana-course/content/serialize-instruction-data.md
@@ -10,17 +10,31 @@ objectives:
 
 # TL;DR
 
-- Transactions are made up of an array of instructions, a single transaction can have any number of instructions in it, each targeting its own program. When a transaction is submitted, the Solana runtime will process its instructions in order and atomically, meaning that if any of the instructions fail for any reason, the entire transaction will fail to be processed.
-- Every _instruction_ is made up of 3 components: the intended program's ID, an array of all account’s involved, and a byte buffer of instruction data.
-- Every _transaction_ contains: an array of all accounts it intends to read from or write to, one or more instructions, a recent blockhash, and one or more signatures.
-- In order to pass instruction data from a client, it must be serialized into a byte buffer. To facilitate this process of serialization, we will be using [Borsh](https://borsh.io/).
-- Transactions can fail to be processed by the blockchain for any number of reasons, we’ll discuss some of the most common ones here.
+- Transactions are made up of an array of instructions, a single transaction can
+  have any number of instructions in it, each targeting its own program. When a
+  transaction is submitted, the Solana runtime will process its instructions in
+  order and atomically, meaning that if any of the instructions fail for any
+  reason, the entire transaction will fail to be processed.
+- Every _instruction_ is made up of 3 components: the intended program's ID, an
+  array of all account’s involved, and a byte buffer of instruction data.
+- Every _transaction_ contains: an array of all accounts it intends to read from
+  or write to, one or more instructions, a recent blockhash, and one or more
+  signatures.
+- In order to pass instruction data from a client, it must be serialized into a
+  byte buffer. To facilitate this process of serialization, we will be using
+  [Borsh](https://borsh.io/).
+- Transactions can fail to be processed by the blockchain for any number of
+  reasons, we’ll discuss some of the most common ones here.
 
 # Overview
 
 ## Transactions
 
-Transactions are how we send information to the blockchain in order to be processed. So far, we’ve learned how to create very basic transactions with limited functionality. But transactions, and the programs they are sent to, can be designed to be far more flexible and handle far more complexity than we’ve dealt with up to now.
+Transactions are how we send information to the blockchain in order to be
+processed. So far, we’ve learned how to create very basic transactions with
+limited functionality. But transactions, and the programs they are sent to, can
+be designed to be far more flexible and handle far more complexity than we’ve
+dealt with up to now.
 
 ### Transaction Contents
 
@@ -31,63 +45,114 @@ Every transaction contains:
 - A recent blockhash
 - One or more signatures
 
-`@solana/web3.js` simplifies this process for you so that all you really need to focus on is adding instructions and signatures. The library builds the array of accounts based on that information and handles the logic for including a recent blockhash.
+`@solana/web3.js` simplifies this process for you so that all you really need to
+focus on is adding instructions and signatures. The library builds the array of
+accounts based on that information and handles the logic for including a recent
+blockhash.
 
 ## Instructions
 
 Every instruction contains:
 
 - The program ID (public key) of the intended program
-- An array listing every account that will be read from or written to during execution
+- An array listing every account that will be read from or written to during
+  execution
 - A byte buffer of instruction data
 
-Identifying the program by its public key ensures that the instruction is carried out by the correct program.
+Identifying the program by its public key ensures that the instruction is
+carried out by the correct program.
 
-Including an array of every account that will be read from or written to allows the network to perform a number of optimizations which allow for high transaction load and quicker execution.
+Including an array of every account that will be read from or written to allows
+the network to perform a number of optimizations which allow for high
+transaction load and quicker execution.
 
 The byte buffer lets you pass external data to a program.
 
-You can include multiple instructions in a single transaction. The Solana runtime will process these instructions in order and atomically. In other words, if every instruction succeeds then the transaction as a whole will be successful, but if a single instruction fails then the entire transaction will fail immediately with no side-effects.
+You can include multiple instructions in a single transaction. The Solana
+runtime will process these instructions in order and atomically. In other words,
+if every instruction succeeds then the transaction as a whole will be
+successful, but if a single instruction fails then the entire transaction will
+fail immediately with no side-effects.
 
 A note on the account array and optimization:
 
-It is not just an array of the accounts’ public keys. Each object in the array includes the account’s public key, whether or not it is a signer on the transaction, and whether or not it is writable. Including whether or not an account is writable during the execution of an instruction allows the runtime to facilitate parallel processing of smart contracts. Because you must define which accounts are read-only and which you will write to, the runtime can determine which transactions are non-overlapping or read-only and allow them to execute concurrently. To learn more about the Solana’s runtime, check out this [blog post](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts).
+It is not just an array of the accounts’ public keys. Each object in the array
+includes the account’s public key, whether or not it is a signer on the
+transaction, and whether or not it is writable. Including whether or not an
+account is writable during the execution of an instruction allows the runtime to
+facilitate parallel processing of smart contracts. Because you must define which
+accounts are read-only and which you will write to, the runtime can determine
+which transactions are non-overlapping or read-only and allow them to execute
+concurrently. To learn more about the Solana’s runtime, check out this
+[blog post](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts).
 
 ### Instruction Data
 
-The ability to add arbitrary data to an instruction ensures that programs can be dynamic and flexible enough for broad use cases in the same way that the body of an HTTP request lets you build dynamic and flexible REST APIs.
+The ability to add arbitrary data to an instruction ensures that programs can be
+dynamic and flexible enough for broad use cases in the same way that the body of
+an HTTP request lets you build dynamic and flexible REST APIs.
 
-Just as the structure of the body of an HTTP request is dependent on the endpoint you intend to call, the structure of the byte buffer used as instruction data is entirely dependent on the recipient program. If you’re building a full-stack dApp on your own, then you’ll need to copy the same structure that you used when building the program over to the client-side code. If you’re working with another developer who is handling the program development, you can coordinate to ensure matching buffer layouts.
+Just as the structure of the body of an HTTP request is dependent on the
+endpoint you intend to call, the structure of the byte buffer used as
+instruction data is entirely dependent on the recipient program. If you’re
+building a full-stack dApp on your own, then you’ll need to copy the same
+structure that you used when building the program over to the client-side code.
+If you’re working with another developer who is handling the program
+development, you can coordinate to ensure matching buffer layouts.
 
-Let’s think about a concrete example. Imagine working on a Web3 game and being responsible for writing client-side code that interacts with a player inventory program. The program was designed to allow the client to:
+Let’s think about a concrete example. Imagine working on a Web3 game and being
+responsible for writing client-side code that interacts with a player inventory
+program. The program was designed to allow the client to:
 
 - Add inventory based on a player’s game-play results
 - Transfer inventory from one player to another
 - Equip a player with selected inventory items
 
-This program would have been structured such that each of these is encapsulated in its own function.
+This program would have been structured such that each of these is encapsulated
+in its own function.
 
-Each program, however, only has one entry point. You would instruct the program on which of these functions to run through the instruction data.
+Each program, however, only has one entry point. You would instruct the program
+on which of these functions to run through the instruction data.
 
-You would also include in the instruction data any information the function needs in order to execute properly, e.g. an inventory item’s ID, a player to transfer inventory to, etc.
+You would also include in the instruction data any information the function
+needs in order to execute properly, e.g. an inventory item’s ID, a player to
+transfer inventory to, etc.
 
-Exactly _how_ this data would be structured would depend on how the program was written, but it’s common to have the first field in instruction data be a number that the program can map to a function, after which additional fields act as function arguments.
+Exactly _how_ this data would be structured would depend on how the program was
+written, but it’s common to have the first field in instruction data be a number
+that the program can map to a function, after which additional fields act as
+function arguments.
 
 ## Serialization
 
-In addition to knowing what information to include in an instruction data buffer, you also need to serialize it properly. The most common serializer used in Solana is [Borsh](https://borsh.io). Per the website:
+In addition to knowing what information to include in an instruction data
+buffer, you also need to serialize it properly. The most common serializer used
+in Solana is [Borsh](https://borsh.io). Per the website:
 
-> Borsh stands for Binary Object Representation Serializer for Hashing. It is meant to be used in security-critical projects as it prioritizes consistency, safety, speed; and comes with a strict specification.
+> Borsh stands for Binary Object Representation Serializer for Hashing. It is
+> meant to be used in security-critical projects as it prioritizes consistency,
+> safety, speed; and comes with a strict specification.
 
-Borsh maintains a [JS library](https://github.com/near/borsh-js) that handles serializing common types into a buffer. There are also other packages built on top of borsh that try to make this process even easier. We’ll be using the `@project-serum/borsh` library which can be installed using `npm`.
+Borsh maintains a [JS library](https://github.com/near/borsh-js) that handles
+serializing common types into a buffer. There are also other packages built on
+top of borsh that try to make this process even easier. We’ll be using the
+`@project-serum/borsh` library which can be installed using `npm`.
 
-Building off of the previous game inventory example, let’s look at a hypothetical scenario where we are instructing the program to equip a player with a given item. Assume the program is designed to accept a buffer that represents a struct with the following properties:
+Building off of the previous game inventory example, let’s look at a
+hypothetical scenario where we are instructing the program to equip a player
+with a given item. Assume the program is designed to accept a buffer that
+represents a struct with the following properties:
 
-1. `variant` as an unsigned, 8-bit integer that instructs the program which instruction, or function, to execute.
-2. `playerId` as an unsigned, 16-bit integer that represents the player ID of the player who is to be equipped with the given item.
-3. `itemId` as an unsigned, 256-bit integer that represents the item ID of the item that will be equipped to the given player.
+1. `variant` as an unsigned, 8-bit integer that instructs the program which
+   instruction, or function, to execute.
+2. `playerId` as an unsigned, 16-bit integer that represents the player ID of
+   the player who is to be equipped with the given item.
+3. `itemId` as an unsigned, 256-bit integer that represents the item ID of the
+   item that will be equipped to the given player.
 
-All of this will be passed as a byte buffer that will be read in order, so ensuring proper buffer layout order is crucial. You would create the buffer layout schema or template for the above as follows:
+All of this will be passed as a byte buffer that will be read in order, so
+ensuring proper buffer layout order is crucial. You would create the buffer
+layout schema or template for the above as follows:
 
 ```tsx
 import * as borsh from "@project-serum/borsh";
@@ -99,7 +164,11 @@ const equipPlayerSchema = borsh.struct([
 ]);
 ```
 
-You can then encode data using this schema with the `encode` method. This method accepts as arguments an object representing the data to be serialized and a buffer. In the below example, we allocate a new buffer that’s much larger than needed, then encode the data into that buffer and slice it down into a new buffer that’s only as large as needed.
+You can then encode data using this schema with the `encode` method. This method
+accepts as arguments an object representing the data to be serialized and a
+buffer. In the below example, we allocate a new buffer that’s much larger than
+needed, then encode the data into that buffer and slice it down into a new
+buffer that’s only as large as needed.
 
 ```tsx
 import * as borsh from "@project-serum/borsh";
@@ -119,11 +188,15 @@ equipPlayerSchema.encode(
 const instructionBuffer = buffer.slice(0, equipPlayerSchema.getSpan(buffer));
 ```
 
-Once a buffer is properly created and the data serialized, all that’s left is building the transaction. This is similar to what you’ve done in previous lessons. The example below assumes that:
+Once a buffer is properly created and the data serialized, all that’s left is
+building the transaction. This is similar to what you’ve done in previous
+lessons. The example below assumes that:
 
-- `player`, `playerInfoAccount`, and `PROGRAM_ID` are already defined somewhere outside the code snippet
+- `player`, `playerInfoAccount`, and `PROGRAM_ID` are already defined somewhere
+  outside the code snippet
 - `player` is a user’s public key
-- `playerInfoAccount` is the public key of the account where inventory changes will be written
+- `playerInfoAccount` is the public key of the account where inventory changes
+  will be written
 - `SystemProgram` will be used in the process of executing the instruction.
 
 ```tsx
@@ -181,30 +254,50 @@ web3.sendAndConfirmTransaction(connection, transaction, [player]).then(txid => {
 
 # Demo
 
-Let’s practice this together by building a Movie Review app that lets users submit a movie review and have it stored on Solana’s network. We’ll build this app a little bit at a time over the next few lessons, adding new functionality each lesson.
+Let’s practice this together by building a Movie Review app that lets users
+submit a movie review and have it stored on Solana’s network. We’ll build this
+app a little bit at a time over the next few lessons, adding new functionality
+each lesson.
 
 ![Screenshot of movie review frontend](../assets/movie-reviews-frontend.png)
 
-The public key of the Solana program we’ll use for this application is `CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
+The public key of the Solana program we’ll use for this application is
+`CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
 
 ### 1. Download the starter code
 
-Before we get started, go ahead and download the [starter code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/starter).
+Before we get started, go ahead and download the
+[starter code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/starter).
 
-The project is a fairly simple Next.js application. It includes the `WalletContextProvider` we created in the Wallets lesson, a `Card` component for displaying a movie review, a `MovieList` component that displays reviews in a list, a `Form` component for submitting a new review, and a `Movie.ts` file that contains a class definition for a `Movie` object.
+The project is a fairly simple Next.js application. It includes the
+`WalletContextProvider` we created in the Wallets lesson, a `Card` component for
+displaying a movie review, a `MovieList` component that displays reviews in a
+list, a `Form` component for submitting a new review, and a `Movie.ts` file that
+contains a class definition for a `Movie` object.
 
-Note that for now, the movies displayed on the page when you run `npm run dev` are mocks. In this lesson, we’ll focus on adding a new review but we won’t actually be able to see that review displayed. Next lesson, we’ll focus on deserializing custom data from on-chain accounts.
+Note that for now, the movies displayed on the page when you run `npm run dev`
+are mocks. In this lesson, we’ll focus on adding a new review but we won’t
+actually be able to see that review displayed. Next lesson, we’ll focus on
+deserializing custom data from on-chain accounts.
 
 ### 2. Create the buffer layout
 
-Remember that to properly interact with a Solana program, you need to know how it expects data to be structured. Our Movie Review program is expecting instruction data to contain:
+Remember that to properly interact with a Solana program, you need to know how
+it expects data to be structured. Our Movie Review program is expecting
+instruction data to contain:
 
-1. `variant` as an unsigned, 8-bit integer representing which instruction should be executed (in other words which function on the program should be called).
-2. `title` as a string representing the title of the movie that you are reviewing.
-3. `rating` as an unsigned, 8-bit integer representing the rating out of 5 that you are giving to the movie you are reviewing.
-4. `description` as a string representing the written portion of the review you are leaving for the movie.
+1. `variant` as an unsigned, 8-bit integer representing which instruction should
+   be executed (in other words which function on the program should be called).
+2. `title` as a string representing the title of the movie that you are
+   reviewing.
+3. `rating` as an unsigned, 8-bit integer representing the rating out of 5 that
+   you are giving to the movie you are reviewing.
+4. `description` as a string representing the written portion of the review you
+   are leaving for the movie.
 
-Let’s configure a `borsh` layout in the `Movie` class. Start by importing `@project-serum/borsh`. Next, create a `borshInstructionSchema` property and set it to the appropriate `borsh` struct containing the properties listed above.
+Let’s configure a `borsh` layout in the `Movie` class. Start by importing
+`@project-serum/borsh`. Next, create a `borshInstructionSchema` property and set
+it to the appropriate `borsh` struct containing the properties listed above.
 
 ```tsx
 import * as borsh from '@project-serum/borsh'
@@ -225,11 +318,14 @@ export class Movie {
 }
 ```
 
-Keep in mind that _order matters_. If the order of properties here differs from how the program is structured, the transaction will fail.
+Keep in mind that _order matters_. If the order of properties here differs from
+how the program is structured, the transaction will fail.
 
 ### 3. Create a method to serialize data
 
-Now that we have the buffer layout set up, let’s create a method in `Movie` called `serialize()` that will return a `Buffer` with a `Movie` object’s properties encoded into the appropriate layout.
+Now that we have the buffer layout set up, let’s create a method in `Movie`
+called `serialize()` that will return a `Buffer` with a `Movie` object’s
+properties encoded into the appropriate layout.
 
 ```tsx
 import * as borsh from '@project-serum/borsh'
@@ -256,15 +352,25 @@ export class Movie {
 }
 ```
 
-The method shown above first creates a large enough buffer for our object, then encodes `{ ...this, variant: 0 }` into the buffer. Because the `Movie` class definition contains 3 of the 4 properties required by the buffer layout and uses the same naming, we can use it directly with the spread operator and just add the `variant` property. Finally, the method returns a new buffer that leaves off the unused portion of the original.
+The method shown above first creates a large enough buffer for our object, then
+encodes `{ ...this, variant: 0 }` into the buffer. Because the `Movie` class
+definition contains 3 of the 4 properties required by the buffer layout and uses
+the same naming, we can use it directly with the spread operator and just add
+the `variant` property. Finally, the method returns a new buffer that leaves off
+the unused portion of the original.
 
 ### 4. Send transaction when user submits form
 
-Now that we have the building blocks for the instruction data, we can create and send the transaction when a user submits the form. Open `Form.tsx` and locate the `handleTransactionSubmit` function. This gets called by `handleSubmit` each time a user submits the Movie Review form.
+Now that we have the building blocks for the instruction data, we can create and
+send the transaction when a user submits the form. Open `Form.tsx` and locate
+the `handleTransactionSubmit` function. This gets called by `handleSubmit` each
+time a user submits the Movie Review form.
 
-Inside this function, we’ll be creating and sending the transaction that contains the data submitted through the form.
+Inside this function, we’ll be creating and sending the transaction that
+contains the data submitted through the form.
 
-Start by importing `@solana/web3.js` and importing `useConnection` and `useWallet` from `@solana/wallet-adapter-react`.
+Start by importing `@solana/web3.js` and importing `useConnection` and
+`useWallet` from `@solana/wallet-adapter-react`.
 
 ```tsx
 import { FC } from "react";
@@ -287,7 +393,9 @@ import * as web3 from "@solana/web3.js";
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 ```
 
-Next, before the `handleSubmit` function, call `useConnection()` to get a `connection` object and call `useWallet()` to get `publicKey` and `sendTransaction`.
+Next, before the `handleSubmit` function, call `useConnection()` to get a
+`connection` object and call `useWallet()` to get `publicKey` and
+`sendTransaction`.
 
 ```tsx
 import { FC } from 'react'
@@ -317,17 +425,23 @@ export const Form: FC = () => {
 }
 ```
 
-Before we implement `handleTransactionSubmit`, let’s talk about what needs to be done. We need to:
+Before we implement `handleTransactionSubmit`, let’s talk about what needs to be
+done. We need to:
 
-1. Check that `publicKey` exists to ensure that the user has connected their wallet.
-2. Call `serialize()` on `movie` to get a buffer representing the instruction data.
+1. Check that `publicKey` exists to ensure that the user has connected their
+   wallet.
+2. Call `serialize()` on `movie` to get a buffer representing the instruction
+   data.
 3. Create a new `Transaction` object.
 4. Get all of the accounts that the transaction will read from or write to.
-5. Create a new `Instruction` object that includes all of these accounts in the `keys` argument, includes the buffer in the `data` argument, and includes the program’s public key in the `programId` argument.
+5. Create a new `Instruction` object that includes all of these accounts in the
+   `keys` argument, includes the buffer in the `data` argument, and includes the
+   program’s public key in the `programId` argument.
 6. Add the instruction from the last step to the transaction.
 7. Call `sendTransaction`, passing in the assembled transaction.
 
-That’s quite a lot to process! But don’t worry, it gets easier the more you do it. Let’s start with the first 3 steps from above:
+That’s quite a lot to process! But don’t worry, it gets easier the more you do
+it. Let’s start with the first 3 steps from above:
 
 ```tsx
 const handleTransactionSubmit = async (movie: Movie) => {
@@ -341,7 +455,12 @@ const handleTransactionSubmit = async (movie: Movie) => {
 };
 ```
 
-The next step is to get all of the accounts that the transaction will read from or write to. In past lessons, the account where data will be stored has been given to you. This time, the account’s address is more dynamic, so it needs to be computed. We’ll cover this in depth in the next lesson, but for now you can use the following, where `pda` is the address to the account where data will be stored:
+The next step is to get all of the accounts that the transaction will read from
+or write to. In past lessons, the account where data will be stored has been
+given to you. This time, the account’s address is more dynamic, so it needs to
+be computed. We’ll cover this in depth in the next lesson, but for now you can
+use the following, where `pda` is the address to the account where data will be
+stored:
 
 ```tsx
 const [pda] = await web3.PublicKey.findProgramAddress(
@@ -350,7 +469,9 @@ const [pda] = await web3.PublicKey.findProgramAddress(
 );
 ```
 
-In addition to this account, the program will also need to read from `SystemProgram`, so our array needs to include `web3.SystemProgram.programId` as well.
+In addition to this account, the program will also need to read from
+`SystemProgram`, so our array needs to include `web3.SystemProgram.programId` as
+well.
 
 With that, we can finish the remaining steps:
 
@@ -404,25 +525,43 @@ const handleTransactionSubmit = async (movie: Movie) => {
 };
 ```
 
-And that’s it! You should now be able to use the form on the site to submit a movie review. While you won’t see the UI update to reflect the new review, you can look at the transaction’s program logs on Solana Explorer to see that it was successful.
+And that’s it! You should now be able to use the form on the site to submit a
+movie review. While you won’t see the UI update to reflect the new review, you
+can look at the transaction’s program logs on Solana Explorer to see that it was
+successful.
 
-If you need a bit more time with this project to feel comfortable, have a look at the complete [solution code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-serialize-instruction-data).
+If you need a bit more time with this project to feel comfortable, have a look
+at the complete
+[solution code](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-serialize-instruction-data).
 
 # Challenge
 
-Now it’s your turn to build something independently. Create an application that lets students of this course introduce themselves! The Solana program that supports this is at `HdE95RSVsdb315jfJtaykXhXY478h53X6okDupVfY9yf`.
+Now it’s your turn to build something independently. Create an application that
+lets students of this course introduce themselves! The Solana program that
+supports this is at `HdE95RSVsdb315jfJtaykXhXY478h53X6okDupVfY9yf`.
 
 ![Screenshot of Student Intros frontend](../assets/student-intros-frontend.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/starter).
-2. Create the instruction buffer layout in `StudentIntro.ts`. The program expects instruction data to contain:
-   1. `variant` as an unsigned, 8-bit integer representing the instruction to run (should be 0).
+1. You can build this from scratch or you can download the starter code
+   [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/starter).
+2. Create the instruction buffer layout in `StudentIntro.ts`. The program
+   expects instruction data to contain:
+   1. `variant` as an unsigned, 8-bit integer representing the instruction to
+      run (should be 0).
    2. `name` as a string representing the student's name.
-   3. `message` as a string representing the message the student is sharing about their Solana journey.
-3. Create a method in `StudentIntro.ts` that will use the buffer layout to serialize a `StudentIntro` object.
-4. In the `Form` component, implement the `handleTransactionSubmit` function so that it serializes a `StudentIntro`, builds the appropriate transaction and transaction instructions, and submits the transaction to the user's wallet.
-5. You should now be able to submit introductions and have the information stored on chain! Be sure to log the transaction ID and look at it in Solana Explorer to verify that it worked.
+   3. `message` as a string representing the message the student is sharing
+      about their Solana journey.
+3. Create a method in `StudentIntro.ts` that will use the buffer layout to
+   serialize a `StudentIntro` object.
+4. In the `Form` component, implement the `handleTransactionSubmit` function so
+   that it serializes a `StudentIntro`, builds the appropriate transaction and
+   transaction instructions, and submits the transaction to the user's wallet.
+5. You should now be able to submit introductions and have the information
+   stored on chain! Be sure to log the transaction ID and look at it in Solana
+   Explorer to verify that it worked.
 
-If you get really stumped, you can check out the solution code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
+If you get really stumped, you can check out the solution code
+[here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
 
-Feel free to get creative with these challenges and take them even further. The instructions aren't here to hold you back!
+Feel free to get creative with these challenges and take them even further. The
+instructions aren't here to hold you back!

--- a/developers/courses/solana-course/content/serialize-instruction-data.md
+++ b/developers/courses/solana-course/content/serialize-instruction-data.md
@@ -1,18 +1,18 @@
 ---
 title: Serialize Custom Instruction Data
 objectives:
-- Explain the contents of a transaction
-- Explain transaction instructions
-- Explain the basics of Solana's runtime optimizations
-- Explain Borsh
-- Use Borsh to serialize custom instruction data
+  - Explain the contents of a transaction
+  - Explain transaction instructions
+  - Explain the basics of Solana's runtime optimizations
+  - Explain Borsh
+  - Use Borsh to serialize custom instruction data
 ---
 
 # TL;DR
 
 - Transactions are made up of an array of instructions, a single transaction can have any number of instructions in it, each targeting its own program. When a transaction is submitted, the Solana runtime will process its instructions in order and atomically, meaning that if any of the instructions fail for any reason, the entire transaction will fail to be processed.
-- Every *instruction* is made up of 3 components: the intended program's ID, an array of all account’s involved, and a byte buffer of instruction data.
-- Every *transaction* contains: an array of all accounts it intends to read from or write to, one or more instructions, a recent blockhash, and one or more signatures.
+- Every _instruction_ is made up of 3 components: the intended program's ID, an array of all account’s involved, and a byte buffer of instruction data.
+- Every _transaction_ contains: an array of all accounts it intends to read from or write to, one or more instructions, a recent blockhash, and one or more signatures.
 - In order to pass instruction data from a client, it must be serialized into a byte buffer. To facilitate this process of serialization, we will be using [Borsh](https://borsh.io/).
 - Transactions can fail to be processed by the blockchain for any number of reasons, we’ll discuss some of the most common ones here.
 
@@ -71,7 +71,7 @@ Each program, however, only has one entry point. You would instruct the program 
 
 You would also include in the instruction data any information the function needs in order to execute properly, e.g. an inventory item’s ID, a player to transfer inventory to, etc.
 
-Exactly *how* this data would be structured would depend on how the program was written, but it’s common to have the first field in instruction data be a number that the program can map to a function, after which additional fields act as function arguments.
+Exactly _how_ this data would be structured would depend on how the program was written, but it’s common to have the first field in instruction data be a number that the program can map to a function, after which additional fields act as function arguments.
 
 ## Serialization
 
@@ -90,30 +90,33 @@ Building off of the previous game inventory example, let’s look at a hypotheti
 All of this will be passed as a byte buffer that will be read in order, so ensuring proper buffer layout order is crucial. You would create the buffer layout schema or template for the above as follows:
 
 ```tsx
-import * as borsh from '@project-serum/borsh'
+import * as borsh from "@project-serum/borsh";
 
 const equipPlayerSchema = borsh.struct([
-	borsh.u8('variant'),
-	borsh.u16('playerId'),
-	borsh.u256('itemId')
-])
+  borsh.u8("variant"),
+  borsh.u16("playerId"),
+  borsh.u256("itemId"),
+]);
 ```
 
 You can then encode data using this schema with the `encode` method. This method accepts as arguments an object representing the data to be serialized and a buffer. In the below example, we allocate a new buffer that’s much larger than needed, then encode the data into that buffer and slice it down into a new buffer that’s only as large as needed.
 
 ```tsx
-import * as borsh from '@project-serum/borsh'
+import * as borsh from "@project-serum/borsh";
 
 const equipPlayerSchema = borsh.struct([
-	borsh.u8('variant'),
-	borsh.u16('playerId'),
-	borsh.u256('itemId')
-])
+  borsh.u8("variant"),
+  borsh.u16("playerId"),
+  borsh.u256("itemId"),
+]);
 
-const buffer = Buffer.alloc(1000)
-equipPlayerSchema.encode({ variant: 2, playerId: 1435, itemId: 737498 }, buffer)
+const buffer = Buffer.alloc(1000);
+equipPlayerSchema.encode(
+  { variant: 2, playerId: 1435, itemId: 737498 },
+  buffer,
+);
 
-const instructionBuffer = buffer.slice(0, equipPlayerSchema.getSpan(buffer))
+const instructionBuffer = buffer.slice(0, equipPlayerSchema.getSpan(buffer));
 ```
 
 Once a buffer is properly created and the data serialized, all that’s left is building the transaction. This is similar to what you’ve done in previous lessons. The example below assumes that:
@@ -124,27 +127,30 @@ Once a buffer is properly created and the data serialized, all that’s left is 
 - `SystemProgram` will be used in the process of executing the instruction.
 
 ```tsx
-import * as borsh from '@project-serum/borsh'
-import * as web3 from '@solana/web3.js'
+import * as borsh from "@project-serum/borsh";
+import * as web3 from "@solana/web3.js";
 
 const equipPlayerSchema = borsh.struct([
-	borsh.u8('variant'),
-	borsh.u16('playerId'),
-	borsh.u256('itemId')
-])
+  borsh.u8("variant"),
+  borsh.u16("playerId"),
+  borsh.u256("itemId"),
+]);
 
-const buffer = Buffer.alloc(1000)
-equipPlayerSchema.encode({ variant: 2, playerId: 1435, itemId: 737498 }, buffer)
+const buffer = Buffer.alloc(1000);
+equipPlayerSchema.encode(
+  { variant: 2, playerId: 1435, itemId: 737498 },
+  buffer,
+);
 
-const instructionBuffer = buffer.slice(0, equipPlayerSchema.getSpan(buffer))
+const instructionBuffer = buffer.slice(0, equipPlayerSchema.getSpan(buffer));
 
-const endpoint = web3.clusterApiUrl('devnet')
-const connection = new web3.Connection(endpoint)
+const endpoint = web3.clusterApiUrl("devnet");
+const connection = new web3.Connection(endpoint);
 
-const transaction = new web3.Transaction()
+const transaction = new web3.Transaction();
 const instruction = new web3.TransactionInstruction({
-	keys: [
-		{
+  keys: [
+    {
       pubkey: player.publicKey,
       isSigner: true,
       isWritable: false,
@@ -158,17 +164,19 @@ const instruction = new web3.TransactionInstruction({
       pubkey: web3.SystemProgram.programId,
       isSigner: false,
       isWritable: false,
-    }
-	],
-	data: instructionBuffer,
-	programId: PROGRAM_ID
-})
+    },
+  ],
+  data: instructionBuffer,
+  programId: PROGRAM_ID,
+});
 
-transaction.add(instruction)
+transaction.add(instruction);
 
-web3.sendAndConfirmTransaction(connection, transaction, [player]).then((txid) => {
-	console.log(`Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`)
-})
+web3.sendAndConfirmTransaction(connection, transaction, [player]).then(txid => {
+  console.log(
+    `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+  );
+});
 ```
 
 # Demo
@@ -217,7 +225,7 @@ export class Movie {
 }
 ```
 
-Keep in mind that *order matters*. If the order of properties here differs from how the program is structured, the transaction will fail.
+Keep in mind that _order matters_. If the order of properties here differs from how the program is structured, the transaction will fail.
 
 ### 3. Create a method to serialize data
 
@@ -259,12 +267,24 @@ Inside this function, we’ll be creating and sending the transaction that conta
 Start by importing `@solana/web3.js` and importing `useConnection` and `useWallet` from `@solana/wallet-adapter-react`.
 
 ```tsx
-import { FC } from 'react'
-import { Movie } from '../models/Movie'
-import { useState } from 'react'
-import { Box, Button, FormControl, FormLabel, Input, NumberDecrementStepper, NumberIncrementStepper, NumberInput, NumberInputField, NumberInputStepper, Textarea } from '@chakra-ui/react'
-import * as web3 from '@solana/web3.js'
-import { useConnection, useWallet } from '@solana/wallet-adapter-react'
+import { FC } from "react";
+import { Movie } from "../models/Movie";
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  Textarea,
+} from "@chakra-ui/react";
+import * as web3 from "@solana/web3.js";
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 ```
 
 Next, before the `handleSubmit` function, call `useConnection()` to get a `connection` object and call `useWallet()` to get `publicKey` and `sendTransaction`.
@@ -311,23 +331,23 @@ That’s quite a lot to process! But don’t worry, it gets easier the more you 
 
 ```tsx
 const handleTransactionSubmit = async (movie: Movie) => {
-	if (!publicKey) {
-		alert('Please connect your wallet!')
-		return
-	}
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-	const buffer = movie.serialize()
-	const transaction = new web3.Transaction()
-}
+  const buffer = movie.serialize();
+  const transaction = new web3.Transaction();
+};
 ```
 
 The next step is to get all of the accounts that the transaction will read from or write to. In past lessons, the account where data will be stored has been given to you. This time, the account’s address is more dynamic, so it needs to be computed. We’ll cover this in depth in the next lesson, but for now you can use the following, where `pda` is the address to the account where data will be stored:
 
 ```tsx
 const [pda] = await web3.PublicKey.findProgramAddress(
-	[publicKey.toBuffer(), Buffer.from(movie.title)],
-	new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID)
-)
+  [publicKey.toBuffer(), Buffer.from(movie.title)],
+  new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID),
+);
 ```
 
 In addition to this account, the program will also need to read from `SystemProgram`, so our array needs to include `web3.SystemProgram.programId` as well.
@@ -336,50 +356,52 @@ With that, we can finish the remaining steps:
 
 ```tsx
 const handleTransactionSubmit = async (movie: Movie) => {
-	if (!publicKey) {
-		alert('Please connect your wallet!')
-		return
-	}
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-	const buffer = movie.serialize()
-	const transaction = new web3.Transaction()
+  const buffer = movie.serialize();
+  const transaction = new web3.Transaction();
 
-	const [pda] = await web3.PublicKey.findProgramAddress(
-		[publicKey.toBuffer(), new TextEncoder().encode(movie.title)],
-		new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID)
-	)
+  const [pda] = await web3.PublicKey.findProgramAddress(
+    [publicKey.toBuffer(), new TextEncoder().encode(movie.title)],
+    new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID),
+  );
 
-	const instruction = new web3.TransactionInstruction({
-		keys: [
-			{
-				pubkey: publicKey,
-				isSigner: true,
-				isWritable: false,
-			},
-			{
-				pubkey: pda,
-				isSigner: false,
-				isWritable: true
-			},
-			{
-				pubkey: web3.SystemProgram.programId,
-				isSigner: false,
-				isWritable: false
-			}
-		],
-		data: buffer,
-		programId: new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID)
-	})
+  const instruction = new web3.TransactionInstruction({
+    keys: [
+      {
+        pubkey: publicKey,
+        isSigner: true,
+        isWritable: false,
+      },
+      {
+        pubkey: pda,
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: web3.SystemProgram.programId,
+        isSigner: false,
+        isWritable: false,
+      },
+    ],
+    data: buffer,
+    programId: new web3.PublicKey(MOVIE_REVIEW_PROGRAM_ID),
+  });
 
-	transaction.add(instruction)
+  transaction.add(instruction);
 
-	try {
-		let txid = await sendTransaction(transaction, connection)
-		console.log(`Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`)
-	} catch (e) {
-		alert(JSON.stringify(e))
-	}
-}
+  try {
+    let txid = await sendTransaction(transaction, connection);
+    console.log(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+  } catch (e) {
+    alert(JSON.stringify(e));
+  }
+};
 ```
 
 And that’s it! You should now be able to use the form on the site to submit a movie review. While you won’t see the UI update to reflect the new review, you can look at the transaction’s program logs on Solana Explorer to see that it was successful.

--- a/developers/courses/solana-course/content/signer-auth.md
+++ b/developers/courses/solana-course/content/signer-auth.md
@@ -1,23 +1,21 @@
 ---
 title: Signer Authorization
 objectives:
-- Explain the security risks associated with not performing appropriate signer checks
-- Implement signer checks using long-form Rust
-- Implement signer checks using Anchor’s `Signer` type
-- Implement signer checks using Anchor’s `#[account(signer)]` constraint
+  - Explain the security risks associated with not performing appropriate signer checks
+  - Implement signer checks using long-form Rust
+  - Implement signer checks using Anchor’s `Signer` type
+  - Implement signer checks using Anchor’s `#[account(signer)]` constraint
 ---
 
 # TL;DR
 
 - Use **Signer Checks** to verify that specific accounts have signed a transaction. Without appropriate signer checks, accounts may be able to execute instructions they shouldn’t be authorized to perform.
 - To implement a signer check in Rust, simply check that an account’s `is_signer` property is `true`
-    
-    ```rust
-    if !ctx.accounts.authority.is_signer {
-    	return Err(ProgramError::MissingRequiredSignature.into());
-    }
-    ```
-    
+  ```rust
+  if !ctx.accounts.authority.is_signer {
+  	return Err(ProgramError::MissingRequiredSignature.into());
+  }
+  ```
 - In Anchor, you can use the **`Signer`** account type in your account validation struct to have Anchor automatically perform a signer check on a given account
 - Anchor also has an account constraint that will automatically verify that a given account has signed a transaction
 
@@ -27,7 +25,7 @@ Signer checks are used to verify that a given account’s owner has authorized a
 
 ### Missing Signer Check
 
-The example below shows an oversimplified version of an instruction that updates the `authority` field stored on a program account. 
+The example below shows an oversimplified version of an instruction that updates the `authority` field stored on a program account.
 
 Notice that the `authority` field on the `UpdateAuthority` account validation struct is of type `AccountInfo`. In Anchor, the `AccountInfo` account type indicates that no checks are performed on the account prior to instruction execution.
 
@@ -123,7 +121,7 @@ However, putting this check into the instruction function muddles the separation
 
 Fortunately, Anchor makes it easy to perform signer checks by providing the `Signer` account type. Simply change the `authority` account’s type in the account validation struct to be of type `Signer`, and Anchor will check at runtime that the specified account is a signer on the transaction. This is the approach we generally recommend since it allows you to separate the signer check from instruction logic.
 
-In the example below, if the `authority` account does not sign the transaction, then the transaction will fail before even reaching the instruction logic. 
+In the example below, if the `authority` account does not sign the transaction, then the transaction will fail before even reaching the instruction logic.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -164,9 +162,9 @@ Note that when you use the `Signer` type, no other ownership or type checks are 
 
 While in most cases, the `Signer` account type will suffice to ensure an account has signed a transaction, the fact that no other ownership or type checks are performed means that this account can’t really be used for anything else in the instruction.
 
-This is where the `signer` *constraint* comes in handy. The `#[account(signer)]` constraint allows you to verify the account signed the transaction, while also getting the benefits of using the `Account` type if you wanted access to it’s underlying data as well. 
+This is where the `signer` _constraint_ comes in handy. The `#[account(signer)]` constraint allows you to verify the account signed the transaction, while also getting the benefits of using the `Account` type if you wanted access to it’s underlying data as well.
 
-As an example of when this would be useful, imagine writing an instruction that you expect to be invoked via CPI that expects one of the passed in accounts to be both a ******signer****** on the transaciton and a ***********data source***********. Using the `Signer` account type here removes the automatic deserialization and type checking you would get with the `Account` type. This is both inconvenient, as you need to manually deserialize the account data in the instruction logic, and may make your program vulnerable by not getting the ownership and type checking performed by the `Account` type.
+As an example of when this would be useful, imagine writing an instruction that you expect to be invoked via CPI that expects one of the passed in accounts to be both a **\*\***signer**\*\*** on the transaciton and a ****\*\*\*****data source****\*\*\*****. Using the `Signer` account type here removes the automatic deserialization and type checking you would get with the `Account` type. This is both inconvenient, as you need to manually deserialize the account data in the instruction logic, and may make your program vulnerable by not getting the ownership and type checking performed by the `Account` type.
 
 In the example below, you can safely write logic to interact with the data stored in the `authority` account while also verifying that it signed the transaction.
 
@@ -221,11 +219,11 @@ This program initializes a simplified token “vault” account and demonstrates
 
 ### 1. Starter
 
-To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-signer-auth/tree/starter). The starter code includes a program with two instructions and the boilerplate setup for the test file. 
+To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-signer-auth/tree/starter). The starter code includes a program with two instructions and the boilerplate setup for the test file.
 
-The `initialize_vault` instruction initializes two new accounts: `Vault` and `TokenAccount`. The `Vault` account will be initialized using a Program Derived Address (PDA) and store the address of a token account and the authority of the vault. The authority of the token account will be the `vault` PDA which enables the program to sign for the transfer of tokens. 
+The `initialize_vault` instruction initializes two new accounts: `Vault` and `TokenAccount`. The `Vault` account will be initialized using a Program Derived Address (PDA) and store the address of a token account and the authority of the vault. The authority of the token account will be the `vault` PDA which enables the program to sign for the transfer of tokens.
 
-The `insecure_withdraw` instruction will transfer tokens in the `vault` account’s token account to a `withdraw_destination` token account. However, the `authority` account in the `InsecureWithdraw` struct has a type of `UncheckedAccount`. This is a wrapper around `AccountInfo` to explicitly indicate the account is unchecked. 
+The `insecure_withdraw` instruction will transfer tokens in the `vault` account’s token account to a `withdraw_destination` token account. However, the `authority` account in the `InsecureWithdraw` struct has a type of `UncheckedAccount`. This is a wrapper around `AccountInfo` to explicitly indicate the account is unchecked.
 
 Without a signer check, anyone can simply provide the public key of the `authority` account that matches `authority` stored on the `vault` account and the `insecure_withdraw` instruction would continue to process.
 
@@ -453,7 +451,7 @@ If you want to take a look at the final solution code you can find it on the `so
 
 # Challenge
 
-At this point in the course, we hope you've started to work on programs and projects outside the Demos and Challenges provided in these lessons. For this and the remainder of the lessons on security vulnerabilities, the Challenge for each lesson will be to audit your own code for the security vulnerability discussed in the lesson. 
+At this point in the course, we hope you've started to work on programs and projects outside the Demos and Challenges provided in these lessons. For this and the remainder of the lessons on security vulnerabilities, the Challenge for each lesson will be to audit your own code for the security vulnerability discussed in the lesson.
 
 Alternatively, you can find open source programs to audit. There are plenty of programs you can look at. A good start if you don't mind diving into native Rust would be the [SPL programs](https://github.com/solana-labs/solana-program-library).
 

--- a/developers/courses/solana-course/content/signer-auth.md
+++ b/developers/courses/solana-course/content/signer-auth.md
@@ -1,7 +1,8 @@
 ---
 title: Signer Authorization
 objectives:
-  - Explain the security risks associated with not performing appropriate signer checks
+  - Explain the security risks associated with not performing appropriate signer
+    checks
   - Implement signer checks using long-form Rust
   - Implement signer checks using Anchor’s `Signer` type
   - Implement signer checks using Anchor’s `#[account(signer)]` constraint
@@ -9,29 +10,49 @@ objectives:
 
 # TL;DR
 
-- Use **Signer Checks** to verify that specific accounts have signed a transaction. Without appropriate signer checks, accounts may be able to execute instructions they shouldn’t be authorized to perform.
-- To implement a signer check in Rust, simply check that an account’s `is_signer` property is `true`
+- Use **Signer Checks** to verify that specific accounts have signed a
+  transaction. Without appropriate signer checks, accounts may be able to
+  execute instructions they shouldn’t be authorized to perform.
+- To implement a signer check in Rust, simply check that an account’s
+  `is_signer` property is `true`
   ```rust
   if !ctx.accounts.authority.is_signer {
   	return Err(ProgramError::MissingRequiredSignature.into());
   }
   ```
-- In Anchor, you can use the **`Signer`** account type in your account validation struct to have Anchor automatically perform a signer check on a given account
-- Anchor also has an account constraint that will automatically verify that a given account has signed a transaction
+- In Anchor, you can use the **`Signer`** account type in your account
+  validation struct to have Anchor automatically perform a signer check on a
+  given account
+- Anchor also has an account constraint that will automatically verify that a
+  given account has signed a transaction
 
 # Overview
 
-Signer checks are used to verify that a given account’s owner has authorized a transaction. Without a signer check, operations whose execution should be limited to only specific accounts can potentially be performed by any account. In the worst case scenario, this could result in wallets being completely drained by attackers passing in whatever account they want to an instruction.
+Signer checks are used to verify that a given account’s owner has authorized a
+transaction. Without a signer check, operations whose execution should be
+limited to only specific accounts can potentially be performed by any account.
+In the worst case scenario, this could result in wallets being completely
+drained by attackers passing in whatever account they want to an instruction.
 
 ### Missing Signer Check
 
-The example below shows an oversimplified version of an instruction that updates the `authority` field stored on a program account.
+The example below shows an oversimplified version of an instruction that updates
+the `authority` field stored on a program account.
 
-Notice that the `authority` field on the `UpdateAuthority` account validation struct is of type `AccountInfo`. In Anchor, the `AccountInfo` account type indicates that no checks are performed on the account prior to instruction execution.
+Notice that the `authority` field on the `UpdateAuthority` account validation
+struct is of type `AccountInfo`. In Anchor, the `AccountInfo` account type
+indicates that no checks are performed on the account prior to instruction
+execution.
 
-Although the `has_one` constraint is used to validate the `authority` account passed into the instruction matches the `authority` field stored on the `vault` account, there is no check to verify the `authority` account authorized the transaction.
+Although the `has_one` constraint is used to validate the `authority` account
+passed into the instruction matches the `authority` field stored on the `vault`
+account, there is no check to verify the `authority` account authorized the
+transaction.
 
-This means an attacker can simply pass in the public key of the `authority` account and their own public key as the `new_authority` account to reassign themselves as the new authority of the `vault` account. At that point, they can interact with the program as the new authority.
+This means an attacker can simply pass in the public key of the `authority`
+account and their own public key as the `new_authority` account to reassign
+themselves as the new authority of the `vault` account. At that point, they can
+interact with the program as the new authority.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -68,7 +89,10 @@ pub struct Vault {
 
 ### Add signer authorization checks
 
-All you need to do to validate that the `authority` account signed is to add a signer check within the instruction. That simply means checking that `authority.is_signer` is `true`, and returning a `MissingRequiredSignature` error if `false`.
+All you need to do to validate that the `authority` account signed is to add a
+signer check within the instruction. That simply means checking that
+`authority.is_signer` is `true`, and returning a `MissingRequiredSignature`
+error if `false`.
 
 ```tsx
 if !ctx.accounts.authority.is_signer {
@@ -76,7 +100,10 @@ if !ctx.accounts.authority.is_signer {
 }
 ```
 
-By adding a signer check, the instruction would only process if the account passed in as the `authority` account also signed the transaction. If the transaction was not signed by the account passed in as the `authority` account, then the transaction would fail.
+By adding a signer check, the instruction would only process if the account
+passed in as the `authority` account also signed the transaction. If the
+transaction was not signed by the account passed in as the `authority` account,
+then the transaction would fail.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -117,11 +144,18 @@ pub struct Vault {
 
 ### Use Anchor’s `Signer` account type
 
-However, putting this check into the instruction function muddles the separation between account validation and instruction logic.
+However, putting this check into the instruction function muddles the separation
+between account validation and instruction logic.
 
-Fortunately, Anchor makes it easy to perform signer checks by providing the `Signer` account type. Simply change the `authority` account’s type in the account validation struct to be of type `Signer`, and Anchor will check at runtime that the specified account is a signer on the transaction. This is the approach we generally recommend since it allows you to separate the signer check from instruction logic.
+Fortunately, Anchor makes it easy to perform signer checks by providing the
+`Signer` account type. Simply change the `authority` account’s type in the
+account validation struct to be of type `Signer`, and Anchor will check at
+runtime that the specified account is a signer on the transaction. This is the
+approach we generally recommend since it allows you to separate the signer check
+from instruction logic.
 
-In the example below, if the `authority` account does not sign the transaction, then the transaction will fail before even reaching the instruction logic.
+In the example below, if the `authority` account does not sign the transaction,
+then the transaction will fail before even reaching the instruction logic.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -156,17 +190,33 @@ pub struct Vault {
 }
 ```
 
-Note that when you use the `Signer` type, no other ownership or type checks are performed.
+Note that when you use the `Signer` type, no other ownership or type checks are
+performed.
 
 ### Use Anchor’s `#[account(signer)]` constraint
 
-While in most cases, the `Signer` account type will suffice to ensure an account has signed a transaction, the fact that no other ownership or type checks are performed means that this account can’t really be used for anything else in the instruction.
+While in most cases, the `Signer` account type will suffice to ensure an account
+has signed a transaction, the fact that no other ownership or type checks are
+performed means that this account can’t really be used for anything else in the
+instruction.
 
-This is where the `signer` _constraint_ comes in handy. The `#[account(signer)]` constraint allows you to verify the account signed the transaction, while also getting the benefits of using the `Account` type if you wanted access to it’s underlying data as well.
+This is where the `signer` _constraint_ comes in handy. The `#[account(signer)]`
+constraint allows you to verify the account signed the transaction, while also
+getting the benefits of using the `Account` type if you wanted access to it’s
+underlying data as well.
 
-As an example of when this would be useful, imagine writing an instruction that you expect to be invoked via CPI that expects one of the passed in accounts to be both a **\*\***signer**\*\*** on the transaciton and a ****\*\*\*****data source****\*\*\*****. Using the `Signer` account type here removes the automatic deserialization and type checking you would get with the `Account` type. This is both inconvenient, as you need to manually deserialize the account data in the instruction logic, and may make your program vulnerable by not getting the ownership and type checking performed by the `Account` type.
+As an example of when this would be useful, imagine writing an instruction that
+you expect to be invoked via CPI that expects one of the passed in accounts to
+be both a **\*\***signer**\*\*** on the transaciton and a \***\*\*\*\*\*\***data
+source\***\*\*\*\*\*\***. Using the `Signer` account type here removes the
+automatic deserialization and type checking you would get with the `Account`
+type. This is both inconvenient, as you need to manually deserialize the account
+data in the instruction logic, and may make your program vulnerable by not
+getting the ownership and type checking performed by the `Account` type.
 
-In the example below, you can safely write logic to interact with the data stored in the `authority` account while also verifying that it signed the transaction.
+In the example below, you can safely write logic to interact with the data
+stored in the `authority` account while also verifying that it signed the
+transaction.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -213,21 +263,38 @@ pub struct AuthState{
 
 # Demo
 
-Let’s practice by creating a simple program to demonstrate how a missing signer check can allow an attacker to withdraw tokens that don’t belong to them.
+Let’s practice by creating a simple program to demonstrate how a missing signer
+check can allow an attacker to withdraw tokens that don’t belong to them.
 
-This program initializes a simplified token “vault” account and demonstrates how a missing signer check could allow the vault to be drained.
+This program initializes a simplified token “vault” account and demonstrates how
+a missing signer check could allow the vault to be drained.
 
 ### 1. Starter
 
-To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-signer-auth/tree/starter). The starter code includes a program with two instructions and the boilerplate setup for the test file.
+To get started, download the starter code from the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-signer-auth/tree/starter). The
+starter code includes a program with two instructions and the boilerplate setup
+for the test file.
 
-The `initialize_vault` instruction initializes two new accounts: `Vault` and `TokenAccount`. The `Vault` account will be initialized using a Program Derived Address (PDA) and store the address of a token account and the authority of the vault. The authority of the token account will be the `vault` PDA which enables the program to sign for the transfer of tokens.
+The `initialize_vault` instruction initializes two new accounts: `Vault` and
+`TokenAccount`. The `Vault` account will be initialized using a Program Derived
+Address (PDA) and store the address of a token account and the authority of the
+vault. The authority of the token account will be the `vault` PDA which enables
+the program to sign for the transfer of tokens.
 
-The `insecure_withdraw` instruction will transfer tokens in the `vault` account’s token account to a `withdraw_destination` token account. However, the `authority` account in the `InsecureWithdraw` struct has a type of `UncheckedAccount`. This is a wrapper around `AccountInfo` to explicitly indicate the account is unchecked.
+The `insecure_withdraw` instruction will transfer tokens in the `vault`
+account’s token account to a `withdraw_destination` token account. However, the
+`authority` account in the `InsecureWithdraw` struct has a type of
+`UncheckedAccount`. This is a wrapper around `AccountInfo` to explicitly
+indicate the account is unchecked.
 
-Without a signer check, anyone can simply provide the public key of the `authority` account that matches `authority` stored on the `vault` account and the `insecure_withdraw` instruction would continue to process.
+Without a signer check, anyone can simply provide the public key of the
+`authority` account that matches `authority` stored on the `vault` account and
+the `insecure_withdraw` instruction would continue to process.
 
-While this is somewhat contrived in that any DeFi program with a vault would be more sophisticated than this, it will show how the lack of a signer check can result in tokens being withdrawn by the wrong party.
+While this is somewhat contrived in that any DeFi program with a vault would be
+more sophisticated than this, it will show how the lack of a signer check can
+result in tokens being withdrawn by the wrong party.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -318,11 +385,17 @@ pub struct Vault {
 
 ### 2. Test `insecure_withdraw` instruction
 
-The test file includes the code to invoke the `initialize_vault` instruction using `wallet` as the `authority` on the vault. The code then mints 100 tokens to the `vault` token account. Theoretically, the `wallet` key should be the only one that can withdraw the 100 tokens from the vault.
+The test file includes the code to invoke the `initialize_vault` instruction
+using `wallet` as the `authority` on the vault. The code then mints 100 tokens
+to the `vault` token account. Theoretically, the `wallet` key should be the only
+one that can withdraw the 100 tokens from the vault.
 
-Now, let’s add a test to invoke `insecure_withdraw` on the program to show that the current version of the program allows a third party to in fact withdraw those 100 tokens.
+Now, let’s add a test to invoke `insecure_withdraw` on the program to show that
+the current version of the program allows a third party to in fact withdraw
+those 100 tokens.
 
-In the test, we’ll still use the public key of `wallet` as the `authority` account, but we’ll use a different keypair to sign and send the transaction.
+In the test, we’ll still use the public key of `wallet` as the `authority`
+account, but we’ll use a different keypair to sign and send the transaction.
 
 ```tsx
 describe("signer-authorization", () => {
@@ -356,11 +429,21 @@ signer-authorization
   ✔ Insecure withdraw  (405ms)
 ```
 
-Since there is no signer check for the `authority` account, the `insecure_withdraw` instruction will transfer tokens from the `vault` token account to the `withdrawDestinationFake` token account as long as the public key of the`authority` account matches the public key stored on the authority field of the `vault` account. Clearly, the `insecure_withdraw` instruction is as insecure as the name suggests.
+Since there is no signer check for the `authority` account, the
+`insecure_withdraw` instruction will transfer tokens from the `vault` token
+account to the `withdrawDestinationFake` token account as long as the public key
+of the`authority` account matches the public key stored on the authority field
+of the `vault` account. Clearly, the `insecure_withdraw` instruction is as
+insecure as the name suggests.
 
 ### 3. Add `secure_withdraw` instruction
 
-Let’s fix the problem in a new instruction called `secure_withdraw`. This instruction will be identical to the `insecure_withdraw` instruction, except we’ll use the `Signer` type in the Accounts struct to validate the `authority` account in the `SecureWithdraw` struct. If the `authority` account is not a signer on the transaction, then we expect the transaction to fail and return an error.
+Let’s fix the problem in a new instruction called `secure_withdraw`. This
+instruction will be identical to the `insecure_withdraw` instruction, except
+we’ll use the `Signer` type in the Accounts struct to validate the `authority`
+account in the `SecureWithdraw` struct. If the `authority` account is not a
+signer on the transaction, then we expect the transaction to fail and return an
+error.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -413,7 +496,12 @@ pub struct SecureWithdraw<'info> {
 
 ### 4. Test `secure_withdraw` instruction
 
-With the instruction in place, return to the test file to test the `secure_withdraw` instruction. Invoke the `secure_withdraw` instruction, again using the public key of `wallet` as the `authority` account and the `withdrawDestinationFake` keypair as the signer and withdraw destination. Since the `authority` account is validated using the `Signer` type, we expect the transaction to fail the signer check and return an error.
+With the instruction in place, return to the test file to test the
+`secure_withdraw` instruction. Invoke the `secure_withdraw` instruction, again
+using the public key of `wallet` as the `authority` account and the
+`withdrawDestinationFake` keypair as the signer and withdraw destination. Since
+the `authority` account is validated using the `Signer` type, we expect the
+transaction to fail the signer check and return an error.
 
 ```tsx
 describe("signer-authorization", () => {
@@ -439,20 +527,35 @@ describe("signer-authorization", () => {
 })
 ```
 
-Run `anchor test` to see that the transaction will now return a signature verification error.
+Run `anchor test` to see that the transaction will now return a signature
+verification error.
 
 ```bash
 Error: Signature verification failed
 ```
 
-That’s it! This is a fairly simple thing to avoid, but incredibly important. Make sure to always think through who should who should be authorizing instructions and make sure that each is a signer on the transaction.
+That’s it! This is a fairly simple thing to avoid, but incredibly important.
+Make sure to always think through who should who should be authorizing
+instructions and make sure that each is a signer on the transaction.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the repository](https://github.com/Unboxed-Software/solana-signer-auth/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the repository](https://github.com/Unboxed-Software/solana-signer-auth/tree/solution).
 
 # Challenge
 
-At this point in the course, we hope you've started to work on programs and projects outside the Demos and Challenges provided in these lessons. For this and the remainder of the lessons on security vulnerabilities, the Challenge for each lesson will be to audit your own code for the security vulnerability discussed in the lesson.
+At this point in the course, we hope you've started to work on programs and
+projects outside the Demos and Challenges provided in these lessons. For this
+and the remainder of the lessons on security vulnerabilities, the Challenge for
+each lesson will be to audit your own code for the security vulnerability
+discussed in the lesson.
 
-Alternatively, you can find open source programs to audit. There are plenty of programs you can look at. A good start if you don't mind diving into native Rust would be the [SPL programs](https://github.com/solana-labs/solana-program-library).
+Alternatively, you can find open source programs to audit. There are plenty of
+programs you can look at. A good start if you don't mind diving into native Rust
+would be the
+[SPL programs](https://github.com/solana-labs/solana-program-library).
 
-So for this lesson, take a look at a program (whether yours or one you've found online) and audit it for signer checks. If you find a bug in somebody else's program, please alert them! If you find a bug in your own program, be sure to patch it right away.
+So for this lesson, take a look at a program (whether yours or one you've found
+online) and audit it for signer checks. If you find a bug in somebody else's
+program, please alert them! If you find a bug in your own program, be sure to
+patch it right away.

--- a/developers/courses/solana-course/content/solana-pay.md
+++ b/developers/courses/solana-course/content/solana-pay.md
@@ -1,16 +1,16 @@
 ---
 title: Solana Pay
 objectives:
-- Use the Solana Pay specification to build payment requests and initiate transactions using URLs encoded as QR codes
-- Use the `@solana/pay` library to help with the creation of Solana Pay transaction requests
-- Partially sign transactions and implement transaction gating based on certain conditions
+  - Use the Solana Pay specification to build payment requests and initiate transactions using URLs encoded as QR codes
+  - Use the `@solana/pay` library to help with the creation of Solana Pay transaction requests
+  - Partially sign transactions and implement transaction gating based on certain conditions
 ---
 
 # TL;DR
 
--   **Solana Pay** is a specification for encoding Solana transaction requests within URLs, enabling standardized transaction requests across different Solana apps and wallets
--   **Partial signing** of transactions allows for the creation of transactions that require multiple signatures before they are submitted to the network
--   **Transaction gating** involves implementing rules that determine whether certain transactions are allowed to be processed or not, based on certain conditions or the presence of specific data in the transaction
+- **Solana Pay** is a specification for encoding Solana transaction requests within URLs, enabling standardized transaction requests across different Solana apps and wallets
+- **Partial signing** of transactions allows for the creation of transactions that require multiple signatures before they are submitted to the network
+- **Transaction gating** involves implementing rules that determine whether certain transactions are allowed to be processed or not, based on certain conditions or the presence of specific data in the transaction
 
 # Overview
 
@@ -84,13 +84,13 @@ The main thing you, the developer, need to do to make the transaction request fl
 In Next.js, you do this by adding a file to the `pages/api` folder and exporting a function that handles the request and response.
 
 ```typescript
-import { NextApiRequest, NextApiResponse } from "next"
+import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse,
+  req: NextApiRequest,
+  res: NextApiResponse,
 ) {
-    // Handle the request
+  // Handle the request
 }
 ```
 
@@ -104,24 +104,24 @@ The wallet consuming your transaction request URL will first issue a GET request
 Building on the empty endpoint from before, that may look like this:
 
 ```typescript
-import { NextApiRequest, NextApiResponse } from "next"
+import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse,
+  req: NextApiRequest,
+  res: NextApiResponse,
 ) {
-    if (req.method === "GET") {
-        return get(res)
-    } else {
-        return res.status(405).json({ error: "Method not allowed" })
-    }
+  if (req.method === "GET") {
+    return get(res);
+  } else {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
 }
 
 function get(res: NextApiResponse) {
-    res.status(200).json({
-        label: "Store Name",
-        icon: "https://solana.com/src/img/branding/solanaLogoMark.svg",
-    });
+  res.status(200).json({
+    label: "Store Name",
+    icon: "https://solana.com/src/img/branding/solanaLogoMark.svg",
+  });
 }
 ```
 
@@ -139,67 +139,64 @@ With this information and any additional parameters provided, you can build the 
 4. Serializing the transaction and returning it in a `PostResponse` object along with a message for the user.
 
 ```typescript
-import { NextApiRequest, NextApiResponse } from "next"
+import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse,
+  req: NextApiRequest,
+  res: NextApiResponse,
 ) {
-    if (req.method === "GET") {
-        return get(res)
-    } else if (req.method === "POST") {
-        return post(req, res)
-    } else {
-        return res.status(405).json({ error: "Method not allowed" })
-    }
+  if (req.method === "GET") {
+    return get(res);
+  } else if (req.method === "POST") {
+    return post(req, res);
+  } else {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
 }
 
 function get(res: NextApiResponse) {
-    res.status(200).json({
-        label: "Store Name",
-        icon: "https://solana.com/src/img/branding/solanaLogoMark.svg",
-    });
+  res.status(200).json({
+    label: "Store Name",
+    icon: "https://solana.com/src/img/branding/solanaLogoMark.svg",
+  });
 }
-async function post(
-    req: PublicKey,
-    res: PublicKey,
-) {
-    const { account, reference } = req.body
+async function post(req: PublicKey, res: PublicKey) {
+  const { account, reference } = req.body;
 
-    const connection = new Connection(clusterApiUrl("devnet"));
+  const connection = new Connection(clusterApiUrl("devnet"));
 
-    const { blockhash } = await connection.getLatestBlockhash();
+  const { blockhash } = await connection.getLatestBlockhash();
 
-    const transaction = new Transaction({
-        recentBlockhash: blockhash,
-        feePayer: account,
-    });
+  const transaction = new Transaction({
+    recentBlockhash: blockhash,
+    feePayer: account,
+  });
 
-    const instruction = SystemProgram.transfer({
-        fromPubkey: account,
-        toPubkey: Keypair.generate().publicKey,
-        lamports: 0.001 * LAMPORTS_PER_SOL,
-    });
+  const instruction = SystemProgram.transfer({
+    fromPubkey: account,
+    toPubkey: Keypair.generate().publicKey,
+    lamports: 0.001 * LAMPORTS_PER_SOL,
+  });
 
-    transaction.add(instruction);
+  transaction.add(instruction);
 
-    transaction.keys.push({
-        pubkey: reference,
-        isSigner: false,
-        isWritable: false,
-    })
+  transaction.keys.push({
+    pubkey: reference,
+    isSigner: false,
+    isWritable: false,
+  });
 
-    const serializedTransaction = transaction.serialize({
-        requireAllSignatures: false,
-    });
-    const base64 = serializedTransaction.toString("base64");
+  const serializedTransaction = transaction.serialize({
+    requireAllSignatures: false,
+  });
+  const base64 = serializedTransaction.toString("base64");
 
-    const message = "Simple transfer of 0.001 SOL";
+  const message = "Simple transfer of 0.001 SOL";
 
-    res.send(200).json({
-        transaction: base64,
-        message,
-    })
+  res.send(200).json({
+    transaction: base64,
+    message,
+  });
 }
 ```
 
@@ -207,7 +204,7 @@ There is nothing too out of the ordinary here. It's the same transaction constru
 
 ### Confirm transaction
 
-You may have noticed that the previous example assumed a `reference` was provided as a query parameter. While this is *not* a value provided by the requesting wallet, it *is* useful to set up your initial transaction request URL to contain this query parameter.
+You may have noticed that the previous example assumed a `reference` was provided as a query parameter. While this is _not_ a value provided by the requesting wallet, it _is_ useful to set up your initial transaction request URL to contain this query parameter.
 
 Since your application isn't the one submitting a transaction to the network, your code won't have access to a transaction signature. This would typically be how your app can locate a transaction on the network and see its status.
 
@@ -227,12 +224,12 @@ const nfts = await metaplex.nfts().findAllByOwner({ owner: account }).run();
 
 // iterate over the nfts array
 for (let i = 0; i < nfts.length; i++) {
-    // check if the current nft has a collection field with the desired value
-    if (nfts[i].collection?.address.toString() == collection.toString()) {
-        // build transaction
-    } else {
-        // return an error
-    }
+  // check if the current nft has a collection field with the desired value
+  if (nfts[i].collection?.address.toString() == collection.toString()) {
+    // build transaction
+  } else {
+    // return an error
+  }
 }
 ```
 
@@ -246,8 +243,8 @@ Fortunately, Solana enables signature composability with partial signing.
 
 Partially signing a multi-signature transaction allows signers to add their signature before the transaction is broadcast on the network. This can be useful in a number of situations, including:
 
--   Approving transactions that require the signature of multiple parties, such as a merchant and a buyer who need to confirm the details of a payment.
--   Invoking custom programs that require the signatures of both a user and an administrator. This can help to limit access to the program instructions and ensure that only authorized parties can execute them.
+- Approving transactions that require the signature of multiple parties, such as a merchant and a buyer who need to confirm the details of a payment.
+- Invoking custom programs that require the signatures of both a user and an administrator. This can help to limit access to the program instructions and ensure that only authorized parties can execute them.
 
 ```typescript
 const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
@@ -279,7 +276,7 @@ The `@solana/pay` library simplifies this with the provided `createQR` helper fu
 - `color` (optional) - the foreground color. Defaults to black.
 
 ```typescript
-const qr = createQR(url, 400, 'transparent')
+const qr = createQR(url, 400, "transparent");
 ```
 
 # Demo
@@ -288,7 +285,7 @@ Now that you've got a conceptual grasp on Solana Pay, let's put it into practice
 
 ### 1. Starter
 
-To get started, download the starter code on the `starter` branch of this [repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/starter). The starter code is a Next.js app that displays a Solana Pay QR code. Notice that the menu bar lets you switch between different QR codes. The default option is a simple SOL transfer for illustrative purposes. Throughout  We'll be adding functionality to the location options in the menu bar.
+To get started, download the starter code on the `starter` branch of this [repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/starter). The starter code is a Next.js app that displays a Solana Pay QR code. Notice that the menu bar lets you switch between different QR codes. The default option is a simple SOL transfer for illustrative purposes. Throughout We'll be adding functionality to the location options in the menu bar.
 
 ![Screenshot of scavenger hunt app](../assets/scavenger-hunt-screenshot.png)
 
@@ -333,26 +330,26 @@ If you were able to successfully execute the transaction using the QR code, you'
 
 Now that you're up and running, it's time to create an endpoint that supports transaction requests for location check-in using the Scavenger Hunt program.
 
-Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper function for initializing `eventOrganizer` from a private key environment variable.  The first thing we'll do in this file is the following:
+Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper function for initializing `eventOrganizer` from a private key environment variable. The first thing we'll do in this file is the following:
 
 1. Export a `handler` function to handle an arbitrary HTTP request
 2. Add `get` and `post` functions for handling those HTTP methods
 3. Add logic to the body of the `handler` function to either call `get`, `post`, or return a 405 error based on the HTTP request method
 
 ```typescript
-import { NextApiRequest, NextApiResponse } from "next"
+import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse
+  req: NextApiRequest,
+  res: NextApiResponse,
 ) {
-    if (req.method === "GET") {
-        return get(res)
-    } else if (req.method === "POST") {
-        return await post(req, res)
-    } else {
-        return res.status(405).json({ error: "Method not allowed" })
-    }
+  if (req.method === "GET") {
+    return get(res);
+  } else if (req.method === "POST") {
+    return await post(req, res);
+  } else {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
 }
 
 function get(res: NextApiResponse) {}
@@ -366,10 +363,10 @@ Remember, the first request from a wallet will be a GET request expecting the en
 
 ```jsx
 function get(res: NextApiResponse) {
-    res.status(200).json({
-        label: "Scavenger Hunt!",
-        icon: "https://solana.com/src/img/branding/solanaLogoMark.svg",
-    });
+  res.status(200).json({
+    label: "Scavenger Hunt!",
+    icon: "https://solana.com/src/img/branding/solanaLogoMark.svg",
+  });
 }
 ```
 
@@ -453,89 +450,93 @@ While each of these steps is straightforward, it's a lot of steps. To simplify t
 We'll also add the following imports:
 
 ```typescript
-import { NextApiRequest, NextApiResponse } from "next"
-import { PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js"
-import { locationAtIndex, Location, locations } from "../../utils/locations"
-import { connection, gameId, program } from "../../utils/programSetup"
+import { NextApiRequest, NextApiResponse } from "next";
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { locationAtIndex, Location, locations } from "../../utils/locations";
+import { connection, gameId, program } from "../../utils/programSetup";
 ```
 
 Using the empty helper functions and the new imports, we can fill in the `buildTransaction` function:
 
 ```typescript
 async function buildTransaction(
-    account: PublicKey,
-    reference: PublicKey,
-    id: string
+  account: PublicKey,
+  reference: PublicKey,
+  id: string,
 ): Promise<string> {
-    const userState = await fetchUserState(account)
+  const userState = await fetchUserState(account);
 
-    const currentLocation = locationAtIndex(new Number(id).valueOf())
+  const currentLocation = locationAtIndex(new Number(id).valueOf());
 
-    if (!currentLocation) {
-        throw { message: "Invalid location id" }
-    }
+  if (!currentLocation) {
+    throw { message: "Invalid location id" };
+  }
 
-    if (!verifyCorrectLocation(userState, currentLocation)) {
-        throw { message: "You must visit each location in order!" }
-    }
+  if (!verifyCorrectLocation(userState, currentLocation)) {
+    throw { message: "You must visit each location in order!" };
+  }
 
-    const { blockhash, lastValidBlockHeight } =
-        await connection.getLatestBlockhash()
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash();
 
-    const transaction = new Transaction({
-        feePayer: account,
-        blockhash,
-        lastValidBlockHeight,
-    })
+  const transaction = new Transaction({
+    feePayer: account,
+    blockhash,
+    lastValidBlockHeight,
+  });
 
-    if (!userState) {
-        transaction.add(await createInitUserInstruction(account))
-    }
+  if (!userState) {
+    transaction.add(await createInitUserInstruction(account));
+  }
 
-    transaction.add(
-        await createCheckInInstruction(account, reference, currentLocation)
-    )
+  transaction.add(
+    await createCheckInInstruction(account, reference, currentLocation),
+  );
 
-    transaction.partialSign(eventOrganizer)
+  transaction.partialSign(eventOrganizer);
 
-    const serializedTransaction = transaction.serialize({
-        requireAllSignatures: false,
-    })
+  const serializedTransaction = transaction.serialize({
+    requireAllSignatures: false,
+  });
 
-    const base64 = serializedTransaction.toString("base64")
+  const base64 = serializedTransaction.toString("base64");
 
-    return base64
+  return base64;
 }
 
 interface UserState {
-    user: PublicKey
-    gameId: PublicKey
-    lastLocation: PublicKey
+  user: PublicKey;
+  gameId: PublicKey;
+  lastLocation: PublicKey;
 }
 
 async function fetchUserState(account: PublicKey): Promise<UserState | null> {
-    return null
+  return null;
 }
 
 function verifyCorrectLocation(
-    userState: UserState | null,
-    currentLocation: Location
+  userState: UserState | null,
+  currentLocation: Location,
 ): boolean {
-    return false
+  return false;
 }
 
 async function createInitUserInstruction(
-    account: PublicKey
+  account: PublicKey,
 ): Promise<TransactionInstruction> {
-    throw ""
+  throw "";
 }
 
 async function createCheckInInstruction(
-    account: PublicKey,
-    reference: PublicKey,
-    location: Location
+  account: PublicKey,
+  reference: PublicKey,
+  location: Location,
 ): Promise<TransactionInstruction> {
-    throw ""
+  throw "";
 }
 ```
 
@@ -545,16 +546,16 @@ With the `buildTransaction` function finished, we can start implementing the emp
 
 ```typescript
 async function fetchUserState(account: PublicKey): Promise<UserState | null> {
-    const userStatePDA = PublicKey.findProgramAddressSync(
-        [gameId.toBuffer(), account.toBuffer()],
-        program.programId
-    )[0]
+  const userStatePDA = PublicKey.findProgramAddressSync(
+    [gameId.toBuffer(), account.toBuffer()],
+    program.programId,
+  )[0];
 
-    try {
-        return await program.account.userState.fetch(userStatePDA)
-    } catch {
-        return null
-    }
+  try {
+    return await program.account.userState.fetch(userStatePDA);
+  } catch {
+    return null;
+  }
 }
 ```
 
@@ -568,22 +569,22 @@ If these conditions are satisfied, the function will return true. Otherwise, it'
 
 ```typescript
 function verifyCorrectLocation(
-    userState: UserState | null,
-    currentLocation: Location
+  userState: UserState | null,
+  currentLocation: Location,
 ): boolean {
-    if (!userState) {
-        return currentLocation.index === 1
-    }
+  if (!userState) {
+    return currentLocation.index === 1;
+  }
 
-    const lastLocation = locations.find(
-        (location) => location.key.toString() === userState.lastLocation.toString()
-    )
+  const lastLocation = locations.find(
+    location => location.key.toString() === userState.lastLocation.toString(),
+  );
 
-    if (!lastLocation || currentLocation.index !== lastLocation.index + 1) {
-        return false
-    } else {
-        return true
-    }
+  if (!lastLocation || currentLocation.index !== lastLocation.index + 1) {
+    return false;
+  } else {
+    return true;
+  }
 }
 ```
 
@@ -593,36 +594,36 @@ Lastly, let's implement `createInitUserInstruction` and `createCheckInInstructio
 
 ```typescript
 async function createInitUserInstruction(
-    account: PublicKey
+  account: PublicKey,
 ): Promise<TransactionInstruction> {
-    const initializeInstruction = await program.methods
-        .initialize(gameId)
-        .accounts({ user: account })
-        .instruction()
+  const initializeInstruction = await program.methods
+    .initialize(gameId)
+    .accounts({ user: account })
+    .instruction();
 
-    return initializeInstruction
+  return initializeInstruction;
 }
 
 async function createCheckInInstruction(
-    account: PublicKey,
-    reference: PublicKey,
-    location: Location
+  account: PublicKey,
+  reference: PublicKey,
+  location: Location,
 ): Promise<TransactionInstruction> {
-    const checkInInstruction = await program.methods
-        .checkIn(gameId, location.key)
-        .accounts({
-            user: account,
-            eventOrganizer: eventOrganizer.publicKey,
-        })
-        .instruction()
-
-    checkInInstruction.keys.push({
-        pubkey: reference,
-        isSigner: false,
-        isWritable: false,
+  const checkInInstruction = await program.methods
+    .checkIn(gameId, location.key)
+    .accounts({
+      user: account,
+      eventOrganizer: eventOrganizer.publicKey,
     })
+    .instruction();
 
-    return checkInInstruction
+  checkInInstruction.keys.push({
+    pubkey: reference,
+    isSigner: false,
+    isWritable: false,
+  });
+
+  return checkInInstruction;
 }
 ```
 

--- a/developers/courses/solana-course/content/solana-pay.md
+++ b/developers/courses/solana-course/content/solana-pay.md
@@ -1,30 +1,55 @@
 ---
 title: Solana Pay
 objectives:
-  - Use the Solana Pay specification to build payment requests and initiate transactions using URLs encoded as QR codes
-  - Use the `@solana/pay` library to help with the creation of Solana Pay transaction requests
-  - Partially sign transactions and implement transaction gating based on certain conditions
+  - Use the Solana Pay specification to build payment requests and initiate
+    transactions using URLs encoded as QR codes
+  - Use the `@solana/pay` library to help with the creation of Solana Pay
+    transaction requests
+  - Partially sign transactions and implement transaction gating based on
+    certain conditions
 ---
 
 # TL;DR
 
-- **Solana Pay** is a specification for encoding Solana transaction requests within URLs, enabling standardized transaction requests across different Solana apps and wallets
-- **Partial signing** of transactions allows for the creation of transactions that require multiple signatures before they are submitted to the network
-- **Transaction gating** involves implementing rules that determine whether certain transactions are allowed to be processed or not, based on certain conditions or the presence of specific data in the transaction
+- **Solana Pay** is a specification for encoding Solana transaction requests
+  within URLs, enabling standardized transaction requests across different
+  Solana apps and wallets
+- **Partial signing** of transactions allows for the creation of transactions
+  that require multiple signatures before they are submitted to the network
+- **Transaction gating** involves implementing rules that determine whether
+  certain transactions are allowed to be processed or not, based on certain
+  conditions or the presence of specific data in the transaction
 
 # Overview
 
-The Solana community is continually improving and expanding the network's functionality. But that doesn't always mean developing brand new technology. Sometimes it means leveraging the network's existing features in new and interesting ways.
+The Solana community is continually improving and expanding the network's
+functionality. But that doesn't always mean developing brand new technology.
+Sometimes it means leveraging the network's existing features in new and
+interesting ways.
 
-Solana Pay is a great example of this. Rather than add new functionality to the network, Solana Pay uses the network's existing signing features in a unique way to enable merchants and applications to request transactions and build gating mechanisms for specific transaction types.
+Solana Pay is a great example of this. Rather than add new functionality to the
+network, Solana Pay uses the network's existing signing features in a unique way
+to enable merchants and applications to request transactions and build gating
+mechanisms for specific transaction types.
 
-Throughout this lesson, you'll learn how to use Solana Pay to create transfer and transaction requests, encode these requests as a QR code, partially sign transactions, and gate transactions based on conditions you choose. Rather than leaving it at that, we hope you'll see this as an example of leveraging existing features in new and interesting ways, using it as a launching pad for your own unique client-side network interactions.
+Throughout this lesson, you'll learn how to use Solana Pay to create transfer
+and transaction requests, encode these requests as a QR code, partially sign
+transactions, and gate transactions based on conditions you choose. Rather than
+leaving it at that, we hope you'll see this as an example of leveraging existing
+features in new and interesting ways, using it as a launching pad for your own
+unique client-side network interactions.
 
 ## Solana Pay
 
-The [Solana Pay specification](https://docs.solanapay.com/spec) is a set standards that allow users to request payments and initiate transactions using URLs in a uniform way across various Solana apps and wallets.
+The [Solana Pay specification](https://docs.solanapay.com/spec) is a set
+standards that allow users to request payments and initiate transactions using
+URLs in a uniform way across various Solana apps and wallets.
 
-Request URLs are prefixed with `solana:` so that platforms can direct the link to the appropriate application. For example, on mobile a URL that starts with `solana:` will be directed to wallet applications that support the Solana Pay specification. From there, the wallet can use the remainder of the URL to appropriately handle the request.
+Request URLs are prefixed with `solana:` so that platforms can direct the link
+to the appropriate application. For example, on mobile a URL that starts with
+`solana:` will be directed to wallet applications that support the Solana Pay
+specification. From there, the wallet can use the remainder of the URL to
+appropriately handle the request.
 
 There are two types of requests defined by the Solana Pay specification:
 
@@ -33,16 +58,27 @@ There are two types of requests defined by the Solana Pay specification:
 
 ### Transfer requests
 
-The transfer request specification describes a non-interactive request for SOL or SPL token transfer. Transfer request URLs take the following format `solana:<recipient>?<optional-query-params>`.
+The transfer request specification describes a non-interactive request for SOL
+or SPL token transfer. Transfer request URLs take the following format
+`solana:<recipient>?<optional-query-params>`.
 
-The value of `recipient` is required and must be a base58-encoded public key of the account from which a transfer is being requested. Additionally, the following optional query parameters are supported:
+The value of `recipient` is required and must be a base58-encoded public key of
+the account from which a transfer is being requested. Additionally, the
+following optional query parameters are supported:
 
-- `amount` - a non-negative integer or decimal value indicating the amount of tokens to transfer
-- `spl-token` - a base58-encoded public key of an SPL Token mint account if the transfer is of an SPL token and not SOL
-- `reference` - optional reference values as base58-encoded 32 byte arrays. This can be used by a client for identifying the transaction on-chain since the client will not have a transaction's signature.
-- `label` - a URL-encoded UTF-8 string that describes the source of the transfer request
-- `message` - a URL-encoded UTF-8 string that describes the nature of the transfer request
-- `memo` - a URL-encoded UTF-8 string that must be included in the SPL memo instruction in the payment transaction
+- `amount` - a non-negative integer or decimal value indicating the amount of
+  tokens to transfer
+- `spl-token` - a base58-encoded public key of an SPL Token mint account if the
+  transfer is of an SPL token and not SOL
+- `reference` - optional reference values as base58-encoded 32 byte arrays. This
+  can be used by a client for identifying the transaction on-chain since the
+  client will not have a transaction's signature.
+- `label` - a URL-encoded UTF-8 string that describes the source of the transfer
+  request
+- `message` - a URL-encoded UTF-8 string that describes the nature of the
+  transfer request
+- `memo` - a URL-encoded UTF-8 string that must be included in the SPL memo
+  instruction in the payment transaction
 
 By way of example, here is a URL describing a transfer request for 1 SOL:
 
@@ -58,30 +94,46 @@ solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd
 
 ### Transaction requests
 
-The Solana Pay transaction request is similar to a transfer request in that it is simply a URL that can be consumed by a supporting wallet. However, this request is interactive and the format is more open-ended:
+The Solana Pay transaction request is similar to a transfer request in that it
+is simply a URL that can be consumed by a supporting wallet. However, this
+request is interactive and the format is more open-ended:
 
 ```text
 solana:<link>
 ```
 
-The value of `link` should be a URL to which the consuming wallet can make an HTTP request. Rather than containing all the information needed for a transaction, a transaction request uses this URL to fetch the transaction that should be presented to the user.
+The value of `link` should be a URL to which the consuming wallet can make an
+HTTP request. Rather than containing all the information needed for a
+transaction, a transaction request uses this URL to fetch the transaction that
+should be presented to the user.
 
 When a wallet receives a transaction Request URL, four things happen:
 
-1. The wallet sends a GET request to the application at the provided `link` URL to retrieve a label and icon image to display to the user.
+1. The wallet sends a GET request to the application at the provided `link` URL
+   to retrieve a label and icon image to display to the user.
 2. The wallet then sends a POST request with the public key of the end user.
-3. Using the public key of the end user (and any additional information provided in `link`), the application then builds the transaction and responds with a base64-encoded serialized transaction.
-4. The wallet decodes and deserializes the transaction, then lets the user sign and send the transaction.
+3. Using the public key of the end user (and any additional information provided
+   in `link`), the application then builds the transaction and responds with a
+   base64-encoded serialized transaction.
+4. The wallet decodes and deserializes the transaction, then lets the user sign
+   and send the transaction.
 
-Given that transaction requests are more involved than transfer requests, the remainder of this lesson will focus on creating transaction requests.
+Given that transaction requests are more involved than transfer requests, the
+remainder of this lesson will focus on creating transaction requests.
 
 ## Create a transaction request
 
 ### Define the API endpoint
 
-The main thing you, the developer, need to do to make the transaction request flow work is set up a REST API endpoint at the URL you plan to include in the transaction request. In this lesson, we'll be using [Next.js API Routes](https://nextjs.org/docs/api-routes/introduction) for our endpoints, but you're welcome to use whatever stack and tools you're most comfortable with.
+The main thing you, the developer, need to do to make the transaction request
+flow work is set up a REST API endpoint at the URL you plan to include in the
+transaction request. In this lesson, we'll be using
+[Next.js API Routes](https://nextjs.org/docs/api-routes/introduction) for our
+endpoints, but you're welcome to use whatever stack and tools you're most
+comfortable with.
 
-In Next.js, you do this by adding a file to the `pages/api` folder and exporting a function that handles the request and response.
+In Next.js, you do this by adding a file to the `pages/api` folder and exporting
+a function that handles the request and response.
 
 ```typescript
 import { NextApiRequest, NextApiResponse } from "next";
@@ -96,7 +148,9 @@ export default async function handler(
 
 ### Handle a GET request
 
-The wallet consuming your transaction request URL will first issue a GET request to this endpoint. You'll want your endpoint to return a JSON object with two fields:
+The wallet consuming your transaction request URL will first issue a GET request
+to this endpoint. You'll want your endpoint to return a JSON object with two
+fields:
 
 1. `label` - a string that describes the source of the transaction request
 2. `icon`- a URL to an image that can be displayed to the user
@@ -125,18 +179,25 @@ function get(res: NextApiResponse) {
 }
 ```
 
-When the wallet makes a GET request to the API endpoint, the `get` function is called, returning a response with a status code of 200 and the JSON object containing `label` and `icon`.
+When the wallet makes a GET request to the API endpoint, the `get` function is
+called, returning a response with a status code of 200 and the JSON object
+containing `label` and `icon`.
 
 ### Handle a POST request and build the transaction
 
-After issuing a GET request, the wallet will issue a POST request to the same URL. Your endpoint should expect the POST request's `body` to contain a JSON object with an `account` field provided by the requesting wallet. The value of `account` will be a string representing the end user's public key.
+After issuing a GET request, the wallet will issue a POST request to the same
+URL. Your endpoint should expect the POST request's `body` to contain a JSON
+object with an `account` field provided by the requesting wallet. The value of
+`account` will be a string representing the end user's public key.
 
-With this information and any additional parameters provided, you can build the transaction and return it to the wallet for signing by:
+With this information and any additional parameters provided, you can build the
+transaction and return it to the wallet for signing by:
 
 1. Connecting to the Solana network and getting the latest `blockhash`.
 2. Creating a new transaction using the `blockhash`.
 3. Adding instructions to the transaction
-4. Serializing the transaction and returning it in a `PostResponse` object along with a message for the user.
+4. Serializing the transaction and returning it in a `PostResponse` object along
+   with a message for the user.
 
 ```typescript
 import { NextApiRequest, NextApiResponse } from "next";
@@ -200,23 +261,46 @@ async function post(req: PublicKey, res: PublicKey) {
 }
 ```
 
-There is nothing too out of the ordinary here. It's the same transaction construction you would use in a standard client-side application. The only difference is that instead of signing and submitting to the network, you send the transaction as a base64-encoded string back in the HTTP response. The wallet that issued the request can then present the transaction to the user for signing.
+There is nothing too out of the ordinary here. It's the same transaction
+construction you would use in a standard client-side application. The only
+difference is that instead of signing and submitting to the network, you send
+the transaction as a base64-encoded string back in the HTTP response. The wallet
+that issued the request can then present the transaction to the user for
+signing.
 
 ### Confirm transaction
 
-You may have noticed that the previous example assumed a `reference` was provided as a query parameter. While this is _not_ a value provided by the requesting wallet, it _is_ useful to set up your initial transaction request URL to contain this query parameter.
+You may have noticed that the previous example assumed a `reference` was
+provided as a query parameter. While this is _not_ a value provided by the
+requesting wallet, it _is_ useful to set up your initial transaction request URL
+to contain this query parameter.
 
-Since your application isn't the one submitting a transaction to the network, your code won't have access to a transaction signature. This would typically be how your app can locate a transaction on the network and see its status.
+Since your application isn't the one submitting a transaction to the network,
+your code won't have access to a transaction signature. This would typically be
+how your app can locate a transaction on the network and see its status.
 
-To get around this, you can include a `reference` value as a query parameter for each transaction request. This value should be a base58-encoded 32 byte array that can be included as a non-signer key on the transaction. This allows your app to then use the `getSignaturesForAddress` RPC method to locate the transaction. Your app can then tailor its UI according to a transaction's status.
+To get around this, you can include a `reference` value as a query parameter for
+each transaction request. This value should be a base58-encoded 32 byte array
+that can be included as a non-signer key on the transaction. This allows your
+app to then use the `getSignaturesForAddress` RPC method to locate the
+transaction. Your app can then tailor its UI according to a transaction's
+status.
 
-If you use the `@solana/pay` library, you can use the `findReference` helper function instead of using `getSignaturesForAddress` directly.
+If you use the `@solana/pay` library, you can use the `findReference` helper
+function instead of using `getSignaturesForAddress` directly.
 
 ## Gated transactions
 
-We've mentioned before how Solana Pay is an example of being able to do cool new things with the network by getting creative with existing functionality. Another small example of doing this within the Solana Pay umbrella is to only make certain transactions available once certain conditions are met.
+We've mentioned before how Solana Pay is an example of being able to do cool new
+things with the network by getting creative with existing functionality. Another
+small example of doing this within the Solana Pay umbrella is to only make
+certain transactions available once certain conditions are met.
 
-Since you control the endpoint building the transaction, you can determine what criteria must be met before a transaction is built. For example, you can use the `account` field provided in the POST request to check if the end user holds an NFT from a particular collection or if that public key is on a predetermined list of accounts who can make this particular transaction.
+Since you control the endpoint building the transaction, you can determine what
+criteria must be met before a transaction is built. For example, you can use the
+`account` field provided in the POST request to check if the end user holds an
+NFT from a particular collection or if that public key is on a predetermined
+list of accounts who can make this particular transaction.
 
 ```typescript
 // retrieve array of nfts owned by the given wallet
@@ -235,16 +319,28 @@ for (let i = 0; i < nfts.length; i++) {
 
 ### Partial Signing
 
-If you want certain transactions behind some kind of gating mechanism, that functionality will have to be enforced on-chain as well. Returning an error from your Solana Pay endpoint makes it more difficult for end users to do the transaction, but they could still build it manually.
+If you want certain transactions behind some kind of gating mechanism, that
+functionality will have to be enforced on-chain as well. Returning an error from
+your Solana Pay endpoint makes it more difficult for end users to do the
+transaction, but they could still build it manually.
 
-What this means is that the instruction(s) being called should require some type of "admin" signature that only your application can provide. In doing that, however, you'll have made it so that our previous examples don't work. The transaction is built and sent to the requesting wallet for the end user's signature, but the submitted transaction will fail without the admin signature.
+What this means is that the instruction(s) being called should require some type
+of "admin" signature that only your application can provide. In doing that,
+however, you'll have made it so that our previous examples don't work. The
+transaction is built and sent to the requesting wallet for the end user's
+signature, but the submitted transaction will fail without the admin signature.
 
 Fortunately, Solana enables signature composability with partial signing.
 
-Partially signing a multi-signature transaction allows signers to add their signature before the transaction is broadcast on the network. This can be useful in a number of situations, including:
+Partially signing a multi-signature transaction allows signers to add their
+signature before the transaction is broadcast on the network. This can be useful
+in a number of situations, including:
 
-- Approving transactions that require the signature of multiple parties, such as a merchant and a buyer who need to confirm the details of a payment.
-- Invoking custom programs that require the signatures of both a user and an administrator. This can help to limit access to the program instructions and ensure that only authorized parties can execute them.
+- Approving transactions that require the signature of multiple parties, such as
+  a merchant and a buyer who need to confirm the details of a payment.
+- Invoking custom programs that require the signatures of both a user and an
+  administrator. This can help to limit access to the program instructions and
+  ensure that only authorized parties can execute them.
 
 ```typescript
 const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
@@ -260,18 +356,30 @@ const transaction = new Transaction({
 transaction.partialSign(adminKeypair)
 ```
 
-The `partialSign` function is used to add a signature to a transaction without overriding any previous signatures on the transaction. If you are building a transaction with multiple signers, it is important to remember that if you don't specify a transaction's `feePayer`, the first signer will be used as the fee payer for the transaction. To avoid any confusion or unexpected behavior, make sure to explicitly set the fee payer when necessary.
+The `partialSign` function is used to add a signature to a transaction without
+overriding any previous signatures on the transaction. If you are building a
+transaction with multiple signers, it is important to remember that if you don't
+specify a transaction's `feePayer`, the first signer will be used as the fee
+payer for the transaction. To avoid any confusion or unexpected behavior, make
+sure to explicitly set the fee payer when necessary.
 
-In our example of only allowing a transaction request to go through when the end user has a specific NFT, you would simply add your admin signature to the transaction using `partialSign` before encoding the transaction as a base64-encoded string and issuing the HTTP response.
+In our example of only allowing a transaction request to go through when the end
+user has a specific NFT, you would simply add your admin signature to the
+transaction using `partialSign` before encoding the transaction as a
+base64-encoded string and issuing the HTTP response.
 
 ## Solana Pay QR codes
 
-One of the standout features of Solana Pay is its easy integration with QR codes. Since transfer and transaction requests are simply URLs, you can embed them into QR codes that you make available in your application or elsewhere.
+One of the standout features of Solana Pay is its easy integration with QR
+codes. Since transfer and transaction requests are simply URLs, you can embed
+them into QR codes that you make available in your application or elsewhere.
 
-The `@solana/pay` library simplifies this with the provided `createQR` helper function. This function needs you to provide the following:
+The `@solana/pay` library simplifies this with the provided `createQR` helper
+function. This function needs you to provide the following:
 
 - `url` - the url of the transaction request.
-- `size` (optional) - the width and height of the QR code in pixels. Defaults to 512.
+- `size` (optional) - the width and height of the QR code in pixels. Defaults
+  to 512.
 - `background` (optional) - the background color. Defaults to white.
 - `color` (optional) - the foreground color. Defaults to black.
 
@@ -281,33 +389,66 @@ const qr = createQR(url, 400, "transparent");
 
 # Demo
 
-Now that you've got a conceptual grasp on Solana Pay, let's put it into practice. We'll use Solana Pay to generate a series of QR codes for a scavenger hunt. Participants must visit each scavenger hunt location in order. At each location, they'll use the provided QR code to submit the appropriate transaction to the scavenger hunt's smart contract that keeps track of user progress.
+Now that you've got a conceptual grasp on Solana Pay, let's put it into
+practice. We'll use Solana Pay to generate a series of QR codes for a scavenger
+hunt. Participants must visit each scavenger hunt location in order. At each
+location, they'll use the provided QR code to submit the appropriate transaction
+to the scavenger hunt's smart contract that keeps track of user progress.
 
 ### 1. Starter
 
-To get started, download the starter code on the `starter` branch of this [repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/starter). The starter code is a Next.js app that displays a Solana Pay QR code. Notice that the menu bar lets you switch between different QR codes. The default option is a simple SOL transfer for illustrative purposes. Throughout We'll be adding functionality to the location options in the menu bar.
+To get started, download the starter code on the `starter` branch of this
+[repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/starter).
+The starter code is a Next.js app that displays a Solana Pay QR code. Notice
+that the menu bar lets you switch between different QR codes. The default option
+is a simple SOL transfer for illustrative purposes. Throughout We'll be adding
+functionality to the location options in the menu bar.
 
 ![Screenshot of scavenger hunt app](../assets/scavenger-hunt-screenshot.png)
 
-To do this, we'll be creating a new endpoint for a transaction request that builds a transaction for invoking an Anchor program on Devnet. This program has been made specifically for this "scavenger hunt" app and has two instructions: `initialize` and `check_in`. The `initialize` instruction is used to set up the user's state, while the `check_in` instruction is used to record a check-in at a location in the scavenger hunt. We won't be making any changes to the program in this demo, but feel free to check out the [source code](https://github.com/Unboxed-Software/anchor-scavenger-hunt) if you'd like to familiarize yourself with the program.
+To do this, we'll be creating a new endpoint for a transaction request that
+builds a transaction for invoking an Anchor program on Devnet. This program has
+been made specifically for this "scavenger hunt" app and has two instructions:
+`initialize` and `check_in`. The `initialize` instruction is used to set up the
+user's state, while the `check_in` instruction is used to record a check-in at a
+location in the scavenger hunt. We won't be making any changes to the program in
+this demo, but feel free to check out the
+[source code](https://github.com/Unboxed-Software/anchor-scavenger-hunt) if
+you'd like to familiarize yourself with the program.
 
-Before moving on, make sure you get familiar with the starter code for the Scavenger Hunt app. Looking at `pages/index.tsx`, `utils/createQrCode/simpleTransfer`, and `/utils/checkTransaction` will let you see how the transaction request for sending SOL is set up. We'll be following a similar pattern for the transaction request for checking in at a location.
+Before moving on, make sure you get familiar with the starter code for the
+Scavenger Hunt app. Looking at `pages/index.tsx`,
+`utils/createQrCode/simpleTransfer`, and `/utils/checkTransaction` will let you
+see how the transaction request for sending SOL is set up. We'll be following a
+similar pattern for the transaction request for checking in at a location.
 
 ### 2. Setup
 
-Before we move forward, let's make sure you can run the app locally. Start by renaming the `.env.example` file in the frontend directory to `.env`. This file contains a keypair that will be used in this demo to partially sign transactions.
+Before we move forward, let's make sure you can run the app locally. Start by
+renaming the `.env.example` file in the frontend directory to `.env`. This file
+contains a keypair that will be used in this demo to partially sign
+transactions.
 
-Next, install dependencies with `yarn`, then use `yarn dev` and open your browser `localhost:3000` (or the port indicated in the console if 3000 was already in use).
+Next, install dependencies with `yarn`, then use `yarn dev` and open your
+browser `localhost:3000` (or the port indicated in the console if 3000 was
+already in use).
 
-Now, if you try to scan the QR code shown on the page from your mobile device, you'll get an error. That's because the QR code is set up to send you to your computer's `localhost:3000`, which isn't an address your phone can get to. Further, Solana Pay needs to use an HTTPS URL to work.
+Now, if you try to scan the QR code shown on the page from your mobile device,
+you'll get an error. That's because the QR code is set up to send you to your
+computer's `localhost:3000`, which isn't an address your phone can get to.
+Further, Solana Pay needs to use an HTTPS URL to work.
 
-To get around this, you can use [ngrok](https://ngrok.com/). You'll need to install it if you haven't used it before. Once it's installed, run the following command in your terminal, replacing `3000` with whichever port you're using for this project:
+To get around this, you can use [ngrok](https://ngrok.com/). You'll need to
+install it if you haven't used it before. Once it's installed, run the following
+command in your terminal, replacing `3000` with whichever port you're using for
+this project:
 
 ```bash
 ngrok http 3000
 ```
 
-This will provide you with a unique URL that you can use to access your local server remotely. The output will look something like this:
+This will provide you with a unique URL that you can use to access your local
+server remotely. The output will look something like this:
 
 ```bash
 Session Status                online
@@ -320,21 +461,34 @@ Web Interface                 http://127.0.0.1:4040
 Forwarding                    https://7761-24-28-107-82.ngrok.io -> http://localhost:3000
 ```
 
-Now, open the HTTPS ngrok URL shown in your console in the browser (e.g. https://7761-24-28-107-82.ngrok.io). This will allow you to scan QR codes from your mobile device while testing locally.
+Now, open the HTTPS ngrok URL shown in your console in the browser (e.g.
+https://7761-24-28-107-82.ngrok.io). This will allow you to scan QR codes from
+your mobile device while testing locally.
 
-At the time of writing, this demo works best with Solflare. Some wallets will display an incorrect warning message when scanning a Solana Pay QR code. Regardless of the wallet you use, make sure you switch to devnet in the wallet. Then scan the QR code on the home page labeled “SOL Transfer”. This QR code is a reference implementation for a transaction request that performs a simple SOL transfer. It also calls the `requestAirdrop` function to fund your mobile wallet with Devnet SOL since most people don't have Devnet SOL available for testing.
+At the time of writing, this demo works best with Solflare. Some wallets will
+display an incorrect warning message when scanning a Solana Pay QR code.
+Regardless of the wallet you use, make sure you switch to devnet in the wallet.
+Then scan the QR code on the home page labeled “SOL Transfer”. This QR code is a
+reference implementation for a transaction request that performs a simple SOL
+transfer. It also calls the `requestAirdrop` function to fund your mobile wallet
+with Devnet SOL since most people don't have Devnet SOL available for testing.
 
-If you were able to successfully execute the transaction using the QR code, you're good to move on!
+If you were able to successfully execute the transaction using the QR code,
+you're good to move on!
 
 ### 3. Create a check-in transaction request endpoint
 
-Now that you're up and running, it's time to create an endpoint that supports transaction requests for location check-in using the Scavenger Hunt program.
+Now that you're up and running, it's time to create an endpoint that supports
+transaction requests for location check-in using the Scavenger Hunt program.
 
-Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper function for initializing `eventOrganizer` from a private key environment variable. The first thing we'll do in this file is the following:
+Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper
+function for initializing `eventOrganizer` from a private key environment
+variable. The first thing we'll do in this file is the following:
 
 1. Export a `handler` function to handle an arbitrary HTTP request
 2. Add `get` and `post` functions for handling those HTTP methods
-3. Add logic to the body of the `handler` function to either call `get`, `post`, or return a 405 error based on the HTTP request method
+3. Add logic to the body of the `handler` function to either call `get`, `post`,
+   or return a 405 error based on the HTTP request method
 
 ```typescript
 import { NextApiRequest, NextApiResponse } from "next";
@@ -359,7 +513,9 @@ async function post(req: NextApiRequest, res: NextApiResponse) {}
 
 ### 4. Update `get` function
 
-Remember, the first request from a wallet will be a GET request expecting the endpoint to return a label and icon. Update the `get` function to send a response with a "Scavenger Hunt!" label and a Solana logo icon.
+Remember, the first request from a wallet will be a GET request expecting the
+endpoint to return a label and icon. Update the `get` function to send a
+response with a "Scavenger Hunt!" label and a Solana logo icon.
 
 ```jsx
 function get(res: NextApiResponse) {
@@ -372,18 +528,32 @@ function get(res: NextApiResponse) {
 
 ### 5. Update `post` function
 
-After the GET request, a wallet will issue a POST request to the endpoint. The request's `body` will contain a JSON object with an `account` field representing the end user's public key.
+After the GET request, a wallet will issue a POST request to the endpoint. The
+request's `body` will contain a JSON object with an `account` field representing
+the end user's public key.
 
-Additionally, the query parameters will contain whatever you encoded into the QR code. If you take a look at `utils/createQrCode/checkIn.ts`, you'll notice that this particular app includes parameters for `reference` and `id` as the following:
+Additionally, the query parameters will contain whatever you encoded into the QR
+code. If you take a look at `utils/createQrCode/checkIn.ts`, you'll notice that
+this particular app includes parameters for `reference` and `id` as the
+following:
 
-1. `reference` - a randomly generated public key used to identify the transaction
+1. `reference` - a randomly generated public key used to identify the
+   transaction
 2. `id` - the location id as an integer
 
-Go ahead and update the `post` function to extract `account`, `reference`, and `id` from the request. You should respond with an error if any of these is missing.
+Go ahead and update the `post` function to extract `account`, `reference`, and
+`id` from the request. You should respond with an error if any of these is
+missing.
 
-Next, add a `try catch` statement where the `catch` block responds with an error and the `try` block calls out to a new function `buildTransaction`. If `buildTransaction` is successful, respond with a 200 and a JSON object with the transaction and a message that the user has found the given location. Don't worry about the logic for the `buildTransaction` function just yet - we'll do that next.
+Next, add a `try catch` statement where the `catch` block responds with an error
+and the `try` block calls out to a new function `buildTransaction`. If
+`buildTransaction` is successful, respond with a 200 and a JSON object with the
+transaction and a message that the user has found the given location. Don't
+worry about the logic for the `buildTransaction` function just yet - we'll do
+that next.
 
-Note that you'll need to import `PublicKey` and `Transaction` from `@solana/web3.js` here as well.
+Note that you'll need to import `PublicKey` and `Transaction` from
+`@solana/web3.js` here as well.
 
 ```typescript
 import { NextApiRequest, NextApiResponse } from "next"
@@ -432,10 +602,13 @@ async function buildTransaction(
 
 ### 6. Implement the `buildTransaction` function
 
-Next, let’s implement the `buildTransaction` function. It should build, partially sign, and return the check-in transaction. The sequence of items it needs to perform is:
+Next, let’s implement the `buildTransaction` function. It should build,
+partially sign, and return the check-in transaction. The sequence of items it
+needs to perform is:
 
 1. Fetch the user state
-2. Use the `locationAtIndex` helper function and the location id to get a Location object
+2. Use the `locationAtIndex` helper function and the location id to get a
+   Location object
 3. Verify that the user is at the correct location
 4. Get the current blockhash and last valid block height from the connection
 5. Create a new transaction object
@@ -445,7 +618,11 @@ Next, let’s implement the `buildTransaction` function. It should build, partia
 9. Partially sign the transaction with the event organizer's keypair
 10. Serialize the transaction with base64 encoding and return the transaction
 
-While each of these steps is straightforward, it's a lot of steps. To simplify the function, we're going to create empty helper functions that we'll fill in later for steps 1, 3, 6, and 7-8. We'll call these `fetchUserState`, `verifyCorrectLocation`, `createInitUserInstruction`, and `createCheckInInstruction`, respectively.
+While each of these steps is straightforward, it's a lot of steps. To simplify
+the function, we're going to create empty helper functions that we'll fill in
+later for steps 1, 3, 6, and 7-8. We'll call these `fetchUserState`,
+`verifyCorrectLocation`, `createInitUserInstruction`, and
+`createCheckInInstruction`, respectively.
 
 We'll also add the following imports:
 
@@ -460,7 +637,8 @@ import { locationAtIndex, Location, locations } from "../../utils/locations";
 import { connection, gameId, program } from "../../utils/programSetup";
 ```
 
-Using the empty helper functions and the new imports, we can fill in the `buildTransaction` function:
+Using the empty helper functions and the new imports, we can fill in the
+`buildTransaction` function:
 
 ```typescript
 async function buildTransaction(
@@ -542,7 +720,10 @@ async function createCheckInInstruction(
 
 ### 7. Implement `fetchUserState` function
 
-With the `buildTransaction` function finished, we can start implementing the empty helper functions we created, starting with `fetchUserState`. This function uses the `gameId` and user's `account` to derive the user state PDA, then fetches that account, returning null if it doesn't exist.
+With the `buildTransaction` function finished, we can start implementing the
+empty helper functions we created, starting with `fetchUserState`. This function
+uses the `gameId` and user's `account` to derive the user state PDA, then
+fetches that account, returning null if it doesn't exist.
 
 ```typescript
 async function fetchUserState(account: PublicKey): Promise<UserState | null> {
@@ -561,11 +742,16 @@ async function fetchUserState(account: PublicKey): Promise<UserState | null> {
 
 ### 8. Implement `verifyCorrectLocation` function
 
-Next, let’s implement the `verifyCorrectLocation` helper function. This function is used to verify that a user is at the correct location in a scavenger hunt game.
+Next, let’s implement the `verifyCorrectLocation` helper function. This function
+is used to verify that a user is at the correct location in a scavenger hunt
+game.
 
-If `userState` is `null`, that means the user should be visiting the first location. Otherwise, the user should be visiting the location whose index is 1 more than their last visited location.
+If `userState` is `null`, that means the user should be visiting the first
+location. Otherwise, the user should be visiting the location whose index is 1
+more than their last visited location.
 
-If these conditions are satisfied, the function will return true. Otherwise, it'll return false.
+If these conditions are satisfied, the function will return true. Otherwise,
+it'll return false.
 
 ```typescript
 function verifyCorrectLocation(
@@ -590,7 +776,10 @@ function verifyCorrectLocation(
 
 ### 9. Implement the instruction creation functions
 
-Lastly, let's implement `createInitUserInstruction` and `createCheckInInstruction`. These can use Anchor to generate and return the corresponding instructions. The only catch is that `createCheckInInstruction` needs to add `reference` to the instructions list of keys.
+Lastly, let's implement `createInitUserInstruction` and
+`createCheckInInstruction`. These can use Anchor to generate and return the
+corresponding instructions. The only catch is that `createCheckInInstruction`
+needs to add `reference` to the instructions list of keys.
 
 ```typescript
 async function createInitUserInstruction(
@@ -629,18 +818,35 @@ async function createCheckInInstruction(
 
 ### 10. Test the app
 
-At this point your app should be working! Go ahead and test it using your mobile wallet. Start by scanning the QR code for `Location 1`. Remember to make sure your frontend is running using the ngrok URL rather than `localhost`.
+At this point your app should be working! Go ahead and test it using your mobile
+wallet. Start by scanning the QR code for `Location 1`. Remember to make sure
+your frontend is running using the ngrok URL rather than `localhost`.
 
-After scanning the QR code, you should see a message indicating that you are at location 1. From there, scan the QR code on the `Location 2` page. You may need to wait a few seconds for the previous transaction to finalize before continuing.
+After scanning the QR code, you should see a message indicating that you are at
+location 1. From there, scan the QR code on the `Location 2` page. You may need
+to wait a few seconds for the previous transaction to finalize before
+continuing.
 
-Congratulations, you have successfully finished the scavenger hunt demo using Solana Pay! Depending on your background, this may not feel intuitive or straightforward. If that's the case, feel free to go through the demo again or make something on your own. Solana Pay opens a lot of doors for bridging the gap between real life and on-chain interaction.
+Congratulations, you have successfully finished the scavenger hunt demo using
+Solana Pay! Depending on your background, this may not feel intuitive or
+straightforward. If that's the case, feel free to go through the demo again or
+make something on your own. Solana Pay opens a lot of doors for bridging the gap
+between real life and on-chain interaction.
 
-If you want to take a look at the final solution code you can find it on the solution branch of [the same repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+solution branch of
+[the same repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/solution).
 
 # Challenge
 
-It's time to try this out on your own. Feel free to build out an idea of your own using Solana Pay. Or, if you need some inspiration, you can use the prompt below.
+It's time to try this out on your own. Feel free to build out an idea of your
+own using Solana Pay. Or, if you need some inspiration, you can use the prompt
+below.
 
-Build out an app using Solana Pay (or modify the one from the demo) to mint an NFT to users. To take it up a notch, only make the transaction possible if the user meets one or more conditions (e.g. holds an NFT from a specific collection, is already on a pre-determined list, etc.).
+Build out an app using Solana Pay (or modify the one from the demo) to mint an
+NFT to users. To take it up a notch, only make the transaction possible if the
+user meets one or more conditions (e.g. holds an NFT from a specific collection,
+is already on a pre-determined list, etc.).
 
-Get creative with this! The Solana pay spec opens up a lot of doors for unique use cases.
+Get creative with this! The Solana pay spec opens up a lot of doors for unique
+use cases.

--- a/developers/courses/solana-course/content/token-program.md
+++ b/developers/courses/solana-course/content/token-program.md
@@ -1,11 +1,11 @@
 ---
 title: Create Tokens With The Token Program
 objectives:
-- Create token mints
-- Create token accounts
-- Mint tokens
-- Transfer tokens
-- Burn tokens
+  - Create token mints
+  - Create token accounts
+  - Mint tokens
+  - Transfer tokens
+  - Burn tokens
 ---
 
 # TL;DR
@@ -21,6 +21,7 @@ objectives:
 The Token Program is one of many programs made available by the Solana Program Library (SPL). It contains instructions for creating and interacting with SPL-Tokens. These tokens represent all non-native (i.e. not SOL) tokens on the Solana network.
 
 This lesson will focus on the basics of creating and managing a new SPL-Token using the Token Program:
+
 1. Creating a new Token Mint
 2. Creating Token Accounts
 3. Minting
@@ -41,15 +42,15 @@ To create a new Token Mint, you need to send the right transaction instructions 
 
 ```tsx
 const tokenMint = await createMint(
-    connection,
-    payer,
-    mintAuthority,
-    freezeAuthority,
-    decimal
+  connection,
+  payer,
+  mintAuthority,
+  freezeAuthority,
+  decimal,
 );
 ```
 
- The `createMint` function returns the `publicKey` of the new token mint. This function requires the following arguments:
+The `createMint` function returns the `publicKey` of the new token mint. This function requires the following arguments:
 
 - `connection` - the JSON-RPC connection to the cluster
 - `payer` - the public key of the payer for the transaction
@@ -60,51 +61,54 @@ const tokenMint = await createMint(
 When creating a new mint from a script that has access to your secret key, you can simply use the `createMint` function. However, if you were to build a website to allow users to create a new token mint, you would need to do so with the user's secret key without making them expose it to the browser. In that case, you would want to build and submit a transaction with the right instructions.
 
 Under the hood, the `createMint` function is simply creating a transaction that contains two instructions:
+
 1. Create a new account
 2. Initialize a new mint
 
 This would look as follows:
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildCreateMintTransaction(
-    connection: web3.Connection,
-    payer: web3.PublicKey,
-    decimals: number
+  connection: web3.Connection,
+  payer: web3.PublicKey,
+  decimals: number,
 ): Promise<web3.Transaction> {
-    const lamports = await token.getMinimumBalanceForRentExemptMint(connection);
-    const accountKeypair = web3.Keypair.generate();
-    const programId = token.TOKEN_PROGRAM_ID
+  const lamports = await token.getMinimumBalanceForRentExemptMint(connection);
+  const accountKeypair = web3.Keypair.generate();
+  const programId = token.TOKEN_PROGRAM_ID;
 
-    const transaction = new web3.Transaction().add(
-        web3.SystemProgram.createAccount({
-            fromPubkey: payer,
-            newAccountPubkey: accountKeypair.publicKey,
-            space: token.MINT_SIZE,
-            lamports,
-            programId,
-        }),
-        token.createInitializeMintInstruction(
-            accountKeypair.publicKey,
-            decimals,
-            payer,
-            payer,
-            programId
-        )
-    );
+  const transaction = new web3.Transaction().add(
+    web3.SystemProgram.createAccount({
+      fromPubkey: payer,
+      newAccountPubkey: accountKeypair.publicKey,
+      space: token.MINT_SIZE,
+      lamports,
+      programId,
+    }),
+    token.createInitializeMintInstruction(
+      accountKeypair.publicKey,
+      decimals,
+      payer,
+      payer,
+      programId,
+    ),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
-When manually building the instructions to create a new token mint, make sure you add the instructions for creating the account and initializing the mint to the *same transaction*. If you were to do each step in a separate transaction, it's theoretically possible for somebody else to take the account you create and initialize it for their own mint.
+When manually building the instructions to create a new token mint, make sure you add the instructions for creating the account and initializing the mint to the _same transaction_. If you were to do each step in a separate transaction, it's theoretically possible for somebody else to take the account you create and initialize it for their own mint.
 
 ### Rent and Rent Exemption
+
 Note that the first line in the function body of the previous code snippet contains a call to `getMinimumBalanceForRentExemptMint`, the result of which is passed into the `createAccount` function. This is part of account initialization called rent exemption.
 
 Until recently, all accounts on Solana were required to do one of the following to avoid being deallocated:
+
 1. Pay rent at specific intervals
 2. Deposit enough SOL upon initialization to be considered rent-exempt
 
@@ -122,11 +126,11 @@ You can use the `spl-token` library's `createAccount` function to create the new
 
 ```tsx
 const tokenAccount = await createAccount(
-    connection,
-    payer,
-    mint,
-    owner,
-    keypair
+  connection,
+  payer,
+  mint,
+  owner,
+  keypair,
 );
 ```
 
@@ -141,43 +145,44 @@ The `createAccount` function returns the `publicKey` of the new token account. T
 Please note that this `createAccount` function is different from the `createAccount` function shown above when we looked under the hood of the `createMint` function. Previously we used the `createAccount` function on `SystemProgram` to return the instruction for creating all accounts. The `createAccount` function here is a helper function in the `spl-token` library that submits a transaction with two instructions. The first creates the account and the second initializes the account as a Token Account.
 
 Like with creating a Token Mint, if we needed to build the transaction for `createAccount` manually we could duplicate what the function is doing under the hood:
+
 1. Use `getMint` to retrieve the data associated with the `mint`
 2. Use `getAccountLenForMint` to calculate the space needed for the token account
 3. Use `getMinimumBalanceForRentExemption` to calculate the lamports needed for rent exemption
 4. Create a new transaction using `SystemProgram.createAccount` and `createInitializeAccountInstruction`. Note that this `createAccount` is from `@solana/web3.js` and used to create a generic new account. The `createInitializeAccountInstruction` uses this new account to initialize the new token account
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildCreateTokenAccountTransaction(
-    connection: web3.Connection,
-    payer: web3.PublicKey,
-    mint: web3.PublicKey
+  connection: web3.Connection,
+  payer: web3.PublicKey,
+  mint: web3.PublicKey,
 ): Promise<web3.Transaction> {
-    const mintState = await token.getMint(connection, mint)
-    const accountKeypair = await web3.Keypair.generate()
-    const space = token.getAccountLenForMint(mintState);
-    const lamports = await connection.getMinimumBalanceForRentExemption(space);
-    const programId = token.TOKEN_PROGRAM_ID
+  const mintState = await token.getMint(connection, mint);
+  const accountKeypair = await web3.Keypair.generate();
+  const space = token.getAccountLenForMint(mintState);
+  const lamports = await connection.getMinimumBalanceForRentExemption(space);
+  const programId = token.TOKEN_PROGRAM_ID;
 
-    const transaction = new web3.Transaction().add(
-        web3.SystemProgram.createAccount({
-            fromPubkey: payer,
-            newAccountPubkey: accountKeypair.publicKey,
-            space,
-            lamports,
-            programId,
-        }),
-        token.createInitializeAccountInstruction(
-            accountKeypair.publicKey,
-            mint,
-            payer,
-            programId
-        )
-    );
+  const transaction = new web3.Transaction().add(
+    web3.SystemProgram.createAccount({
+      fromPubkey: payer,
+      newAccountPubkey: accountKeypair.publicKey,
+      space,
+      lamports,
+      programId,
+    }),
+    token.createInitializeAccountInstruction(
+      accountKeypair.publicKey,
+      mint,
+      payer,
+      programId,
+    ),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -189,10 +194,10 @@ Similar to above, you can create an associated token account using the `spl-toke
 
 ```tsx
 const associatedTokenAccount = await createAssociatedTokenAccount(
-    connection,
-	payer,
-	mint,
-	owner,
+  connection,
+  payer,
+  mint,
+  owner,
 );
 ```
 
@@ -211,25 +216,29 @@ Under the hood, `createAssociatedTokenAccount` is doing two things:
 2. Building a transaction using instructions from `createAssociatedTokenAccountInstruction`
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildCreateAssociatedTokenAccountTransaction(
-    payer: web3.PublicKey,
-    mint: web3.PublicKey
+  payer: web3.PublicKey,
+  mint: web3.PublicKey,
 ): Promise<web3.Transaction> {
-    const associatedTokenAddress = await token.getAssociatedTokenAddress(mint, payer, false);
+  const associatedTokenAddress = await token.getAssociatedTokenAddress(
+    mint,
+    payer,
+    false,
+  );
 
-    const transaction = new web3.Transaction().add(
-        token.createAssociatedTokenAccountInstruction(
-            payer,
-            associatedTokenAddress,
-            payer,
-            mint
-        )
-    )
+  const transaction = new web3.Transaction().add(
+    token.createAssociatedTokenAccountInstruction(
+      payer,
+      associatedTokenAddress,
+      payer,
+      mint,
+    ),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -241,12 +250,12 @@ To mint tokens using the `spl-token` library, you can use the `mintTo` function.
 
 ```tsx
 const transactionSignature = await mintTo(
-    connection,
-    payer,
-    mint,
-    destination,
-    authority,
-    amount
+  connection,
+  payer,
+  mint,
+  destination,
+  authority,
+  amount,
 );
 ```
 
@@ -264,25 +273,20 @@ It's not uncommon to update the mint authority on a token mint to null after the
 Under the hood, the `mintTo` function simply creates a transaction with the instructions obtained from the `createMintToInstruction` function.
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildMintToTransaction(
-    authority: web3.PublicKey,
-    mint: web3.PublicKey,
-    amount: number,
-    destination: web3.PublicKey
+  authority: web3.PublicKey,
+  mint: web3.PublicKey,
+  amount: number,
+  destination: web3.PublicKey,
 ): Promise<web3.Transaction> {
-    const transaction = new web3.Transaction().add(
-        token.createMintToInstruction(
-            mint,
-            destination,
-            authority,
-            amount
-        )
-    )
+  const transaction = new web3.Transaction().add(
+    token.createMintToInstruction(mint, destination, authority, amount),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -296,13 +300,13 @@ Once you know the receiver's token account address, you transfer tokens using th
 
 ```tsx
 const transactionSignature = await transfer(
-    connection,
-    payer,
-    source,
-    destination,
-    owner,
-    amount
-)
+  connection,
+  payer,
+  source,
+  destination,
+  owner,
+  amount,
+);
 ```
 
 The `transfer` function returns a `TransactionSignature` that can be viewed on the Solana Explorer. The `transfer` function requires the following arguments:
@@ -314,29 +318,23 @@ The `transfer` function returns a `TransactionSignature` that can be viewed on t
 - `owner` the account of the owner of the `source` token account
 - `amount` the amount of tokens to transfer
 
-
 Under the hood, the `transfer` function simply creates a transaction with the instructions obtained from the `createTransferInstruction` function:
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildTransferTransaction(
-    source: web3.PublicKey,
-    destination: web3.PublicKey,
-    owner: web3.PublicKey,
-    amount: number
+  source: web3.PublicKey,
+  destination: web3.PublicKey,
+  owner: web3.PublicKey,
+  amount: number,
 ): Promise<web3.Transaction> {
-    const transaction = new web3.Transaction().add(
-        token.createTransferInstruction(
-            source,
-            destination,
-            owner,
-            amount,
-        )
-    )
+  const transaction = new web3.Transaction().add(
+    token.createTransferInstruction(source, destination, owner, amount),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -348,13 +346,13 @@ To burn tokens using the `spl-token` library, you use the `burn` function.
 
 ```tsx
 const transactionSignature = await burn(
-    connection,
-    payer,
-    account,
-    mint,
-    owner,
-    amount
-)
+  connection,
+  payer,
+  account,
+  mint,
+  owner,
+  amount,
+);
 ```
 
 The `burn` function returns a `TransactionSignature` that can be viewed on Solana Explorer. The `burn` function requires the following arguments:
@@ -369,25 +367,20 @@ The `burn` function returns a `TransactionSignature` that can be viewed on Solan
 Under the hood, the `burn` function creates a transaction with instructions obtained from the `createBurnInstruction` function:
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildBurnTransaction(
-    account: web3.PublicKey,
-    mint: web3.PublicKey,
-    owner: web3.PublicKey,
-    amount: number
+  account: web3.PublicKey,
+  mint: web3.PublicKey,
+  owner: web3.PublicKey,
+  amount: number,
 ): Promise<web3.Transaction> {
-    const transaction = new web3.Transaction().add(
-        token.createBurnInstruction(
-            account,
-            mint,
-            owner,
-            amount
-        )
-    )
+  const transaction = new web3.Transaction().add(
+    token.createBurnInstruction(account, mint, owner, amount),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -399,13 +392,13 @@ To approve a delegate using the `spl-token` library, you use the `approve` funct
 
 ```tsx
 const transactionSignature = await approve(
-    connection,
-    payer,
-    account,
-    delegate,
-    owner,
-    amount
-  )
+  connection,
+  payer,
+  account,
+  delegate,
+  owner,
+  amount,
+);
 ```
 
 The `approve` function returns a `TransactionSignature` that can be viewed on Solana Explorer. The `approve` function requires the following arguments:
@@ -420,25 +413,20 @@ The `approve` function returns a `TransactionSignature` that can be viewed on So
 Under the hood, the `approve` function creates a transaction with instructions obtained from the `createApproveInstruction` function:
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildApproveTransaction(
-    account: web3.PublicKey,
-    delegate: web3.PublicKey,
-    owner: web3.PublicKey,
-    amount: number
+  account: web3.PublicKey,
+  delegate: web3.PublicKey,
+  owner: web3.PublicKey,
+  amount: number,
 ): Promise<web3.Transaction> {
-    const transaction = new web3.Transaction().add(
-        token.createApproveInstruction(
-            account,
-            delegate,
-            owner,
-            amount
-        )
-    )
+  const transaction = new web3.Transaction().add(
+    token.createApproveInstruction(account, delegate, owner, amount),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -449,12 +437,7 @@ A previously approved delegate for a token account can be later revoked. Once a 
 To revoke a delegate using the `spl-token` library, you use the `revoke` function.
 
 ```tsx
-const transactionSignature = await revoke(
-    connection,
-    payer,
-    account,
-    owner,
-  )
+const transactionSignature = await revoke(connection, payer, account, owner);
 ```
 
 The `revoke` function returns a `TransactionSignature` that can be viewed on Solana Explorer. The `revoke` function requires the following arguments:
@@ -467,21 +450,18 @@ The `revoke` function returns a `TransactionSignature` that can be viewed on Sol
 Under the hood, the `revoke` function creates a transaction with instructions obtained from the `createRevokeInstruction` function:
 
 ```tsx
-import * as web3 from '@solana/web3'
-import * as token from '@solana/spl-token'
+import * as web3 from "@solana/web3";
+import * as token from "@solana/spl-token";
 
 async function buildRevokeTransaction(
-    account: web3.PublicKey,
-    owner: web3.PublicKey,
+  account: web3.PublicKey,
+  owner: web3.PublicKey,
 ): Promise<web3.Transaction> {
-    const transaction = new web3.Transaction().add(
-        token.createRevokeInstruction(
-            account,
-            owner,
-        )
-    )
+  const transaction = new web3.Transaction().add(
+    token.createRevokeInstruction(account, owner),
+  );
 
-    return transaction
+  return transaction;
 }
 ```
 
@@ -502,7 +482,7 @@ You'll then need to add a dependency on `@solana/spl-token`. From the command li
 We'll be using the `@solana/spl-token` library, so let's start by importing it at the top of the file.
 
 ```tsx
-import * as token from '@solana/spl-token'
+import * as token from "@solana/spl-token";
 ```
 
 Next, declare a new function `createNewMint` with parameters `connection`, `payer`, `mintAuthority`, `freezeAuthority`, and `decimals`.
@@ -512,26 +492,25 @@ Import `createMint` from `@solana/spl-token` and then create a function to call 
 
 ```tsx
 async function createNewMint(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    mintAuthority: web3.PublicKey,
-    freezeAuthority: web3.PublicKey,
-    decimals: number
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  mintAuthority: web3.PublicKey,
+  freezeAuthority: web3.PublicKey,
+  decimals: number,
 ): Promise<web3.PublicKey> {
+  const tokenMint = await token.createMint(
+    connection,
+    payer,
+    mintAuthority,
+    freezeAuthority,
+    decimals,
+  );
 
-    const tokenMint = await token.createMint(
-        connection,
-        payer,
-        mintAuthority,
-        freezeAuthority,
-        decimals
-    );
+  console.log(
+    `Token Mint: https://explorer.solana.com/address/${tokenMint}?cluster=devnet`,
+  );
 
-    console.log(
-        `Token Mint: https://explorer.solana.com/address/${tokenMint}?cluster=devnet`
-    );
-
-    return tokenMint;
+  return tokenMint;
 }
 ```
 
@@ -541,18 +520,18 @@ After creating the new mint, let's fetch the account data using the `getMint` fu
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 }
 ```
 
@@ -568,23 +547,23 @@ For our demo we’ll use the`getOrCreateAssociatedTokenAccount` function to crea
 
 ```tsx
 async function createTokenAccount(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    mint: web3.PublicKey,
-    owner: web3.PublicKey
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  mint: web3.PublicKey,
+  owner: web3.PublicKey,
 ) {
-    const tokenAccount = await token.getOrCreateAssociatedTokenAccount(
-        connection,
-        payer,
-        mint,
-        owner
-    )
+  const tokenAccount = await token.getOrCreateAssociatedTokenAccount(
+    connection,
+    payer,
+    mint,
+    owner,
+  );
 
-    console.log(
-        `Token Account: https://explorer.solana.com/address/${tokenAccount.address}?cluster=devnet`
-    )
+  console.log(
+    `Token Account: https://explorer.solana.com/address/${tokenAccount.address}?cluster=devnet`,
+  );
 
-    return tokenAccount
+  return tokenAccount;
 }
 ```
 
@@ -592,25 +571,25 @@ Add a call the `createTokenAccount` in `main`, passing in the mint we created in
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 
-    const tokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        user.publicKey
-    )
+  const tokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    user.publicKey,
+  );
 }
 ```
 
@@ -622,25 +601,25 @@ Create a function `mintTokens` that uses the `spl-token` function `mintTo` to mi
 
 ```tsx
 async function mintTokens(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    mint: web3.PublicKey,
-    destination: web3.PublicKey,
-    authority: web3.Keypair,
-    amount: number
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  mint: web3.PublicKey,
+  destination: web3.PublicKey,
+  authority: web3.Keypair,
+  amount: number,
 ) {
-    const transactionSignature = await token.mintTo(
-        connection,
-        payer,
-        mint,
-        destination,
-        authority,
-        amount
-    )
+  const transactionSignature = await token.mintTo(
+    connection,
+    payer,
+    mint,
+    destination,
+    authority,
+    amount,
+  );
 
-    console.log(
-        `Mint Token Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`
-    )
+  console.log(
+    `Mint Token Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`,
+  );
 }
 ```
 
@@ -650,34 +629,34 @@ Note that we have to adjust the input `amount` for the decimal precision of the 
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 
-    const tokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        user.publicKey
-    )
+  const tokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    user.publicKey,
+  );
 
-    await mintTokens(
-        connection,
-        user,
-        mint,
-        tokenAccount.address,
-        user,
-        100 * 10 ** mintInfo.decimals
-    )
+  await mintTokens(
+    connection,
+    user,
+    mint,
+    tokenAccount.address,
+    user,
+    100 * 10 ** mintInfo.decimals,
+  );
 }
 ```
 
@@ -689,25 +668,25 @@ Create a function `approveDelegate` that uses the `spl-token` function `approve`
 
 ```tsx
 async function approveDelegate(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    account: web3.PublicKey,
-    delegate: web3.PublicKey,
-    owner: web3.Signer | web3.PublicKey,
-    amount: number
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  account: web3.PublicKey,
+  delegate: web3.PublicKey,
+  owner: web3.Signer | web3.PublicKey,
+  amount: number,
 ) {
-    const transactionSignature = await token.approve(
-        connection,
-        payer,
-        account,
-        delegate,
-        owner,
-        amount
-  )
+  const transactionSignature = await token.approve(
+    connection,
+    payer,
+    account,
+    delegate,
+    owner,
+    amount,
+  );
 
-    console.log(
-        `Approve Delegate Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`
-    )
+  console.log(
+    `Approve Delegate Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`,
+  );
 }
 ```
 
@@ -715,45 +694,45 @@ In `main`, lets generate a new `Keypair` to represent the delegate account. Then
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 
-    const tokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        user.publicKey
-    )
+  const tokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    user.publicKey,
+  );
 
-    await mintTokens(
-        connection,
-        user,
-        mint,
-        tokenAccount.address,
-        user,
-        100 * 10 ** mintInfo.decimals
-    )
+  await mintTokens(
+    connection,
+    user,
+    mint,
+    tokenAccount.address,
+    user,
+    100 * 10 ** mintInfo.decimals,
+  );
 
-    const delegate = web3.Keypair.generate();
+  const delegate = web3.Keypair.generate();
 
-    await approveDelegate(
-      connection,
-      user,
-      tokenAccount.address,
-      delegate.publicKey,
-      user.publicKey,
-      50 * 10 ** mintInfo.decimals
-    )
+  await approveDelegate(
+    connection,
+    user,
+    tokenAccount.address,
+    delegate.publicKey,
+    user.publicKey,
+    50 * 10 ** mintInfo.decimals,
+  );
 }
 ```
 
@@ -763,25 +742,25 @@ Next, lets transfer some of the tokens we just minted using the `spl-token` libr
 
 ```tsx
 async function transferTokens(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    source: web3.PublicKey,
-    destination: web3.PublicKey,
-    owner: web3.Keypair,
-    amount: number
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  source: web3.PublicKey,
+  destination: web3.PublicKey,
+  owner: web3.Keypair,
+  amount: number,
 ) {
-    const transactionSignature = await token.transfer(
-        connection,
-        payer,
-        source,
-        destination,
-        owner,
-        amount
-    )
+  const transactionSignature = await token.transfer(
+    connection,
+    payer,
+    source,
+    destination,
+    owner,
+    amount,
+  );
 
-    console.log(
-        `Transfer Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`
-    )
+  console.log(
+    `Transfer Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`,
+  );
 }
 ```
 
@@ -793,61 +772,61 @@ Then, create a token account for the receiver. Finally, lets call our new `trans
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const tokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        user.publicKey
-    )
+  const tokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    user.publicKey,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 
-    await mintTokens(
-        connection,
-        user,
-        mint,
-        tokenAccount.address,
-        user,
-        100 * 10 ** mintInfo.decimals
-    )
+  await mintTokens(
+    connection,
+    user,
+    mint,
+    tokenAccount.address,
+    user,
+    100 * 10 ** mintInfo.decimals,
+  );
 
-    const receiver = web3.Keypair.generate().publicKey
-    const receiverTokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        receiver
-    )
+  const receiver = web3.Keypair.generate().publicKey;
+  const receiverTokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    receiver,
+  );
 
-    const delegate = web3.Keypair.generate();
-    await approveDelegate(
-        connection,
-        user,
-        tokenAccount.address,
-        delegate.publicKey,
-        user.publicKey,
-        50 * 10 ** mintInfo.decimals
-    )
+  const delegate = web3.Keypair.generate();
+  await approveDelegate(
+    connection,
+    user,
+    tokenAccount.address,
+    delegate.publicKey,
+    user.publicKey,
+    50 * 10 ** mintInfo.decimals,
+  );
 
-    await transferTokens(
-        connection,
-        user,
-        tokenAccount.address,
-        receiverTokenAccount.address,
-        delegate,
-        50 * 10 ** mintInfo.decimals
-    )
+  await transferTokens(
+    connection,
+    user,
+    tokenAccount.address,
+    receiverTokenAccount.address,
+    delegate,
+    50 * 10 ** mintInfo.decimals,
+  );
 }
 ```
 
@@ -857,21 +836,21 @@ Now that we've finished transferring tokens, lets revoke the `delegate` using th
 
 ```tsx
 async function revokeDelegate(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    account: web3.PublicKey,
-    owner: web3.Signer | web3.PublicKey,
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  account: web3.PublicKey,
+  owner: web3.Signer | web3.PublicKey,
 ) {
-    const transactionSignature = await token.revoke(
-        connection,
-        payer,
-        account,
-        owner,
-  )
+  const transactionSignature = await token.revoke(
+    connection,
+    payer,
+    account,
+    owner,
+  );
 
-    console.log(
-        `Revote Delegate Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`
-    )
+  console.log(
+    `Revote Delegate Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`,
+  );
 }
 ```
 
@@ -879,68 +858,63 @@ Revoke will set delegate for the token account to null and reset the delegated a
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 
-    const tokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        user.publicKey
-    )
+  const tokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    user.publicKey,
+  );
 
-    await mintTokens(
-        connection,
-        user,
-        mint,
-        tokenAccount.address,
-        user,
-        100 * 10 ** mintInfo.decimals
-    )
+  await mintTokens(
+    connection,
+    user,
+    mint,
+    tokenAccount.address,
+    user,
+    100 * 10 ** mintInfo.decimals,
+  );
 
-    const receiver = web3.Keypair.generate().publicKey
-    const receiverTokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        receiver
-    )
+  const receiver = web3.Keypair.generate().publicKey;
+  const receiverTokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    receiver,
+  );
 
-    const delegate = web3.Keypair.generate();
-    await approveDelegate(
-        connection,
-        user,
-        tokenAccount.address,
-        delegate.publicKey,
-        user.publicKey,
-        50 * 10 ** mintInfo.decimals
-    )
+  const delegate = web3.Keypair.generate();
+  await approveDelegate(
+    connection,
+    user,
+    tokenAccount.address,
+    delegate.publicKey,
+    user.publicKey,
+    50 * 10 ** mintInfo.decimals,
+  );
 
-    await transferTokens(
-        connection,
-        user,
-        tokenAccount.address,
-        receiverTokenAccount.address,
-        delegate,
-        50 * 10 ** mintInfo.decimals
-    )
+  await transferTokens(
+    connection,
+    user,
+    tokenAccount.address,
+    receiverTokenAccount.address,
+    delegate,
+    50 * 10 ** mintInfo.decimals,
+  );
 
-    await revokeDelegate(
-        connection,
-        user,
-        tokenAccount.address,
-        user.publicKey,
-    )
+  await revokeDelegate(connection, user, tokenAccount.address, user.publicKey);
 }
 ```
 
@@ -952,25 +926,25 @@ Create a `burnTokens` function that uses the `spl-token` library's `burn` functi
 
 ```tsx
 async function burnTokens(
-    connection: web3.Connection,
-    payer: web3.Keypair,
-    account: web3.PublicKey,
-    mint: web3.PublicKey,
-    owner: web3.Keypair,
-    amount: number
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  account: web3.PublicKey,
+  mint: web3.PublicKey,
+  owner: web3.Keypair,
+  amount: number,
 ) {
-    const transactionSignature = await token.burn(
-        connection,
-        payer,
-        account,
-        mint,
-        owner,
-        amount
-    )
+  const transactionSignature = await token.burn(
+    connection,
+    payer,
+    account,
+    mint,
+    owner,
+    amount,
+  );
 
-    console.log(
-        `Burn Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`
-    )
+  console.log(
+    `Burn Transaction: https://explorer.solana.com/tx/${transactionSignature}?cluster=devnet`,
+  );
 }
 ```
 
@@ -978,78 +952,75 @@ Now call this new function in `main` to burn 25 of the user's tokens. Remember t
 
 ```tsx
 async function main() {
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"))
-    const user = await initializeKeypair(connection)
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  const user = await initializeKeypair(connection);
 
-    const mint = await createNewMint(
-        connection,
-        user,
-        user.publicKey,
-        user.publicKey,
-        2
-    )
+  const mint = await createNewMint(
+    connection,
+    user,
+    user.publicKey,
+    user.publicKey,
+    2,
+  );
 
-    const mintInfo = await token.getMint(connection, mint);
+  const mintInfo = await token.getMint(connection, mint);
 
-    const tokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        user.publicKey
-    )
+  const tokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    user.publicKey,
+  );
 
-    await mintTokens(
-        connection,
-        user,
-        mint,
-        tokenAccount.address,
-        user,
-        100 * 10 ** mintInfo.decimals
-    )
+  await mintTokens(
+    connection,
+    user,
+    mint,
+    tokenAccount.address,
+    user,
+    100 * 10 ** mintInfo.decimals,
+  );
 
-    const receiver = web3.Keypair.generate().publicKey
-    const receiverTokenAccount = await createTokenAccount(
-        connection,
-        user,
-        mint,
-        receiver
-    )
+  const receiver = web3.Keypair.generate().publicKey;
+  const receiverTokenAccount = await createTokenAccount(
+    connection,
+    user,
+    mint,
+    receiver,
+  );
 
-    const delegate = web3.Keypair.generate();
-    await approveDelegate(
-        connection,
-        user,
-        tokenAccount.address,
-        delegate.publicKey,
-        user.publicKey,
-        50 * 10 ** mintInfo.decimals
-    )
+  const delegate = web3.Keypair.generate();
+  await approveDelegate(
+    connection,
+    user,
+    tokenAccount.address,
+    delegate.publicKey,
+    user.publicKey,
+    50 * 10 ** mintInfo.decimals,
+  );
 
-    await transferTokens(
-        connection,
-        user,
-        tokenAccount.address,
-        receiverTokenAccount.address,
-        delegate,
-        50 * 10 ** mintInfo.decimals
-    )
+  await transferTokens(
+    connection,
+    user,
+    tokenAccount.address,
+    receiverTokenAccount.address,
+    delegate,
+    50 * 10 ** mintInfo.decimals,
+  );
 
-    await revokeDelegate(
-        connection,
-        user,
-        tokenAccount.address,
-        user.publicKey,
-    )
+  await revokeDelegate(connection, user, tokenAccount.address, user.publicKey);
 
-    await burnTokens(
-        connection, 
-        user, 
-        tokenAccount.address, 
-        mint, user, 
-        25 * 10 ** mintInfo.decimals
-    )
+  await burnTokens(
+    connection,
+    user,
+    tokenAccount.address,
+    mint,
+    user,
+    25 * 10 ** mintInfo.decimals,
+  );
 }
 ```
+
 ### 9. Test it all out
 
 With that, run `npm start`. You should see a series of Solana Explorer links logged to the console. Click on them and see what happened each step of the way! You created a new token mint, created a token account, minted 100 tokens, approved a delegate, transferred 50 using a delegate, revoked the delegate, and burned 25 more. You're well on your way to being a token expert.
@@ -1066,15 +1037,16 @@ Note that you will not be able to directly use the helper functions we went over
 
 1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-token-frontend/tree/starter).
 2. Create a new Token Mint in the `CreateMint` component.
-    If you need a refresher on how to send transactions to a wallet for approval, have a look at the [Wallets lesson](./interact-with-wallets.md).
+   If you need a refresher on how to send transactions to a wallet for approval, have a look at the [Wallets lesson](./interact-with-wallets.md).
 
-    When creating a new mint, the newly generated `Keypair` will also have to sign the transaction. When additional signers are required in addition to the connected wallet, use the following format:
+   When creating a new mint, the newly generated `Keypair` will also have to sign the transaction. When additional signers are required in addition to the connected wallet, use the following format:
 
-    ```tsx
-    sendTransaction(transaction, connection, {
-        signers: [Keypair],
-    })
-    ```
+   ```tsx
+   sendTransaction(transaction, connection, {
+     signers: [Keypair],
+   });
+   ```
+
 3. Create a new Token Account in the `CreateTokenAccount` component.
 4. Mint tokens in the `MintToForm` component.
 

--- a/developers/courses/solana-course/content/token-program.md
+++ b/developers/courses/solana-course/content/token-program.md
@@ -10,17 +10,26 @@ objectives:
 
 # TL;DR
 
-- **SPL-Tokens** represent all non-native tokens on the Solana network. Both fungible and non-fungible tokens (NFTs) on Solana are SPL-Tokens
-- The **Token Program** contains instructions for creating and interacting with SPL-Tokens
-- **Token Mints** are accounts which hold data about a specific Token, but do not hold Tokens
+- **SPL-Tokens** represent all non-native tokens on the Solana network. Both
+  fungible and non-fungible tokens (NFTs) on Solana are SPL-Tokens
+- The **Token Program** contains instructions for creating and interacting with
+  SPL-Tokens
+- **Token Mints** are accounts which hold data about a specific Token, but do
+  not hold Tokens
 - **Token Accounts** are used to hold Tokens of a specific Token Mint
-- Creating Token Mints and Token Accounts requires allocating **rent** in SOL. The rent for a Token Account can be refunded when the account is closed, however, Token Mints currently cannot be closed
+- Creating Token Mints and Token Accounts requires allocating **rent** in SOL.
+  The rent for a Token Account can be refunded when the account is closed,
+  however, Token Mints currently cannot be closed
 
 # Overview
 
-The Token Program is one of many programs made available by the Solana Program Library (SPL). It contains instructions for creating and interacting with SPL-Tokens. These tokens represent all non-native (i.e. not SOL) tokens on the Solana network.
+The Token Program is one of many programs made available by the Solana Program
+Library (SPL). It contains instructions for creating and interacting with
+SPL-Tokens. These tokens represent all non-native (i.e. not SOL) tokens on the
+Solana network.
 
-This lesson will focus on the basics of creating and managing a new SPL-Token using the Token Program:
+This lesson will focus on the basics of creating and managing a new SPL-Token
+using the Token Program:
 
 1. Creating a new Token Mint
 2. Creating Token Accounts
@@ -28,17 +37,26 @@ This lesson will focus on the basics of creating and managing a new SPL-Token us
 4. Transferring tokens from one holder to another
 5. Burning tokens
 
-We'll be approaching this from the client-side of the development process using the `@solana/spl-token` Javascript library.
+We'll be approaching this from the client-side of the development process using
+the `@solana/spl-token` Javascript library.
 
 ## Token Mint
 
-To create a new SPL-Token you first have to create a Token Mint. A Token Mint is the account that holds data about a specific token.
+To create a new SPL-Token you first have to create a Token Mint. A Token Mint is
+the account that holds data about a specific token.
 
-As an example, let's look at [USD Coin (USDC) on the Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v). USDC's Token Mint address is `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. With the explorer, we can see the particular details about USDC's Token Mint such as the current supply of tokens, the addresses of the mint and freeze authorities, and the decimal precision of the token:
+As an example, let's look at
+[USD Coin (USDC) on the Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
+USDC's Token Mint address is `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.
+With the explorer, we can see the particular details about USDC's Token Mint
+such as the current supply of tokens, the addresses of the mint and freeze
+authorities, and the decimal precision of the token:
 
 ![Screenshot of USDC Token Mint](../assets/token-program-usdc-mint.png)
 
-To create a new Token Mint, you need to send the right transaction instructions to the Token Program. To do this, we'll use the `createMint` function from `@solana/spl-token`.
+To create a new Token Mint, you need to send the right transaction instructions
+to the Token Program. To do this, we'll use the `createMint` function from
+`@solana/spl-token`.
 
 ```tsx
 const tokenMint = await createMint(
@@ -50,17 +68,27 @@ const tokenMint = await createMint(
 );
 ```
 
-The `createMint` function returns the `publicKey` of the new token mint. This function requires the following arguments:
+The `createMint` function returns the `publicKey` of the new token mint. This
+function requires the following arguments:
 
 - `connection` - the JSON-RPC connection to the cluster
 - `payer` - the public key of the payer for the transaction
-- `mintAuthority` - the account which is authorized to do the actual minting of tokens from the token mint.
-- `freezeAuthority` - an account authorized to freeze the tokens in a token account. If freezing is not a desired attribute, the parameter can be set to null
+- `mintAuthority` - the account which is authorized to do the actual minting of
+  tokens from the token mint.
+- `freezeAuthority` - an account authorized to freeze the tokens in a token
+  account. If freezing is not a desired attribute, the parameter can be set to
+  null
 - `decimals` - specifies the desired decimal precision of the token
 
-When creating a new mint from a script that has access to your secret key, you can simply use the `createMint` function. However, if you were to build a website to allow users to create a new token mint, you would need to do so with the user's secret key without making them expose it to the browser. In that case, you would want to build and submit a transaction with the right instructions.
+When creating a new mint from a script that has access to your secret key, you
+can simply use the `createMint` function. However, if you were to build a
+website to allow users to create a new token mint, you would need to do so with
+the user's secret key without making them expose it to the browser. In that
+case, you would want to build and submit a transaction with the right
+instructions.
 
-Under the hood, the `createMint` function is simply creating a transaction that contains two instructions:
+Under the hood, the `createMint` function is simply creating a transaction that
+contains two instructions:
 
 1. Create a new account
 2. Initialize a new mint
@@ -101,28 +129,46 @@ async function buildCreateMintTransaction(
 }
 ```
 
-When manually building the instructions to create a new token mint, make sure you add the instructions for creating the account and initializing the mint to the _same transaction_. If you were to do each step in a separate transaction, it's theoretically possible for somebody else to take the account you create and initialize it for their own mint.
+When manually building the instructions to create a new token mint, make sure
+you add the instructions for creating the account and initializing the mint to
+the _same transaction_. If you were to do each step in a separate transaction,
+it's theoretically possible for somebody else to take the account you create and
+initialize it for their own mint.
 
 ### Rent and Rent Exemption
 
-Note that the first line in the function body of the previous code snippet contains a call to `getMinimumBalanceForRentExemptMint`, the result of which is passed into the `createAccount` function. This is part of account initialization called rent exemption.
+Note that the first line in the function body of the previous code snippet
+contains a call to `getMinimumBalanceForRentExemptMint`, the result of which is
+passed into the `createAccount` function. This is part of account initialization
+called rent exemption.
 
-Until recently, all accounts on Solana were required to do one of the following to avoid being deallocated:
+Until recently, all accounts on Solana were required to do one of the following
+to avoid being deallocated:
 
 1. Pay rent at specific intervals
 2. Deposit enough SOL upon initialization to be considered rent-exempt
 
-Recently, the first option was done away with and it became a requirement to deposit enough SOL for rent exemption when initializing a new account.
+Recently, the first option was done away with and it became a requirement to
+deposit enough SOL for rent exemption when initializing a new account.
 
-In this case, we're creating a new account for a token mint so we use `getMinimumBalanceForRentExemptMint` from the `@solana/spl-token` library. However, this concept applies to all accounts and you can use the more generic `getMinimumBalanceForRentExemption` method on `Connection` for other accounts you may need to create.
+In this case, we're creating a new account for a token mint so we use
+`getMinimumBalanceForRentExemptMint` from the `@solana/spl-token` library.
+However, this concept applies to all accounts and you can use the more generic
+`getMinimumBalanceForRentExemption` method on `Connection` for other accounts
+you may need to create.
 
 ## Token Account
 
-Before you can mint tokens (issue new supply), you need a Token Account to hold the newly issued tokens.
+Before you can mint tokens (issue new supply), you need a Token Account to hold
+the newly issued tokens.
 
-A Token Account holds tokens of a specific "mint" and has a specified "owner" of the account. Only the owner is authorized to decrease the Token Account balance (transfer, burn, etc.) while anyone can send tokens to the Token Account to increase its balance.
+A Token Account holds tokens of a specific "mint" and has a specified "owner" of
+the account. Only the owner is authorized to decrease the Token Account balance
+(transfer, burn, etc.) while anyone can send tokens to the Token Account to
+increase its balance.
 
-You can use the `spl-token` library's `createAccount` function to create the new Token Account:
+You can use the `spl-token` library's `createAccount` function to create the new
+Token Account:
 
 ```tsx
 const tokenAccount = await createAccount(
@@ -134,22 +180,39 @@ const tokenAccount = await createAccount(
 );
 ```
 
-The `createAccount` function returns the `publicKey` of the new token account. This function requires the following arguments:
+The `createAccount` function returns the `publicKey` of the new token account.
+This function requires the following arguments:
 
 - `connection` - the JSON-RPC connection to the cluster
 - `payer` - the account of the payer for the transaction
 - `mint` - the token mint that the new token account is associated with
 - `owner` - the account of the owner of the new token account
-- `keypair` - this is an optional parameter for specifying the new token account address. If no keypair is provided, the `createAccount` function defaults to a derivation from the associated `mint` and `owner` accounts.
+- `keypair` - this is an optional parameter for specifying the new token account
+  address. If no keypair is provided, the `createAccount` function defaults to a
+  derivation from the associated `mint` and `owner` accounts.
 
-Please note that this `createAccount` function is different from the `createAccount` function shown above when we looked under the hood of the `createMint` function. Previously we used the `createAccount` function on `SystemProgram` to return the instruction for creating all accounts. The `createAccount` function here is a helper function in the `spl-token` library that submits a transaction with two instructions. The first creates the account and the second initializes the account as a Token Account.
+Please note that this `createAccount` function is different from the
+`createAccount` function shown above when we looked under the hood of the
+`createMint` function. Previously we used the `createAccount` function on
+`SystemProgram` to return the instruction for creating all accounts. The
+`createAccount` function here is a helper function in the `spl-token` library
+that submits a transaction with two instructions. The first creates the account
+and the second initializes the account as a Token Account.
 
-Like with creating a Token Mint, if we needed to build the transaction for `createAccount` manually we could duplicate what the function is doing under the hood:
+Like with creating a Token Mint, if we needed to build the transaction for
+`createAccount` manually we could duplicate what the function is doing under the
+hood:
 
 1. Use `getMint` to retrieve the data associated with the `mint`
-2. Use `getAccountLenForMint` to calculate the space needed for the token account
-3. Use `getMinimumBalanceForRentExemption` to calculate the lamports needed for rent exemption
-4. Create a new transaction using `SystemProgram.createAccount` and `createInitializeAccountInstruction`. Note that this `createAccount` is from `@solana/web3.js` and used to create a generic new account. The `createInitializeAccountInstruction` uses this new account to initialize the new token account
+2. Use `getAccountLenForMint` to calculate the space needed for the token
+   account
+3. Use `getMinimumBalanceForRentExemption` to calculate the lamports needed for
+   rent exemption
+4. Create a new transaction using `SystemProgram.createAccount` and
+   `createInitializeAccountInstruction`. Note that this `createAccount` is from
+   `@solana/web3.js` and used to create a generic new account. The
+   `createInitializeAccountInstruction` uses this new account to initialize the
+   new token account
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -188,9 +251,14 @@ async function buildCreateTokenAccountTransaction(
 
 ### Associated Token Account
 
-An Associated Token Account is a Token Account where the address of the Token Account is derived using an owner's public key and a token mint. Associated Token Accounts provide a deterministic way to find the Token Account owned by a specific `publicKey` for a specific token mint. Most of the time you create a Token Account, you'll want it to be an Associated Token Account.
+An Associated Token Account is a Token Account where the address of the Token
+Account is derived using an owner's public key and a token mint. Associated
+Token Accounts provide a deterministic way to find the Token Account owned by a
+specific `publicKey` for a specific token mint. Most of the time you create a
+Token Account, you'll want it to be an Associated Token Account.
 
-Similar to above, you can create an associated token account using the `spl-token` library's `createAssociatedTokenAccount` function.
+Similar to above, you can create an associated token account using the
+`spl-token` library's `createAssociatedTokenAccount` function.
 
 ```tsx
 const associatedTokenAccount = await createAssociatedTokenAccount(
@@ -201,19 +269,26 @@ const associatedTokenAccount = await createAssociatedTokenAccount(
 );
 ```
 
-This function returns the `publicKey` of the new associated token account and requires the following arguments:
+This function returns the `publicKey` of the new associated token account and
+requires the following arguments:
 
 - `connection` - the JSON-RPC connection to the cluster
 - `payer` - the account of the payer for the transaction
 - `mint` - the token mint that the new token account is associated with
 - `owner` - the account of the owner of the new token account
 
-You can also use `getOrCreateAssociatedTokenAccount` to get the Token Account associated with a given address or create it if it doesn't exist. For example, if you were writing code to airdrop tokens to a given user, you'd likely use this function to ensure that the token account associated with the given user gets created if it doesn't already exist.
+You can also use `getOrCreateAssociatedTokenAccount` to get the Token Account
+associated with a given address or create it if it doesn't exist. For example,
+if you were writing code to airdrop tokens to a given user, you'd likely use
+this function to ensure that the token account associated with the given user
+gets created if it doesn't already exist.
 
 Under the hood, `createAssociatedTokenAccount` is doing two things:
 
-1. Using `getAssociatedTokenAddress` to derive the associated token account address from the `mint` and `owner`
-2. Building a transaction using instructions from `createAssociatedTokenAccountInstruction`
+1. Using `getAssociatedTokenAddress` to derive the associated token account
+   address from the `mint` and `owner`
+2. Building a transaction using instructions from
+   `createAssociatedTokenAccountInstruction`
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -244,7 +319,10 @@ async function buildCreateAssociatedTokenAccountTransaction(
 
 ## Mint Tokens
 
-Minting tokens is the process of issuing new tokens into circulation. When you mint tokens, you increase the supply of the token mint and deposit the newly minted tokens into a token account. Only the mint authority of a token mint is allowed to mint new tokens.
+Minting tokens is the process of issuing new tokens into circulation. When you
+mint tokens, you increase the supply of the token mint and deposit the newly
+minted tokens into a token account. Only the mint authority of a token mint is
+allowed to mint new tokens.
 
 To mint tokens using the `spl-token` library, you can use the `mintTo` function.
 
@@ -259,18 +337,26 @@ const transactionSignature = await mintTo(
 );
 ```
 
-The `mintTo` function returns a `TransactionSignature` that can be viewed on the Solana Explorer. The `mintTo` function requires the following arguments:
+The `mintTo` function returns a `TransactionSignature` that can be viewed on the
+Solana Explorer. The `mintTo` function requires the following arguments:
 
 - `connection` - the JSON-RPC connection to the cluster
 - `payer` - the account of the payer for the transaction
 - `mint` - the token mint that the new token account is associated with
 - `destination` - the token account that tokens will be minted to
 - `authority` - the account authorized to mint tokens
-- `amount` - the raw amount of tokens to mint outside of decimals, e.g. if Scrooge Coin mint's decimals property was set to 2 then to get 1 full Scrooge Coin you would need to set this property to 100
+- `amount` - the raw amount of tokens to mint outside of decimals, e.g. if
+  Scrooge Coin mint's decimals property was set to 2 then to get 1 full Scrooge
+  Coin you would need to set this property to 100
 
-It's not uncommon to update the mint authority on a token mint to null after the tokens have been minted. This would set a maximum supply and ensure no tokens can be minted in the future. Conversely, minting authority could be granted to a program so tokens could be automatically minted at regular intervals or according to programmable conditions.
+It's not uncommon to update the mint authority on a token mint to null after the
+tokens have been minted. This would set a maximum supply and ensure no tokens
+can be minted in the future. Conversely, minting authority could be granted to a
+program so tokens could be automatically minted at regular intervals or
+according to programmable conditions.
 
-Under the hood, the `mintTo` function simply creates a transaction with the instructions obtained from the `createMintToInstruction` function.
+Under the hood, the `mintTo` function simply creates a transaction with the
+instructions obtained from the `createMintToInstruction` function.
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -292,11 +378,18 @@ async function buildMintToTransaction(
 
 ## Transfer Tokens
 
-SPL-Token transfers require both the sender and receiver to have token accounts for the mint of the tokens being transferred. The tokens are transferred from the sender’s token account to the receiver’s token account.
+SPL-Token transfers require both the sender and receiver to have token accounts
+for the mint of the tokens being transferred. The tokens are transferred from
+the sender’s token account to the receiver’s token account.
 
-You can use `getOrCreateAssociatedTokenAccount` when obtaining the receiver's associated token account to ensure their token account exists before the transfer. Just remember that if the account doesn't exist already, this function will create it and the payer on the transaction will be debited the lamports required for the account creation.
+You can use `getOrCreateAssociatedTokenAccount` when obtaining the receiver's
+associated token account to ensure their token account exists before the
+transfer. Just remember that if the account doesn't exist already, this function
+will create it and the payer on the transaction will be debited the lamports
+required for the account creation.
 
-Once you know the receiver's token account address, you transfer tokens using the `spl-token` library's `transfer` function.
+Once you know the receiver's token account address, you transfer tokens using
+the `spl-token` library's `transfer` function.
 
 ```tsx
 const transactionSignature = await transfer(
@@ -309,7 +402,8 @@ const transactionSignature = await transfer(
 );
 ```
 
-The `transfer` function returns a `TransactionSignature` that can be viewed on the Solana Explorer. The `transfer` function requires the following arguments:
+The `transfer` function returns a `TransactionSignature` that can be viewed on
+the Solana Explorer. The `transfer` function requires the following arguments:
 
 - `connection` the JSON-RPC connection to the cluster
 - `payer` the account of the payer for the transaction
@@ -318,7 +412,8 @@ The `transfer` function returns a `TransactionSignature` that can be viewed on t
 - `owner` the account of the owner of the `source` token account
 - `amount` the amount of tokens to transfer
 
-Under the hood, the `transfer` function simply creates a transaction with the instructions obtained from the `createTransferInstruction` function:
+Under the hood, the `transfer` function simply creates a transaction with the
+instructions obtained from the `createTransferInstruction` function:
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -340,7 +435,9 @@ async function buildTransferTransaction(
 
 ## Burn Tokens
 
-Burning tokens is the process of decreasing the token supply of a given token mint. Burning tokens removes them from the given token account and from broader circulation.
+Burning tokens is the process of decreasing the token supply of a given token
+mint. Burning tokens removes them from the given token account and from broader
+circulation.
 
 To burn tokens using the `spl-token` library, you use the `burn` function.
 
@@ -355,7 +452,8 @@ const transactionSignature = await burn(
 );
 ```
 
-The `burn` function returns a `TransactionSignature` that can be viewed on Solana Explorer. The `burn` function requires the following arguments:
+The `burn` function returns a `TransactionSignature` that can be viewed on
+Solana Explorer. The `burn` function requires the following arguments:
 
 - `connection` the JSON-RPC connection to the cluster
 - `payer` the account of the payer for the transaction
@@ -364,7 +462,8 @@ The `burn` function returns a `TransactionSignature` that can be viewed on Solan
 - `owner` the account of the owner of the token account
 - `amount` the amount of tokens to burn
 
-Under the hood, the `burn` function creates a transaction with instructions obtained from the `createBurnInstruction` function:
+Under the hood, the `burn` function creates a transaction with instructions
+obtained from the `createBurnInstruction` function:
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -386,9 +485,15 @@ async function buildBurnTransaction(
 
 ## Approve Delegate
 
-Approving a delegate is the process of authorizing another account to transfer or burn tokens from a token account. When using a delegate, the authority over the token account remains with the original owner. The maximum amount of tokens a delegate may transfer or burn is specified at the time the owner of the token account approves the delegate. Note that there can only be one delegate account associated with a token account at any given time.
+Approving a delegate is the process of authorizing another account to transfer
+or burn tokens from a token account. When using a delegate, the authority over
+the token account remains with the original owner. The maximum amount of tokens
+a delegate may transfer or burn is specified at the time the owner of the token
+account approves the delegate. Note that there can only be one delegate account
+associated with a token account at any given time.
 
-To approve a delegate using the `spl-token` library, you use the `approve` function.
+To approve a delegate using the `spl-token` library, you use the `approve`
+function.
 
 ```tsx
 const transactionSignature = await approve(
@@ -401,7 +506,8 @@ const transactionSignature = await approve(
 );
 ```
 
-The `approve` function returns a `TransactionSignature` that can be viewed on Solana Explorer. The `approve` function requires the following arguments:
+The `approve` function returns a `TransactionSignature` that can be viewed on
+Solana Explorer. The `approve` function requires the following arguments:
 
 - `connection` the JSON-RPC connection to the cluster
 - `payer` the account of the payer for the transaction
@@ -410,7 +516,8 @@ The `approve` function returns a `TransactionSignature` that can be viewed on So
 - `owner` the account of the owner of the token account
 - `amount` the maximum number of tokens the delegate may transfer or burn
 
-Under the hood, the `approve` function creates a transaction with instructions obtained from the `createApproveInstruction` function:
+Under the hood, the `approve` function creates a transaction with instructions
+obtained from the `createApproveInstruction` function:
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -432,22 +539,28 @@ async function buildApproveTransaction(
 
 ## Revoke Delegate
 
-A previously approved delegate for a token account can be later revoked. Once a delegate is revoked, the delegate can no longer transfer tokens from the owner's token account. Any remaining amount left untransferred from the previously approved amount can no longer be transferred by the delegate.
+A previously approved delegate for a token account can be later revoked. Once a
+delegate is revoked, the delegate can no longer transfer tokens from the owner's
+token account. Any remaining amount left untransferred from the previously
+approved amount can no longer be transferred by the delegate.
 
-To revoke a delegate using the `spl-token` library, you use the `revoke` function.
+To revoke a delegate using the `spl-token` library, you use the `revoke`
+function.
 
 ```tsx
 const transactionSignature = await revoke(connection, payer, account, owner);
 ```
 
-The `revoke` function returns a `TransactionSignature` that can be viewed on Solana Explorer. The `revoke` function requires the following arguments:
+The `revoke` function returns a `TransactionSignature` that can be viewed on
+Solana Explorer. The `revoke` function requires the following arguments:
 
 - `connection` the JSON-RPC connection to the cluster
 - `payer` the account of the payer for the transaction
 - `account` the token account to revoke the delegate authority from
 - `owner` the account of the owner of the token account
 
-Under the hood, the `revoke` function creates a transaction with instructions obtained from the `createRevokeInstruction` function:
+Under the hood, the `revoke` function creates a transaction with instructions
+obtained from the `createRevokeInstruction` function:
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -467,28 +580,39 @@ async function buildRevokeTransaction(
 
 # Demo
 
-We’re going to create a script that interacts with instructions on the Token Program. We will create a Token Mint, create Token Accounts, mint tokens, approve a delegate, transfer tokens, and burn tokens.
+We’re going to create a script that interacts with instructions on the Token
+Program. We will create a Token Mint, create Token Accounts, mint tokens,
+approve a delegate, transfer tokens, and burn tokens.
 
 ### 1. Basic scaffolding
 
-Let’s start with some basic scaffolding. You’re welcome to set up your project however feels most appropriate for you, but we’ll be using a simple Typescript project with a dependency on the `@solana/web3.js` and `@solana/spl-token` packages.
+Let’s start with some basic scaffolding. You’re welcome to set up your project
+however feels most appropriate for you, but we’ll be using a simple Typescript
+project with a dependency on the `@solana/web3.js` and `@solana/spl-token`
+packages.
 
-You can use `npx create-solana-client [INSERT_NAME_HERE]` in the command line to clone the template we'll be starting from. Or you can manually clone the template [here](https://github.com/Unboxed-Software/solana-client-template).
+You can use `npx create-solana-client [INSERT_NAME_HERE]` in the command line to
+clone the template we'll be starting from. Or you can manually clone the
+template [here](https://github.com/Unboxed-Software/solana-client-template).
 
-You'll then need to add a dependency on `@solana/spl-token`. From the command line inside the newly created directory, use the command `npm install @solana/spl-token`.
+You'll then need to add a dependency on `@solana/spl-token`. From the command
+line inside the newly created directory, use the command
+`npm install @solana/spl-token`.
 
 ### 2. Create Token Mint
 
-We'll be using the `@solana/spl-token` library, so let's start by importing it at the top of the file.
+We'll be using the `@solana/spl-token` library, so let's start by importing it
+at the top of the file.
 
 ```tsx
 import * as token from "@solana/spl-token";
 ```
 
-Next, declare a new function `createNewMint` with parameters `connection`, `payer`, `mintAuthority`, `freezeAuthority`, and `decimals`.
+Next, declare a new function `createNewMint` with parameters `connection`,
+`payer`, `mintAuthority`, `freezeAuthority`, and `decimals`.
 
-In the body of the function
-Import `createMint` from `@solana/spl-token` and then create a function to call `createMint`:
+In the body of the function Import `createMint` from `@solana/spl-token` and
+then create a function to call `createMint`:
 
 ```tsx
 async function createNewMint(
@@ -514,9 +638,12 @@ async function createNewMint(
 }
 ```
 
-With that function completed, call it from the body of `main`, setting `user` as the `payer`, `mintAuthority`, and `freezeAuthority`.
+With that function completed, call it from the body of `main`, setting `user` as
+the `payer`, `mintAuthority`, and `freezeAuthority`.
 
-After creating the new mint, let's fetch the account data using the `getMint` function and store it in a variable called `mintInfo`. We'll use this data later to adjust input `amount` for the decimal precision of the mint.
+After creating the new mint, let's fetch the account data using the `getMint`
+function and store it in a variable called `mintInfo`. We'll use this data later
+to adjust input `amount` for the decimal precision of the mint.
 
 ```tsx
 async function main() {
@@ -537,13 +664,22 @@ async function main() {
 
 ### 3. Create Token Account
 
-Now that we've created the mint, lets create a new Token Account, specifying the `user` as the `owner`.
+Now that we've created the mint, lets create a new Token Account, specifying the
+`user` as the `owner`.
 
-The `createAccount` function creates a new Token Account with the option to specify the address of the Token Account. Recall that if no address is provided, `createAccount` will default to using the associated token account derived using the `mint` and `owner`.
+The `createAccount` function creates a new Token Account with the option to
+specify the address of the Token Account. Recall that if no address is provided,
+`createAccount` will default to using the associated token account derived using
+the `mint` and `owner`.
 
-Alternatively, the function `createAssociatedTokenAccount` will also create an associated token account with the same address derived from the `mint` and `owner` public keys.
+Alternatively, the function `createAssociatedTokenAccount` will also create an
+associated token account with the same address derived from the `mint` and
+`owner` public keys.
 
-For our demo we’ll use the`getOrCreateAssociatedTokenAccount` function to create our token account. This function gets the address of a Token Account if it already exists. If it doesn't, it will create a new Associated Token Account at the appropriate address.
+For our demo we’ll use the`getOrCreateAssociatedTokenAccount` function to create
+our token account. This function gets the address of a Token Account if it
+already exists. If it doesn't, it will create a new Associated Token Account at
+the appropriate address.
 
 ```tsx
 async function createTokenAccount(
@@ -567,7 +703,8 @@ async function createTokenAccount(
 }
 ```
 
-Add a call the `createTokenAccount` in `main`, passing in the mint we created in the previous step and setting the `user` as the `payer` and `owner`.
+Add a call the `createTokenAccount` in `main`, passing in the mint we created in
+the previous step and setting the `user` as the `payer` and `owner`.
 
 ```tsx
 async function main() {
@@ -595,9 +732,13 @@ async function main() {
 
 ### 4. Mint Tokens
 
-Now that we have a token mint and a token account, lets mint tokens to the token account. Note that only the `mintAuthority` can mint new tokens to a token account. Recall that we set the `user` as the `mintAuthority` for the `mint` we created.
+Now that we have a token mint and a token account, lets mint tokens to the token
+account. Note that only the `mintAuthority` can mint new tokens to a token
+account. Recall that we set the `user` as the `mintAuthority` for the `mint` we
+created.
 
-Create a function `mintTokens` that uses the `spl-token` function `mintTo` to mint tokens:
+Create a function `mintTokens` that uses the `spl-token` function `mintTo` to
+mint tokens:
 
 ```tsx
 async function mintTokens(
@@ -623,9 +764,13 @@ async function mintTokens(
 }
 ```
 
-Lets call the function in `main` using the `mint` and `tokenAccount` created previously.
+Lets call the function in `main` using the `mint` and `tokenAccount` created
+previously.
 
-Note that we have to adjust the input `amount` for the decimal precision of the mint. Tokens from our `mint` have a decimal precision of 2. If we only specify 100 as the input `amount`, then only 1 token will be minted to our token account.
+Note that we have to adjust the input `amount` for the decimal precision of the
+mint. Tokens from our `mint` have a decimal precision of 2. If we only specify
+100 as the input `amount`, then only 1 token will be minted to our token
+account.
 
 ```tsx
 async function main() {
@@ -662,9 +807,11 @@ async function main() {
 
 ### 5. Approve Delegate
 
-Now that we have a token mint and a token account, lets authorize a delegate to transfer tokens on our behalf.
+Now that we have a token mint and a token account, lets authorize a delegate to
+transfer tokens on our behalf.
 
-Create a function `approveDelegate` that uses the `spl-token` function `approve` to mint tokens:
+Create a function `approveDelegate` that uses the `spl-token` function `approve`
+to mint tokens:
 
 ```tsx
 async function approveDelegate(
@@ -690,7 +837,10 @@ async function approveDelegate(
 }
 ```
 
-In `main`, lets generate a new `Keypair` to represent the delegate account. Then, lets call our new `approveDelegate` function and authorize the delegate to tranfer up to 50 tokens from the `user` token account. Remember to adjust the `amount` for the decimal precision of the `mint`.
+In `main`, lets generate a new `Keypair` to represent the delegate account.
+Then, lets call our new `approveDelegate` function and authorize the delegate to
+tranfer up to 50 tokens from the `user` token account. Remember to adjust the
+`amount` for the decimal precision of the `mint`.
 
 ```tsx
 async function main() {
@@ -738,7 +888,8 @@ async function main() {
 
 ### 6. Transfer Tokens
 
-Next, lets transfer some of the tokens we just minted using the `spl-token` library's `transfer` function.
+Next, lets transfer some of the tokens we just minted using the `spl-token`
+library's `transfer` function.
 
 ```tsx
 async function transferTokens(
@@ -764,11 +915,18 @@ async function transferTokens(
 }
 ```
 
-Before we can call this new function, we need to know the account into which we'll transfer the tokens.
+Before we can call this new function, we need to know the account into which
+we'll transfer the tokens.
 
-In `main`, lets generate a new `Keypair` to be the receiver (but remember that this is just to simulate having someone to send tokens to - in a real application you'd need to know the wallet address of the person receiving the tokens).
+In `main`, lets generate a new `Keypair` to be the receiver (but remember that
+this is just to simulate having someone to send tokens to - in a real
+application you'd need to know the wallet address of the person receiving the
+tokens).
 
-Then, create a token account for the receiver. Finally, lets call our new `transferTokens` function to transfer tokens from the `user` token account to the `receiver` token account. We'll use the `delegate` we approved in the previous step to perform the transfer on our behalf.
+Then, create a token account for the receiver. Finally, lets call our new
+`transferTokens` function to transfer tokens from the `user` token account to
+the `receiver` token account. We'll use the `delegate` we approved in the
+previous step to perform the transfer on our behalf.
 
 ```tsx
 async function main() {
@@ -832,7 +990,8 @@ async function main() {
 
 ### 7. Revoke Delegate
 
-Now that we've finished transferring tokens, lets revoke the `delegate` using the `spl-token` library's `revoke` function.
+Now that we've finished transferring tokens, lets revoke the `delegate` using
+the `spl-token` library's `revoke` function.
 
 ```tsx
 async function revokeDelegate(
@@ -854,7 +1013,10 @@ async function revokeDelegate(
 }
 ```
 
-Revoke will set delegate for the token account to null and reset the delegated amount to 0. All we will need for this function is the token account and user. Lets call our new `revokeDelegate` function to revoke the delegate from the `user` token account.
+Revoke will set delegate for the token account to null and reset the delegated
+amount to 0. All we will need for this function is the token account and user.
+Lets call our new `revokeDelegate` function to revoke the delegate from the
+`user` token account.
 
 ```tsx
 async function main() {
@@ -922,7 +1084,8 @@ async function main() {
 
 Finally, let's remove some tokens from circulation by burning them.
 
-Create a `burnTokens` function that uses the `spl-token` library's `burn` function to remove half of your tokens from circulation.
+Create a `burnTokens` function that uses the `spl-token` library's `burn`
+function to remove half of your tokens from circulation.
 
 ```tsx
 async function burnTokens(
@@ -948,7 +1111,8 @@ async function burnTokens(
 }
 ```
 
-Now call this new function in `main` to burn 25 of the user's tokens. Remember to adjust the `amount` for the decimal precision of the `mint`.
+Now call this new function in `main` to burn 25 of the user's tokens. Remember
+to adjust the `amount` for the decimal precision of the `mint`.
 
 ```tsx
 async function main() {
@@ -1023,23 +1187,37 @@ async function main() {
 
 ### 9. Test it all out
 
-With that, run `npm start`. You should see a series of Solana Explorer links logged to the console. Click on them and see what happened each step of the way! You created a new token mint, created a token account, minted 100 tokens, approved a delegate, transferred 50 using a delegate, revoked the delegate, and burned 25 more. You're well on your way to being a token expert.
+With that, run `npm start`. You should see a series of Solana Explorer links
+logged to the console. Click on them and see what happened each step of the way!
+You created a new token mint, created a token account, minted 100 tokens,
+approved a delegate, transferred 50 using a delegate, revoked the delegate, and
+burned 25 more. You're well on your way to being a token expert.
 
-If you need a bit more time with this project to feel comfortable, have a look at the complete [solution code](https://github.com/Unboxed-Software/solana-token-client)
+If you need a bit more time with this project to feel comfortable, have a look
+at the complete
+[solution code](https://github.com/Unboxed-Software/solana-token-client)
 
 # Challenge
 
-Now it’s your turn to build something independently. Create an application that allows a users to create a new mint, create a token account, and mint tokens.
+Now it’s your turn to build something independently. Create an application that
+allows a users to create a new mint, create a token account, and mint tokens.
 
-Note that you will not be able to directly use the helper functions we went over in the demo. In order to interact with the Token Program using the Phantom wallet adapter, you will have to build each transaction manually and submit the transaction to Phantom for approval.
+Note that you will not be able to directly use the helper functions we went over
+in the demo. In order to interact with the Token Program using the Phantom
+wallet adapter, you will have to build each transaction manually and submit the
+transaction to Phantom for approval.
 
 ![Screenshot of Token Program Challenge Frontend](../assets/token-program-frontend.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-token-frontend/tree/starter).
-2. Create a new Token Mint in the `CreateMint` component.
-   If you need a refresher on how to send transactions to a wallet for approval, have a look at the [Wallets lesson](./interact-with-wallets.md).
+1. You can build this from scratch or you can download the starter code
+   [here](https://github.com/Unboxed-Software/solana-token-frontend/tree/starter).
+2. Create a new Token Mint in the `CreateMint` component. If you need a
+   refresher on how to send transactions to a wallet for approval, have a look
+   at the [Wallets lesson](./interact-with-wallets.md).
 
-   When creating a new mint, the newly generated `Keypair` will also have to sign the transaction. When additional signers are required in addition to the connected wallet, use the following format:
+   When creating a new mint, the newly generated `Keypair` will also have to
+   sign the transaction. When additional signers are required in addition to the
+   connected wallet, use the following format:
 
    ```tsx
    sendTransaction(transaction, connection, {
@@ -1050,6 +1228,7 @@ Note that you will not be able to directly use the helper functions we went over
 3. Create a new Token Account in the `CreateTokenAccount` component.
 4. Mint tokens in the `MintToForm` component.
 
-If you get stumped, feel free to reference the [solution code](https://github.com/ZYJLiu/solana-token-frontend).
+If you get stumped, feel free to reference the
+[solution code](https://github.com/ZYJLiu/solana-token-frontend).
 
 And remember, get creative with these challenges and make them your own!

--- a/developers/courses/solana-course/content/token-swap.md
+++ b/developers/courses/solana-course/content/token-swap.md
@@ -1,10 +1,10 @@
 ---
 title: Swap Tokens With The Token Swap Program
 objectives:
-- Create a token swap pool
-- Deposit liquidity
-- Withdraw liquidity
-- Swap tokens
+  - Create a token swap pool
+  - Deposit liquidity
+  - Withdraw liquidity
+  - Swap tokens
 ---
 
 # TL;DR
@@ -43,6 +43,7 @@ Solana also maintains the `@solana/spl-token-swap` JS library. This library prov
 Creating swap pools with the SPL Token Swap Program really showcases the account, instruction, and authorization models on Solana. This lesson will combine and build on top of a lot of what we have learned so far in the course. For operations specific to the Token Swap Program, we'll use the `@solana/spl-token-swap` library.
 
 As we talk through creating a swap pool, we'll assume we're creating a swap pool for two tokens named Token A and Token B. Creating the swap pool with the `spl-token-swap` library is as simple as sending a transaction with an instruction created with the `TokenSwap.createInitSwapInstruction` function. However, there are a number of accounts you need to create or derive beforehand that will be needed when creating that instruction:
+
 1. **Token swap state account** - holds information about the swap pool
 2. **Swap pool authority** - the PDA used to sign transactions on behalf of the swap program
 3. **Token accounts for Token A and Token B** - token accounts that will hold tokens A and B for the pool
@@ -57,23 +58,30 @@ Before you can create a swap pool, you'll need to create a token swap state acco
 To create the token swap state account, you use the `SystemProgram` instruction `createAccount`.
 
 ```tsx
-import * as web3 from '@solana/web3'
-import { TokenSwap, TOKEN_SWAP_PROGRAM_ID, TokenSwapLayout } from "@solana/spl-token-swap"
+import * as web3 from "@solana/web3";
+import {
+  TokenSwap,
+  TOKEN_SWAP_PROGRAM_ID,
+  TokenSwapLayout,
+} from "@solana/spl-token-swap";
 
-const transaction = new Web3.Transaction()
-const tokenSwapStateAccount = Web3.Keypair.generate()
-const rent = TokenSwap.getMinBalanceRentForExemptTokenSwap(connection)
-const tokenSwapStateAccountInstruction = await Web3.SystemProgram.createAccount({
+const transaction = new Web3.Transaction();
+const tokenSwapStateAccount = Web3.Keypair.generate();
+const rent = TokenSwap.getMinBalanceRentForExemptTokenSwap(connection);
+const tokenSwapStateAccountInstruction = await Web3.SystemProgram.createAccount(
+  {
     newAccountPubkey: tokenSwapStateAccount.publicKey,
     fromPubkey: wallet.publicKey,
     lamports: rent,
     space: TokenSwapLayout.span,
-    programId: TOKEN_SWAP_PROGRAM_ID
-})
-transaction.add(tokenSwapStateAccountInstruction)
+    programId: TOKEN_SWAP_PROGRAM_ID,
+  },
+);
+transaction.add(tokenSwapStateAccountInstruction);
 ```
 
 A few items to note from this example:
+
 1. You can get the number of lamports required for rent exemption using `TokenSwap.getMinBalanceRentForExemptTokenSwap` from the `spl-token-swap` library.
 2. Similarly, you can use `TokenSwapLayout.span` for the space required on the account.
 3. `programId` must be set to `TOKEN_SWAP_PROGRAM_ID`. This sets the owner of the new account to be the Token Swap Program itself. The Token Swap Program will need to write data to the new account and so must be set as the owner.
@@ -86,9 +94,9 @@ PDAs can only be created by their owning program, so you don't need to create th
 
 ```tsx
 const [swapAuthority, bump] = await Web3.PublicKey.findProgramAddress(
-    [tokenSwapStateAccount.publicKey.toBuffer()],
-    TOKEN_SWAP_PROGRAM_ID,
-)
+  [tokenSwapStateAccount.publicKey.toBuffer()],
+  TOKEN_SWAP_PROGRAM_ID,
+);
 ```
 
 The resulting public key will be used as the authority on a number of the accounts that follow.
@@ -99,19 +107,20 @@ Token A and Token B accounts are associated token accounts used for the actual s
 
 ```tsx
 let tokenAAccountAddress = await token.getAssociatedTokenAddress(
-    tokenAMint, // mint
-    swapAuthority, // owner
-    true // allow owner off curve
-)
+  tokenAMint, // mint
+  swapAuthority, // owner
+  true, // allow owner off curve
+);
 
-const tokenAAccountInstruction = await token.createAssociatedTokenAccountInstruction(
+const tokenAAccountInstruction =
+  await token.createAssociatedTokenAccountInstruction(
     wallet.publicKey, // payer
     tokenAAccountAddress, // ata
     swapAuthority, // owner
-    tokenAMint // mint
-)
+    tokenAMint, // mint
+  );
 
-transaction.add(tokenAAccountInstruction)
+transaction.add(tokenAAccountInstruction);
 ```
 
 If you need a refresher on creating token accounts, have a look at the [Token Program lesson](./token-program.md).
@@ -122,12 +131,12 @@ The pool token mint is the mint of the LP-tokens that represent an LP’s owners
 
 ```tsx
 const poolTokenMint = await token.createMint(
-    connection,
-    wallet,
-    swapAuthority,
-    null,
-    2
-)
+  connection,
+  wallet,
+  swapAuthority,
+  null,
+  2,
+);
 ```
 
 ### Pool Token Account
@@ -135,23 +144,24 @@ const poolTokenMint = await token.createMint(
 The pool token account is the account that the initial liquidity pool tokens get minted to when the swap account is first created. Subsequent minting of LP-tokens will be minted directly to the account of the user adding liquidity to the pool. Liquidity pool tokens represent ownership in the deposited liquidity in the pool.
 
 ```tsx
-const tokenAccountPool = Web3.Keypair.generate()
-const rent = await token.getMinimumBalanceForRentExemptAccount(connection)
+const tokenAccountPool = Web3.Keypair.generate();
+const rent = await token.getMinimumBalanceForRentExemptAccount(connection);
 const createTokenAccountPoolInstruction = Web3.SystemProgram.createAccount({
-    fromPubkey: wallet.publicKey,
-    newAccountPubkey: tokenAccountPool.publicKey,
-    space: token.ACCOUNT_SIZE,
-    lamports: rent,
-    programId: token.TOKEN_PROGRAM_ID,
-})
-const initializeTokenAccountPoolInstruction = token.createInitializeAccountInstruction(
+  fromPubkey: wallet.publicKey,
+  newAccountPubkey: tokenAccountPool.publicKey,
+  space: token.ACCOUNT_SIZE,
+  lamports: rent,
+  programId: token.TOKEN_PROGRAM_ID,
+});
+const initializeTokenAccountPoolInstruction =
+  token.createInitializeAccountInstruction(
     tokenAccountPool.publicKey,
     poolTokenMint,
-    wallet.publicKey
-)
+    wallet.publicKey,
+  );
 
-transaction.add(createTokenAccountPoolInstruction)
-transaction.add(initializeTokenAccountPoolInstruction)
+transaction.add(createTokenAccountPoolInstruction);
+transaction.add(initializeTokenAccountPoolInstruction);
 ```
 
 ### Pool Token Fee Account
@@ -159,29 +169,32 @@ transaction.add(initializeTokenAccountPoolInstruction)
 The pool token fee account is the token account that the fees for the token swaps are paid to. For the Serum deployment of the Token Swap Program that we are using, this account must be owned by a specific account defined in the swap program: [HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN](https://explorer.solana.com/address/HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN?cluster=devnet).
 
 ```tsx
-const feeOwner = new web3.PublicKey('HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN')
+const feeOwner = new web3.PublicKey(
+  "HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN",
+);
 
 let tokenFeeAccountAddress = await token.getAssociatedTokenAddress(
-    poolTokenMint, // mint
-    feeOwner, // owner
-    true // allow owner off curve
-)
+  poolTokenMint, // mint
+  feeOwner, // owner
+  true, // allow owner off curve
+);
 
-const tokenFeeAccountInstruction = await token.createAssociatedTokenAccountInstruction(
+const tokenFeeAccountInstruction =
+  await token.createAssociatedTokenAccountInstruction(
     wallet.publicKey, // payer
     tokenFeeAccountAddress, // ata
     feeOwner, // owner
-    poolTokenMint // mint
-)
+    poolTokenMint, // mint
+  );
 
-transaction.add(tokenFeeAccountInstruction)
+transaction.add(tokenFeeAccountInstruction);
 ```
 
 ### Create the swap pool
 
 With all of the prerequisite accounts created, you can create the swap pool initialization instruction using `TokenSwap.createInitSwapInstruction` from the `spl-token-swap` library.
 
-This function takes *a lot* of arguments. Let's talk through them.
+This function takes _a lot_ of arguments. Let's talk through them.
 
 The first 7 arguments are the prerequisite token accounts we just discussed.
 
@@ -194,33 +207,33 @@ Next, there are 4 pairs of number arguments representing numerators and denomina
 3. **Owner withdraw fee** - extra LP-tokens that are sent to the owner on every withdrawal
 4. **Host fee** - a proportion of the owner trade fees, sent to an extra host token account provided during the trade. This fee incentives external parties (such as a decentralized exchange) to provide frontends for the swap pool and rewards them with a portion.
 
-When using a swap program deployed and maintained by a third party, these fees may or may not be fixed such that you *must* input the correct arguments. You'll need to check the implementation of the backing program.
+When using a swap program deployed and maintained by a third party, these fees may or may not be fixed such that you _must_ input the correct arguments. You'll need to check the implementation of the backing program.
 
 Lastly, there's the curve type, which we'll discuss further later in the lesson.
 
 ```tsx
 const createSwapInstruction = TokenSwap.createInitSwapInstruction(
-    tokenSwapStateAccount,      // Token swap state account
-    swapAuthority,              // Swap pool authority
-    poolTokenA,                 // Token A token account
-    poolTokenB,                 // Token B token account
-    poolTokenMint,              // Swap pool token mint
-    tokenFeeAccountAddress,     // Token fee account
-    tokenAccountPool.publicKey, // Swap pool token account
-    token.TOKEN_PROGRAM_ID,     // Token Program ID
-    TOKEN_SWAP_PROGRAM_ID,      // Token Swap Program ID
-    0,                          // Trade fee numerator
-    10000,                      // Trade fee denominator
-    5,                          // Owner trade fee numerator
-    10000,                      // Owner trade fee denominator
-    0,                          // Owner withdraw fee numerator
-    0,                          // Owner withdraw fee denominator
-    20,                         // Host fee numerator
-    100,                        // Host fee denominator
-    CurveType.ConstantProduct   // Curve type
-)
+  tokenSwapStateAccount, // Token swap state account
+  swapAuthority, // Swap pool authority
+  poolTokenA, // Token A token account
+  poolTokenB, // Token B token account
+  poolTokenMint, // Swap pool token mint
+  tokenFeeAccountAddress, // Token fee account
+  tokenAccountPool.publicKey, // Swap pool token account
+  token.TOKEN_PROGRAM_ID, // Token Program ID
+  TOKEN_SWAP_PROGRAM_ID, // Token Swap Program ID
+  0, // Trade fee numerator
+  10000, // Trade fee denominator
+  5, // Owner trade fee numerator
+  10000, // Owner trade fee denominator
+  0, // Owner withdraw fee numerator
+  0, // Owner withdraw fee denominator
+  20, // Host fee numerator
+  100, // Host fee denominator
+  CurveType.ConstantProduct, // Curve type
+);
 
-transaction.add(createSwapInstruction)
+transaction.add(createSwapInstruction);
 ```
 
 When a transaction with these instructions successfully executes, the swap pool is created and ready to be used.
@@ -228,6 +241,7 @@ When a transaction with these instructions successfully executes, the swap pool 
 ## Interacting with Swap Pools
 
 Once the swap pool is initialized, the Token Swap Program has a few different instructions for using a swap pool. These include:
+
 1. Executing a swap
 2. Depositing liquidity
 3. Withdrawing liquidity
@@ -239,6 +253,7 @@ Users can immediately begin trading on a swap pool using the swap instruction. 
 Since Solana programs require all accounts to be declared in the instruction, users need to gather all account information from the token swap state account: the token A and B accounts, pool token mint, and fee account.
 
 We swap tokens using the `TokenSwap.swapInstruction` helper function which requires the following arguments:
+
 1. `tokenSwap` - the token swap state account
 2. `authority` - the swap pool authority
 3. `userTransferAuthority` - the delegate over the user token account
@@ -258,23 +273,23 @@ The instruction for swapping token A for token B will look like this:
 
 ```tsx
 const swapInstruction = TokenSwap.swapInstruction(
-    tokenSwapStateAccount,
-    swapAuthority,
-    userPublicKey,
-    userTokenA,
-    poolTokenA,
-    poolTokenB,
-    userTokenB,
-    poolMint,
-    feeAccount,
-    null,
-    TOKEN_SWAP_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-    amount * 10 ** MintInfoTokenA.decimals,
-    0
-)
+  tokenSwapStateAccount,
+  swapAuthority,
+  userPublicKey,
+  userTokenA,
+  poolTokenA,
+  poolTokenB,
+  userTokenB,
+  poolMint,
+  feeAccount,
+  null,
+  TOKEN_SWAP_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  amount * 10 ** MintInfoTokenA.decimals,
+  0,
+);
 
-transaction.add(swapInstruction)
+transaction.add(swapInstruction);
 ```
 
 ### Deposit liquidity
@@ -284,6 +299,7 @@ The Token Swap Program has two variations of deposit instructions. One allows us
 In order to deposit liquidity to both sides of the swap pool, a user’s wallet must have a sufficient amount of each token. When depositing both tokens, instead of providing the amount of each token to deposit, the user specifies the amount of LP-tokens they would like to receive. The Token Swap Program then calculates the amount of each token that a depositor will receive given the pool's curve and current liquidity.
 
 We can deposit both tokens at the same time using the `TokenSwap.depositAllTokenTypesInstruction` helper function which requires the following arguments:
+
 1. `tokenSwap` - the token swap state account
 2. `authority` - the swap pool authority
 3. `userTransferAuthority` - the authority over the user token accounts
@@ -305,43 +321,43 @@ The instruction for depositing both token A and token B will look like this:
 
 ```tsx
 const instruction = TokenSwap.depositAllTokenTypesInstruction(
-    tokenSwapStateAccount,
-    swapAuthority,
-    userPublicKey,
-    userTokenA,
-    userTokenB,
-    poolTokenA,
-    poolTokenB,
-    poolMint,
-    userPoolToken,
-    TOKEN_SWAP_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-    poolTokenAmount * 10 ** MintInfoPoolToken.decimals,
-    100e9,
-    100e9
-)
+  tokenSwapStateAccount,
+  swapAuthority,
+  userPublicKey,
+  userTokenA,
+  userTokenB,
+  poolTokenA,
+  poolTokenB,
+  poolMint,
+  userPoolToken,
+  TOKEN_SWAP_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  poolTokenAmount * 10 ** MintInfoPoolToken.decimals,
+  100e9,
+  100e9,
+);
 
-transaction.add(instruction)
+transaction.add(instruction);
 ```
 
 We can deposit tokens to only one side of the swap pool in a similar way using the `TokenSwap.depositSingleTokenTypeExactAmountInInstruction`. The main difference is that the last argument in the instruction is `minimumPoolTokenAmount`. When depositing to only one side of the swap pool, the user specifies exactly how many tokens to deposit. In turn, the Token Swap Program calculates the amount of LP-tokens to mint the user for their deposit. An instruction depositing only Token A will look like this:
 
 ```tsx
 const instruction = TokenSwap.depositSingleTokenTypeExactAmountInInstruction(
-    tokenSwapStateAccount,
-    swapAuthority,
-    userPublicKey,
-    userTokenA,
-    poolTokenA,
-    poolMint,
-    userPoolToken,
-    TOKEN_SWAP_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-    DepositAmountTokenA * 10 ** MintInfoTokenA.decimals,
-    0,
-)
+  tokenSwapStateAccount,
+  swapAuthority,
+  userPublicKey,
+  userTokenA,
+  poolTokenA,
+  poolMint,
+  userPoolToken,
+  TOKEN_SWAP_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  DepositAmountTokenA * 10 ** MintInfoTokenA.decimals,
+  0,
+);
 
-transaction.add(instruction)
+transaction.add(instruction);
 ```
 
 ### Withdraw liquidity
@@ -351,6 +367,7 @@ In exchange for providing liquidity, depositors receive LP-tokens representing t
 The Token Swap Program has two variations of withdraw instructions. One allows users to only withdraw tokens from one side of the swap pool at a time. The other allows for withdraws from both sides of the swap pool at the same time.
 
 We can withdraw both tokens at the same time using the `TokenSwap.withdrawAllTokenTypesInstruction` helper function which requires the following arguements:
+
 1. `tokenSwap` - the token swap state account
 2. `authority` - the swap pool authority
 3. `userTransferAuthority` - the authority over the user token accounts
@@ -373,44 +390,44 @@ The instruction for depositing both token A and token B will look like this:
 
 ```tsx
 const instruction = TokenSwap.withdrawAllTokenTypesInstruction(
-    tokenSwapStateAccount,
-    swapAuthority,
-    userPublicKey,
-    poolMint,
-    feeAccount,
-    userPoolToken,
-    poolTokenA,
-    poolTokenB,
-    userTokenA,
-    userTokenB,
-    TOKEN_SWAP_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-    poolTokenAmount * 10 ** MintInfoPoolToken.decimals,
-    0,
-    0
-)
+  tokenSwapStateAccount,
+  swapAuthority,
+  userPublicKey,
+  poolMint,
+  feeAccount,
+  userPoolToken,
+  poolTokenA,
+  poolTokenB,
+  userTokenA,
+  userTokenB,
+  TOKEN_SWAP_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  poolTokenAmount * 10 ** MintInfoPoolToken.decimals,
+  0,
+  0,
+);
 
-transaction.add(instruction)
+transaction.add(instruction);
 ```
 
 We can withdraw tokens from only one side of the swap pool in a similar way using the `TokenSwap.withdrawSingleTokenTypeExactAmountOut`. The main difference is that the last argument in the instruction is `maximumPoolTokenAmount`. When withdrawing only one side of the swap pool, the user specifies exact how many tokens to withdraw. In turn, the Token Swap Program calculates the amount of LP-tokens to mint the user must burn. An instruction withdrawing only Token B will look like this:
 
 ```tsx
 const instruction = TokenSwap.depositSingleTokenTypeExactAmountInInstruction(
-    tokenSwapStateAccount,
-    swapAuthority,
-    userPublicKey,
-    poolMint,
-    feeAccount,
-    poolTokenB,
-    userTokenB,
-    TOKEN_SWAP_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-    WithdrawAmountTokenB * 10 ** MintInfoTokenB.decimals,
-    100e9,
-)
+  tokenSwapStateAccount,
+  swapAuthority,
+  userPublicKey,
+  poolMint,
+  feeAccount,
+  poolTokenB,
+  userTokenB,
+  TOKEN_SWAP_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  WithdrawAmountTokenB * 10 ** MintInfoTokenB.decimals,
+  100e9,
+);
 
-transaction.add(instruction)
+transaction.add(instruction);
 ```
 
 ## Curves
@@ -469,6 +486,7 @@ Of the two variations of deposit instructions on the Token Swap Program, we'll b
 The deposit instruction should be added inside the `/components/Deposit.tsx` file inside the `handleTransactionSubmit` function. This function is called when the user clicks the Deposit button.
 
 We’ll start by deriving three associated token account addresses:
+
 1. The associated token account corresponding to the user's wallet address and Krypt Coin
 2. The associated token account corresponding to the user's wallet address and Scrooge Coin
 3. The associated token account corresponding to the user's wallet address and the swap pools LP token
@@ -479,18 +497,24 @@ We'll also need the data associated with the pool token mint to adjust the user 
 
 ```tsx
 const handleTransactionSubmit = async (deposit: DepositAllSchema) => {
-    if (!publicKey) {
-        alert('Please connect your wallet!')
-        return
-    }
-	// these are the accounts that hold the tokens
-    const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey)
-    const scroogeATA = await token.getAssociatedTokenAddress(ScroogeCoinMint, publicKey)
-	const tokenAccountPool = await token.getAssociatedTokenAddress(pool_mint, publicKey)
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
+  // these are the accounts that hold the tokens
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    pool_mint,
+    publicKey,
+  );
 
-    // poolMintInfo holds data we've fetched for the pool token mint
-    const poolMintInfo = await token.getMint(connection, poolMint)
-}
+  // poolMintInfo holds data we've fetched for the pool token mint
+  const poolMintInfo = await token.getMint(connection, poolMint);
+};
 ```
 
 Next, we need to check if the `tokenAccountPool` address we just derived has been created. We'll use the `getAccountInfo` function from the `@solana/web3` library to get the account info associated with `tokenAccountPool`. This function will return an `AccountInfo` struct if the account exists or `null` otherwise. If `null` is returned, we'll need to create the account.
@@ -499,107 +523,108 @@ Since the `handleTransactionSubmit` function is already going to be submitting a
 
 ```tsx
 const handleTransactionSubmit = async () => {
-    if (!publicKey) {
-        alert('Please connect your wallet!')
-        return
-    }
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-    const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey)
-    const scroogeATA = await token.getAssociatedTokenAddress(ScroogeCoinMint, publicKey)
-    const tokenAccountPool = await token.getAssociatedTokenAddress(pool_mint, publicKey)
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    pool_mint,
+    publicKey,
+  );
 
-    const poolMintInfo = await token.getMint(connection, poolMint)
+  const poolMintInfo = await token.getMint(connection, poolMint);
 
-    const transaction = new Web3.Transaction()
+  const transaction = new Web3.Transaction();
 
-    let account = await connection.getAccountInfo(tokenAccountPool)
+  let account = await connection.getAccountInfo(tokenAccountPool);
 
-    if (account == null) {
-        const createATAInstruction =
-            token.createAssociatedTokenAccountInstruction(
-                publicKey,
-                tokenAccountPool,
-                publicKey,
-                pool_mint
-            )
-        transaction.add(createATAInstruction)
-    }
-}
+  if (account == null) {
+    const createATAInstruction = token.createAssociatedTokenAccountInstruction(
+      publicKey,
+      tokenAccountPool,
+      publicKey,
+      pool_mint,
+    );
+    transaction.add(createATAInstruction);
+  }
+};
 ```
 
 Finally, we can create the deposit instruction using the `spl-token-swap` library's `TokenSwap.depositAllTokenTypesInstruction` helper function. We then add the instruction and submit the transaction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
-    if (!publicKey) {
-        alert("Please connect your wallet!")
-        return
-    }
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-    const kryptATA = await token.getAssociatedTokenAddress(
-        kryptMint,
-        publicKey
-    )
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
 
-    const scroogeATA = await token.getAssociatedTokenAddress(
-        ScroogeCoinMint,
-        publicKey
-    )
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
 
-    const tokenAccountPool = await token.getAssociatedTokenAddress(
-        poolMint,
-        publicKey
-    )
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    poolMint,
+    publicKey,
+  );
 
-    const poolMintInfo = await token.getMint(connection, poolMint)
+  const poolMintInfo = await token.getMint(connection, poolMint);
 
-    const transaction = new Web3.Transaction()
+  const transaction = new Web3.Transaction();
 
-    let account = await connection.getAccountInfo(tokenAccountPool)
+  let account = await connection.getAccountInfo(tokenAccountPool);
 
-    if (account == null) {
-        const createATAInstruction =
-            token.createAssociatedTokenAccountInstruction(
-                publicKey,
-                tokenAccountPool,
-                publicKey,
-                poolMint
-            )
-        transaction.add(createATAInstruction)
-    }
+  if (account == null) {
+    const createATAInstruction = token.createAssociatedTokenAccountInstruction(
+      publicKey,
+      tokenAccountPool,
+      publicKey,
+      poolMint,
+    );
+    transaction.add(createATAInstruction);
+  }
 
-    const instruction = TokenSwap.depositAllTokenTypesInstruction(
-        tokenSwapStateAccount,
-        swapAuthority,
-        publicKey,
-        kryptATA,
-        scroogeATA,
-        poolKryptAccount,
-        poolScroogeAccount,
-        poolMint,
-        tokenAccountPool,
-        TOKEN_SWAP_PROGRAM_ID,
-        token.TOKEN_PROGRAM_ID,
-        poolTokenAmount * 10 ** poolMintInfo.decimals,
-        100e9,
-        100e9
-    )
+  const instruction = TokenSwap.depositAllTokenTypesInstruction(
+    tokenSwapStateAccount,
+    swapAuthority,
+    publicKey,
+    kryptATA,
+    scroogeATA,
+    poolKryptAccount,
+    poolScroogeAccount,
+    poolMint,
+    tokenAccountPool,
+    TOKEN_SWAP_PROGRAM_ID,
+    token.TOKEN_PROGRAM_ID,
+    poolTokenAmount * 10 ** poolMintInfo.decimals,
+    100e9,
+    100e9,
+  );
 
-    transaction.add(instruction)
+  transaction.add(instruction);
 
-    try {
-        let txid = await sendTransaction(transaction, connection)
-        alert(
-            `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`
-        )
-        console.log(
-            `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`
-        )
-    } catch (e) {
-        console.log(JSON.stringify(e))
-        alert(JSON.stringify(e))
-    }
-}
+  try {
+    let txid = await sendTransaction(transaction, connection);
+    alert(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+    console.log(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+  } catch (e) {
+    console.log(JSON.stringify(e));
+    alert(JSON.stringify(e));
+  }
+};
 ```
 
 With the exception of the user’s `publickey` and their derived associated token accounts (for Krypt Coin, Scrooge Coin, and the pool's LP-token), notice that all the accounts are constants for this swap pool and are defined in the `const.ts` file.
@@ -618,105 +643,106 @@ We’ll start by deriving the three associated token account addresses, fetching
 
 ```tsx
 const handleTransactionSubmit = async () => {
-    if (!publicKey) {
-        alert('Please connect your wallet!')
-        return
-    }
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-    const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey)
-    const scroogeATA = await token.getAssociatedTokenAddress(ScroogeCoinMint, publicKey)
-    const tokenAccountPool = await token.getAssociatedTokenAddress(pool_mint, publicKey)
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    pool_mint,
+    publicKey,
+  );
 
-    const poolMintInfo = await token.getMint(connection, poolMint)
+  const poolMintInfo = await token.getMint(connection, poolMint);
 
-    const transaction = new Web3.Transaction()
+  const transaction = new Web3.Transaction();
 
-    let account = await connection.getAccountInfo(tokenAccountPool)
+  let account = await connection.getAccountInfo(tokenAccountPool);
 
-    if (account == null) {
-        const createATAInstruction =
-            token.createAssociatedTokenAccountInstruction(
-                publicKey,
-                tokenAccountPool,
-                publicKey,
-                pool_mint
-            )
-        transaction.add(createATAInstruction)
-    }
-}
+  if (account == null) {
+    const createATAInstruction = token.createAssociatedTokenAccountInstruction(
+      publicKey,
+      tokenAccountPool,
+      publicKey,
+      pool_mint,
+    );
+    transaction.add(createATAInstruction);
+  }
+};
 ```
 
 Next, we create the withdraw instruction using the `spl-token-swap` library's `TokenSwap.withdrawAllTokenTypesInstruction` helper function. We then add the instruction and submit the transaction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
-    if (!publicKey) {
-        alert("Please connect your wallet!")
-        return
-    }
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-    const kryptATA = await token.getAssociatedTokenAddress(
-        kryptMint,
-        publicKey
-    )
-    const scroogeATA = await token.getAssociatedTokenAddress(
-        ScroogeCoinMint,
-        publicKey
-    )
-    const tokenAccountPool = await token.getAssociatedTokenAddress(
-        poolMint,
-        publicKey
-    )
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    poolMint,
+    publicKey,
+  );
 
-    const poolMintInfo = await token.getMint(connection, poolMint)
+  const poolMintInfo = await token.getMint(connection, poolMint);
 
-    const transaction = new Web3.Transaction()
+  const transaction = new Web3.Transaction();
 
-    let account = await connection.getAccountInfo(tokenAccountPool)
+  let account = await connection.getAccountInfo(tokenAccountPool);
 
-    if (account == null) {
-        const createATAInstruction =
-            token.createAssociatedTokenAccountInstruction(
-                publicKey,
-                tokenAccountPool,
-                publicKey,
-                poolMint
-            )
-        transaction.add(createATAInstruction)
-    }
+  if (account == null) {
+    const createATAInstruction = token.createAssociatedTokenAccountInstruction(
+      publicKey,
+      tokenAccountPool,
+      publicKey,
+      poolMint,
+    );
+    transaction.add(createATAInstruction);
+  }
 
-    const instruction = TokenSwap.withdrawAllTokenTypesInstruction(
-        tokenSwapStateAccount,
-        swapAuthority,
-        publicKey,
-        poolMint,
-        feeAccount,
-        tokenAccountPool,
-        poolKryptAccount,
-        poolScroogeAccount,
-        kryptATA,
-        scroogeATA,
-        TOKEN_SWAP_PROGRAM_ID,
-        TOKEN_PROGRAM_ID,
-        poolTokenAmount * 10 ** poolMintInfo.decimals,
-        0,
-        0
-    )
+  const instruction = TokenSwap.withdrawAllTokenTypesInstruction(
+    tokenSwapStateAccount,
+    swapAuthority,
+    publicKey,
+    poolMint,
+    feeAccount,
+    tokenAccountPool,
+    poolKryptAccount,
+    poolScroogeAccount,
+    kryptATA,
+    scroogeATA,
+    TOKEN_SWAP_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    poolTokenAmount * 10 ** poolMintInfo.decimals,
+    0,
+    0,
+  );
 
-    transaction.add(instruction)
-    try {
-        let txid = await sendTransaction(transaction, connection)
-        alert(
-            `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`
-        )
-        console.log(
-            `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`
-        )
-    } catch (e) {
-        console.log(JSON.stringify(e))
-        alert(JSON.stringify(e))
-    }
-}
+  transaction.add(instruction);
+  try {
+    let txid = await sendTransaction(transaction, connection);
+    alert(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+    console.log(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+  } catch (e) {
+    console.log(JSON.stringify(e));
+    alert(JSON.stringify(e));
+  }
+};
 ```
 
 Notice the ordering of accounts is different for the withdraw transaction and there is an additional `feeAccount` provided this time. This `feeAccount` is the destination for the fee that must be paid by the user for withdrawing liquidity from the pools.
@@ -725,123 +751,122 @@ Notice the ordering of accounts is different for the withdraw transaction and th
 
 Now it's time to implement the actual purpose of this program - the swap instruction!
 
-Note that our UI has a dropdown to allow users to select which token they would like to swap *from*, so we will have to create our instruction differently based on what the user selects.
+Note that our UI has a dropdown to allow users to select which token they would like to swap _from_, so we will have to create our instruction differently based on what the user selects.
 
 We’ll do this inside the `handleTransactionSubmit` function of the `/components/Swap.tsx` file. Once again, we will have to derive the user’s `Associated Token Addresses` for each token mint (Krypt Coin, Scrooge Coin, and Pool Token) and create the `tokenAccountPool` if it does not already exist. Additionally, we'll fetch the data for both the Krypt Coin and Scrooge Coin to account for the decimal precision of the tokens.
 
 ```tsx
 const handleTransactionSubmit = async () => {
-    if (!publicKey) {
-      alert("Please connect your wallet!")
-      return
-    }
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-    const kryptMintInfo = await token.getMint(connection, kryptMint)
-    const ScroogeCoinMintInfo = await token.getMint(connection, ScroogeCoinMint)
+  const kryptMintInfo = await token.getMint(connection, kryptMint);
+  const ScroogeCoinMintInfo = await token.getMint(connection, ScroogeCoinMint);
 
-    const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey)
-    const scroogeATA = await token.getAssociatedTokenAddress(ScroogeCoinMint, publicKey)
-    const tokenAccountPool = await token.getAssociatedTokenAddress(poolMint, publicKey)
-}
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    poolMint,
+    publicKey,
+  );
+};
 ```
 
 From here, the user’s input will determine our path of execution. The user's choice is saved to the `mint` property, so we'll use this to branch between each possible instruction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
-    if (!publicKey) {
-        alert("Please connect your wallet!")
-        return
-    }
+  if (!publicKey) {
+    alert("Please connect your wallet!");
+    return;
+  }
 
-    const kryptMintInfo = await token.getMint(connection, kryptMint)
-    const ScroogeCoinMintInfo = await token.getMint(
-        connection,
-        ScroogeCoinMint
-    )
+  const kryptMintInfo = await token.getMint(connection, kryptMint);
+  const ScroogeCoinMintInfo = await token.getMint(connection, ScroogeCoinMint);
 
-    const kryptATA = await token.getAssociatedTokenAddress(
-        kryptMint,
-        publicKey
-    )
-    const scroogeATA = await token.getAssociatedTokenAddress(
-        ScroogeCoinMint,
-        publicKey
-    )
-    const tokenAccountPool = await token.getAssociatedTokenAddress(
-        poolMint,
-        publicKey
-    )
+  const kryptATA = await token.getAssociatedTokenAddress(kryptMint, publicKey);
+  const scroogeATA = await token.getAssociatedTokenAddress(
+    ScroogeCoinMint,
+    publicKey,
+  );
+  const tokenAccountPool = await token.getAssociatedTokenAddress(
+    poolMint,
+    publicKey,
+  );
 
-    const transaction = new Web3.Transaction()
+  const transaction = new Web3.Transaction();
 
-    let account = await connection.getAccountInfo(tokenAccountPool)
+  let account = await connection.getAccountInfo(tokenAccountPool);
 
-    if (account == null) {
-        const createATAInstruction =
-            token.createAssociatedTokenAccountInstruction(
-                publicKey,
-                tokenAccountPool,
-                publicKey,
-                poolMint
-            )
-        transaction.add(createATAInstruction)
-    }
+  if (account == null) {
+    const createATAInstruction = token.createAssociatedTokenAccountInstruction(
+      publicKey,
+      tokenAccountPool,
+      publicKey,
+      poolMint,
+    );
+    transaction.add(createATAInstruction);
+  }
 
-    // check which direction to swap
-    if (mint == "option1") {
-        const instruction = TokenSwap.swapInstruction(
-            tokenSwapStateAccount,
-            swapAuthority,
-            publicKey,
-            kryptATA,
-            poolKryptAccount,
-            poolScroogeAccount,
-            scroogeATA,
-            poolMint,
-            feeAccount,
-            null,
-            TOKEN_SWAP_PROGRAM_ID,
-            TOKEN_PROGRAM_ID,
-            amount * 10 ** kryptMintInfo.decimals,
-            0
-        )
+  // check which direction to swap
+  if (mint == "option1") {
+    const instruction = TokenSwap.swapInstruction(
+      tokenSwapStateAccount,
+      swapAuthority,
+      publicKey,
+      kryptATA,
+      poolKryptAccount,
+      poolScroogeAccount,
+      scroogeATA,
+      poolMint,
+      feeAccount,
+      null,
+      TOKEN_SWAP_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      amount * 10 ** kryptMintInfo.decimals,
+      0,
+    );
 
-        transaction.add(instruction)
-    } else if (mint == "option2") {
-        const instruction = TokenSwap.swapInstruction(
-            tokenSwapStateAccount,
-            swapAuthority,
-            publicKey,
-            scroogeATA,
-            poolScroogeAccount,
-            poolKryptAccount,
-            kryptATA,
-            poolMint,
-            feeAccount,
-            null,
-            TOKEN_SWAP_PROGRAM_ID,
-            TOKEN_PROGRAM_ID,
-            amount * 10 ** ScroogeCoinMintInfo.decimals,
-            0
-        )
+    transaction.add(instruction);
+  } else if (mint == "option2") {
+    const instruction = TokenSwap.swapInstruction(
+      tokenSwapStateAccount,
+      swapAuthority,
+      publicKey,
+      scroogeATA,
+      poolScroogeAccount,
+      poolKryptAccount,
+      kryptATA,
+      poolMint,
+      feeAccount,
+      null,
+      TOKEN_SWAP_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      amount * 10 ** ScroogeCoinMintInfo.decimals,
+      0,
+    );
 
-        transaction.add(instruction)
-    }
+    transaction.add(instruction);
+  }
 
-    try {
-        let txid = await sendTransaction(transaction, connection)
-        alert(
-            `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`
-        )
-        console.log(
-            `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`
-        )
-    } catch (e) {
-        console.log(JSON.stringify(e))
-        alert(JSON.stringify(e))
-    }
-}
+  try {
+    let txid = await sendTransaction(transaction, connection);
+    alert(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+    console.log(
+      `Transaction submitted: https://explorer.solana.com/tx/${txid}?cluster=devnet`,
+    );
+  } catch (e) {
+    console.log(JSON.stringify(e));
+    alert(JSON.stringify(e));
+  }
+};
 ```
 
 And that’s it! Once you have the swap instruction implemented, the UI should be fully functional and you can airdrop yourself tokens, deposit liquidity, withdraw your liquidity, and swap from token to token!

--- a/developers/courses/solana-course/content/token-swap.md
+++ b/developers/courses/solana-course/content/token-swap.md
@@ -9,53 +9,114 @@ objectives:
 
 # TL;DR
 
-- The **Token Swap Program** is an SPL contract deployed to Devnet available for testing and experimentation by developers and protocols. For production use cases, use your own deployment or one regularly maintained by a reputable service.
-- The program accepts six different **instructions**, all of which we will explore in this lesson.
-- Developers are able to create and use **liquidity pools** to swap between any SPL token that they wish.
-- The program uses a mathematical formula called "**curve**" to calculate the price of all trades. Curves aim to mimic normal market dynamics: for example, as traders buy a lot of one token type, the value of the other token type goes up.
+- The **Token Swap Program** is an SPL contract deployed to Devnet available for
+  testing and experimentation by developers and protocols. For production use
+  cases, use your own deployment or one regularly maintained by a reputable
+  service.
+- The program accepts six different **instructions**, all of which we will
+  explore in this lesson.
+- Developers are able to create and use **liquidity pools** to swap between any
+  SPL token that they wish.
+- The program uses a mathematical formula called "**curve**" to calculate the
+  price of all trades. Curves aim to mimic normal market dynamics: for example,
+  as traders buy a lot of one token type, the value of the other token type goes
+  up.
 
 # Overview
 
 ## Swap Pools
 
-Before we get into how to create and interact with swap pools on Solana, it’s important we understand the basics of what a swap pool is. A swap pool is an aggregation of two different tokens with the purpose of providing liquidity to facilitate exchange between each token.
+Before we get into how to create and interact with swap pools on Solana, it’s
+important we understand the basics of what a swap pool is. A swap pool is an
+aggregation of two different tokens with the purpose of providing liquidity to
+facilitate exchange between each token.
 
-Users provide liquidity to these pools by depositing their own tokens into each pool. These users are called liquidity providers. When a liquidity provider (or LP) deposits some tokens to the swap pool, LP-tokens are minted that represent the LP's fractional ownership in the pool.
+Users provide liquidity to these pools by depositing their own tokens into each
+pool. These users are called liquidity providers. When a liquidity provider (or
+LP) deposits some tokens to the swap pool, LP-tokens are minted that represent
+the LP's fractional ownership in the pool.
 
-Most swap pools charge a trading fee for facilitating each swap. These fees are then paid out to the LP’s in proportion to the amount of liquidity they are providing in the pool. This provides incentive for LP's to provide liquidity to the pool.
+Most swap pools charge a trading fee for facilitating each swap. These fees are
+then paid out to the LP’s in proportion to the amount of liquidity they are
+providing in the pool. This provides incentive for LP's to provide liquidity to
+the pool.
 
-When an LP is ready to withdraw their deposited liquidity, their LP-tokens are burned and tokens from the pool (proportional to the amount of LP-tokens burned) are sent to their wallet.
+When an LP is ready to withdraw their deposited liquidity, their LP-tokens are
+burned and tokens from the pool (proportional to the amount of LP-tokens burned)
+are sent to their wallet.
 
-The purpose of swap pools is to facilitate decentralized trade between users. In traditional finance, users execute trades like this through a centralized exchange on a central limit [order book](https://www.investopedia.com/terms/o/order-book.asp). Generally, this requires a trusted third-party intermediary.
+The purpose of swap pools is to facilitate decentralized trade between users. In
+traditional finance, users execute trades like this through a centralized
+exchange on a central limit
+[order book](https://www.investopedia.com/terms/o/order-book.asp). Generally,
+this requires a trusted third-party intermediary.
 
-Due to the decentralized nature of cryptocurrency, however, we now have a new way to facilitate trades. Many protocols decentralized exchanges have been built to take advantage of this. [Project Serum](https://www.projectserum.com/) is an example of such a decentralized central limit order book built on Solana.
+Due to the decentralized nature of cryptocurrency, however, we now have a new
+way to facilitate trades. Many protocols decentralized exchanges have been built
+to take advantage of this. [Project Serum](https://www.projectserum.com/) is an
+example of such a decentralized central limit order book built on Solana.
 
-Since swap pools are completely decentralized, anybody can issue instructions to the swap program to create a new swap pool between any SPL tokens they wish. This is a massive lift beyond traditional finance. Swap pools and Automated Market Makers (AMMs) are one of DeFi's most fascinating and complex topics. The nitty-gritty details of how they work are outside the scope of this lesson, but there is a ton of material out there available to you if you’re interested in learning more. For example, the Solana Token Swap Program was heavily inspired by [Uniswap](https://uniswap.org/) and [Balancer](https://balancer.fi/), each of which provide excellent documentation that you can read through.
+Since swap pools are completely decentralized, anybody can issue instructions to
+the swap program to create a new swap pool between any SPL tokens they wish.
+This is a massive lift beyond traditional finance. Swap pools and Automated
+Market Makers (AMMs) are one of DeFi's most fascinating and complex topics. The
+nitty-gritty details of how they work are outside the scope of this lesson, but
+there is a ton of material out there available to you if you’re interested in
+learning more. For example, the Solana Token Swap Program was heavily inspired
+by [Uniswap](https://uniswap.org/) and [Balancer](https://balancer.fi/), each of
+which provide excellent documentation that you can read through.
 
 ## Token Swap Program and `@solana/spl-token-swap`
 
-Unlike the Token Program, there is no Solana-maintained deployment of the Token Swap Program. Rather, Solana provides [source code](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program) for the Token Swap Program as a reference implementation that you can fork and deploy yourself. You can also use a token swap program maintained by a third party organization you trust. Throughout this lesson, we'll be using the deployment maintained by Serum at address `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8`.
+Unlike the Token Program, there is no Solana-maintained deployment of the Token
+Swap Program. Rather, Solana provides
+[source code](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
+for the Token Swap Program as a reference implementation that you can fork and
+deploy yourself. You can also use a token swap program maintained by a third
+party organization you trust. Throughout this lesson, we'll be using the
+deployment maintained by Serum at address
+`SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8`.
 
-Solana also maintains the `@solana/spl-token-swap` JS library. This library provides helper functions for interacting with a token swap program. Each helper function takes an argument representing a token swap program ID. As long as the program you use accepts the Token Swap instructions, you can use the `@solana/spl-token-swap` library with it.
+Solana also maintains the `@solana/spl-token-swap` JS library. This library
+provides helper functions for interacting with a token swap program. Each helper
+function takes an argument representing a token swap program ID. As long as the
+program you use accepts the Token Swap instructions, you can use the
+`@solana/spl-token-swap` library with it.
 
 ## Creating a Swap Pool
 
-Creating swap pools with the SPL Token Swap Program really showcases the account, instruction, and authorization models on Solana. This lesson will combine and build on top of a lot of what we have learned so far in the course. For operations specific to the Token Swap Program, we'll use the `@solana/spl-token-swap` library.
+Creating swap pools with the SPL Token Swap Program really showcases the
+account, instruction, and authorization models on Solana. This lesson will
+combine and build on top of a lot of what we have learned so far in the course.
+For operations specific to the Token Swap Program, we'll use the
+`@solana/spl-token-swap` library.
 
-As we talk through creating a swap pool, we'll assume we're creating a swap pool for two tokens named Token A and Token B. Creating the swap pool with the `spl-token-swap` library is as simple as sending a transaction with an instruction created with the `TokenSwap.createInitSwapInstruction` function. However, there are a number of accounts you need to create or derive beforehand that will be needed when creating that instruction:
+As we talk through creating a swap pool, we'll assume we're creating a swap pool
+for two tokens named Token A and Token B. Creating the swap pool with the
+`spl-token-swap` library is as simple as sending a transaction with an
+instruction created with the `TokenSwap.createInitSwapInstruction` function.
+However, there are a number of accounts you need to create or derive beforehand
+that will be needed when creating that instruction:
 
 1. **Token swap state account** - holds information about the swap pool
-2. **Swap pool authority** - the PDA used to sign transactions on behalf of the swap program
-3. **Token accounts for Token A and Token B** - token accounts that will hold tokens A and B for the pool
+2. **Swap pool authority** - the PDA used to sign transactions on behalf of the
+   swap program
+3. **Token accounts for Token A and Token B** - token accounts that will hold
+   tokens A and B for the pool
 4. **Pool token mint** - the mint for the swap pool's LP-token
-5. **Pool token account** - the token account for the initial minting of the pool token mint when the swap account is created
-6. **Pool token fee account** - the account that gets paid the swap pool's trading fees
+5. **Pool token account** - the token account for the initial minting of the
+   pool token mint when the swap account is created
+6. **Pool token fee account** - the account that gets paid the swap pool's
+   trading fees
 
 ### Token Swap State Account
 
-Before you can create a swap pool, you'll need to create a token swap state account. This account will be used to hold information about the swap pool itself.
+Before you can create a swap pool, you'll need to create a token swap state
+account. This account will be used to hold information about the swap pool
+itself.
 
-To create the token swap state account, you use the `SystemProgram` instruction `createAccount`.
+To create the token swap state account, you use the `SystemProgram` instruction
+`createAccount`.
 
 ```tsx
 import * as web3 from "@solana/web3";
@@ -82,15 +143,25 @@ transaction.add(tokenSwapStateAccountInstruction);
 
 A few items to note from this example:
 
-1. You can get the number of lamports required for rent exemption using `TokenSwap.getMinBalanceRentForExemptTokenSwap` from the `spl-token-swap` library.
-2. Similarly, you can use `TokenSwapLayout.span` for the space required on the account.
-3. `programId` must be set to `TOKEN_SWAP_PROGRAM_ID`. This sets the owner of the new account to be the Token Swap Program itself. The Token Swap Program will need to write data to the new account and so must be set as the owner.
+1. You can get the number of lamports required for rent exemption using
+   `TokenSwap.getMinBalanceRentForExemptTokenSwap` from the `spl-token-swap`
+   library.
+2. Similarly, you can use `TokenSwapLayout.span` for the space required on the
+   account.
+3. `programId` must be set to `TOKEN_SWAP_PROGRAM_ID`. This sets the owner of
+   the new account to be the Token Swap Program itself. The Token Swap Program
+   will need to write data to the new account and so must be set as the owner.
 
 ### Swap Pool Authority
 
-The swap pool authority is the account used to sign for transactions on behalf of the swap program. This account is a Program Derived Address (PDA) derived from the Token Swap Program and the token swap state account.
+The swap pool authority is the account used to sign for transactions on behalf
+of the swap program. This account is a Program Derived Address (PDA) derived
+from the Token Swap Program and the token swap state account.
 
-PDAs can only be created by their owning program, so you don't need to create this account directly. You do, however, need to know its public key. You can discover it using the `@solana/web3` library's `PublicKey.findProgramAddress` function.
+PDAs can only be created by their owning program, so you don't need to create
+this account directly. You do, however, need to know its public key. You can
+discover it using the `@solana/web3` library's `PublicKey.findProgramAddress`
+function.
 
 ```tsx
 const [swapAuthority, bump] = await Web3.PublicKey.findProgramAddress(
@@ -99,11 +170,15 @@ const [swapAuthority, bump] = await Web3.PublicKey.findProgramAddress(
 );
 ```
 
-The resulting public key will be used as the authority on a number of the accounts that follow.
+The resulting public key will be used as the authority on a number of the
+accounts that follow.
 
 ### Token accounts for Token A and Token B
 
-Token A and Token B accounts are associated token accounts used for the actual swap pool. These accounts must contain some number of A/B tokens respectively and the swap authority PDA must be marked as the owner of each so that the Token Swap Program can sign for transactions and transfer tokens from each account.
+Token A and Token B accounts are associated token accounts used for the actual
+swap pool. These accounts must contain some number of A/B tokens respectively
+and the swap authority PDA must be marked as the owner of each so that the Token
+Swap Program can sign for transactions and transfer tokens from each account.
 
 ```tsx
 let tokenAAccountAddress = await token.getAssociatedTokenAddress(
@@ -123,11 +198,15 @@ const tokenAAccountInstruction =
 transaction.add(tokenAAccountInstruction);
 ```
 
-If you need a refresher on creating token accounts, have a look at the [Token Program lesson](./token-program.md).
+If you need a refresher on creating token accounts, have a look at the
+[Token Program lesson](./token-program.md).
 
 ### Pool Token Mint
 
-The pool token mint is the mint of the LP-tokens that represent an LP’s ownership in the pool. You create this mint the way you learned in the [Token Program lesson](./token-program.md). For the swap pool to work, the mint authority must be the swap authority account.
+The pool token mint is the mint of the LP-tokens that represent an LP’s
+ownership in the pool. You create this mint the way you learned in the
+[Token Program lesson](./token-program.md). For the swap pool to work, the mint
+authority must be the swap authority account.
 
 ```tsx
 const poolTokenMint = await token.createMint(
@@ -141,7 +220,11 @@ const poolTokenMint = await token.createMint(
 
 ### Pool Token Account
 
-The pool token account is the account that the initial liquidity pool tokens get minted to when the swap account is first created. Subsequent minting of LP-tokens will be minted directly to the account of the user adding liquidity to the pool. Liquidity pool tokens represent ownership in the deposited liquidity in the pool.
+The pool token account is the account that the initial liquidity pool tokens get
+minted to when the swap account is first created. Subsequent minting of
+LP-tokens will be minted directly to the account of the user adding liquidity to
+the pool. Liquidity pool tokens represent ownership in the deposited liquidity
+in the pool.
 
 ```tsx
 const tokenAccountPool = Web3.Keypair.generate();
@@ -166,7 +249,11 @@ transaction.add(initializeTokenAccountPoolInstruction);
 
 ### Pool Token Fee Account
 
-The pool token fee account is the token account that the fees for the token swaps are paid to. For the Serum deployment of the Token Swap Program that we are using, this account must be owned by a specific account defined in the swap program: [HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN](https://explorer.solana.com/address/HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN?cluster=devnet).
+The pool token fee account is the token account that the fees for the token
+swaps are paid to. For the Serum deployment of the Token Swap Program that we
+are using, this account must be owned by a specific account defined in the swap
+program:
+[HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN](https://explorer.solana.com/address/HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN?cluster=devnet).
 
 ```tsx
 const feeOwner = new web3.PublicKey(
@@ -192,22 +279,38 @@ transaction.add(tokenFeeAccountInstruction);
 
 ### Create the swap pool
 
-With all of the prerequisite accounts created, you can create the swap pool initialization instruction using `TokenSwap.createInitSwapInstruction` from the `spl-token-swap` library.
+With all of the prerequisite accounts created, you can create the swap pool
+initialization instruction using `TokenSwap.createInitSwapInstruction` from the
+`spl-token-swap` library.
 
 This function takes _a lot_ of arguments. Let's talk through them.
 
 The first 7 arguments are the prerequisite token accounts we just discussed.
 
-After that comes the constant representing the Token Program ID followed by the constant representing the Token Swap Program ID.
+After that comes the constant representing the Token Program ID followed by the
+constant representing the Token Swap Program ID.
 
-Next, there are 4 pairs of number arguments representing numerators and denominators for the trade fee, owner trade fee, owner withdraw fee, and host fee. The instruction uses the numerator and denominator for each to calculate the percentage of the fee. Lets explain each of the fees:
+Next, there are 4 pairs of number arguments representing numerators and
+denominators for the trade fee, owner trade fee, owner withdraw fee, and host
+fee. The instruction uses the numerator and denominator for each to calculate
+the percentage of the fee. Lets explain each of the fees:
 
-1. **Trade fee** - fees that are retained by the swap pool token accounts during a trade and increase the redeemable value of LP-tokens. This fee rewards users for providing liquidity to the swap pool.
-2. **Owner trade fee** - fees that are retained by the swap pool token accounts during a trade, with the equivalent in LP-tokens minted to the owner of the program
-3. **Owner withdraw fee** - extra LP-tokens that are sent to the owner on every withdrawal
-4. **Host fee** - a proportion of the owner trade fees, sent to an extra host token account provided during the trade. This fee incentives external parties (such as a decentralized exchange) to provide frontends for the swap pool and rewards them with a portion.
+1. **Trade fee** - fees that are retained by the swap pool token accounts during
+   a trade and increase the redeemable value of LP-tokens. This fee rewards
+   users for providing liquidity to the swap pool.
+2. **Owner trade fee** - fees that are retained by the swap pool token accounts
+   during a trade, with the equivalent in LP-tokens minted to the owner of the
+   program
+3. **Owner withdraw fee** - extra LP-tokens that are sent to the owner on every
+   withdrawal
+4. **Host fee** - a proportion of the owner trade fees, sent to an extra host
+   token account provided during the trade. This fee incentives external parties
+   (such as a decentralized exchange) to provide frontends for the swap pool and
+   rewards them with a portion.
 
-When using a swap program deployed and maintained by a third party, these fees may or may not be fixed such that you _must_ input the correct arguments. You'll need to check the implementation of the backing program.
+When using a swap program deployed and maintained by a third party, these fees
+may or may not be fixed such that you _must_ input the correct arguments. You'll
+need to check the implementation of the backing program.
 
 Lastly, there's the curve type, which we'll discuss further later in the lesson.
 
@@ -236,11 +339,13 @@ const createSwapInstruction = TokenSwap.createInitSwapInstruction(
 transaction.add(createSwapInstruction);
 ```
 
-When a transaction with these instructions successfully executes, the swap pool is created and ready to be used.
+When a transaction with these instructions successfully executes, the swap pool
+is created and ready to be used.
 
 ## Interacting with Swap Pools
 
-Once the swap pool is initialized, the Token Swap Program has a few different instructions for using a swap pool. These include:
+Once the swap pool is initialized, the Token Swap Program has a few different
+instructions for using a swap pool. These include:
 
 1. Executing a swap
 2. Depositing liquidity
@@ -248,26 +353,42 @@ Once the swap pool is initialized, the Token Swap Program has a few different in
 
 ### Execute a swap
 
-Users can immediately begin trading on a swap pool using the swap instruction. The swap instruction transfers funds from a user's token account into the swap pool's token account. The swap pool then mints LP-tokens to the user's LP-token account.
+Users can immediately begin trading on a swap pool using the swap instruction.
+The swap instruction transfers funds from a user's token account into the swap
+pool's token account. The swap pool then mints LP-tokens to the user's LP-token
+account.
 
-Since Solana programs require all accounts to be declared in the instruction, users need to gather all account information from the token swap state account: the token A and B accounts, pool token mint, and fee account.
+Since Solana programs require all accounts to be declared in the instruction,
+users need to gather all account information from the token swap state account:
+the token A and B accounts, pool token mint, and fee account.
 
-We swap tokens using the `TokenSwap.swapInstruction` helper function which requires the following arguments:
+We swap tokens using the `TokenSwap.swapInstruction` helper function which
+requires the following arguments:
 
 1. `tokenSwap` - the token swap state account
 2. `authority` - the swap pool authority
 3. `userTransferAuthority` - the delegate over the user token account
 4. `userSource` - user token account to transfer tokens into the swap
-5. `poolSource` - swap pool token account to receive tokens transferred from the user
+5. `poolSource` - swap pool token account to receive tokens transferred from the
+   user
 6. `poolDestination` - swap pool token account to send tokens to the user
-7. `userDestination` - user token account to receive tokens sent from the swap pool
+7. `userDestination` - user token account to receive tokens sent from the swap
+   pool
 8. `poolMint` - the LP-token mint address
 9. `feeAccount` - the token account which receives the owner trade fees
-10. `hostFeeAccount` - the token account which receives the host trade fees (optional parameter), set to null if none is provided
+10. `hostFeeAccount` - the token account which receives the host trade fees
+    (optional parameter), set to null if none is provided
 11. `swapProgramId` - the address of the Token Swap Program
 12. `tokenProgramId` - the address of the Token Program
 13. `amountIn` - amount of tokens the user wants to transfer to the swap pool
-14. `minimumAmountOut` - minimum amount of tokens send to the user token account. This parameter is used to account for slippage. Slippage is the difference between the value of a token when you submit the transaction versus when the order is fulfilled. In this case, the lower the number, the more slippage can possible occur without the transaction failing. Throughout this lesson we'll use 0 for swaps as calculating slippage is outside the scope of this lesson. In a production app, however, it's important to let users specify the amount of slippage they're comfortable with.
+14. `minimumAmountOut` - minimum amount of tokens send to the user token
+    account. This parameter is used to account for slippage. Slippage is the
+    difference between the value of a token when you submit the transaction
+    versus when the order is fulfilled. In this case, the lower the number, the
+    more slippage can possible occur without the transaction failing. Throughout
+    this lesson we'll use 0 for swaps as calculating slippage is outside the
+    scope of this lesson. In a production app, however, it's important to let
+    users specify the amount of slippage they're comfortable with.
 
 The instruction for swapping token A for token B will look like this:
 
@@ -294,17 +415,28 @@ transaction.add(swapInstruction);
 
 ### Deposit liquidity
 
-The Token Swap Program has two variations of deposit instructions. One allows users to only deposit tokens to one side of the swap pool at a time. The other allows for users to deposit to both sides of the swap pool at the same time.
+The Token Swap Program has two variations of deposit instructions. One allows
+users to only deposit tokens to one side of the swap pool at a time. The other
+allows for users to deposit to both sides of the swap pool at the same time.
 
-In order to deposit liquidity to both sides of the swap pool, a user’s wallet must have a sufficient amount of each token. When depositing both tokens, instead of providing the amount of each token to deposit, the user specifies the amount of LP-tokens they would like to receive. The Token Swap Program then calculates the amount of each token that a depositor will receive given the pool's curve and current liquidity.
+In order to deposit liquidity to both sides of the swap pool, a user’s wallet
+must have a sufficient amount of each token. When depositing both tokens,
+instead of providing the amount of each token to deposit, the user specifies the
+amount of LP-tokens they would like to receive. The Token Swap Program then
+calculates the amount of each token that a depositor will receive given the
+pool's curve and current liquidity.
 
-We can deposit both tokens at the same time using the `TokenSwap.depositAllTokenTypesInstruction` helper function which requires the following arguments:
+We can deposit both tokens at the same time using the
+`TokenSwap.depositAllTokenTypesInstruction` helper function which requires the
+following arguments:
 
 1. `tokenSwap` - the token swap state account
 2. `authority` - the swap pool authority
 3. `userTransferAuthority` - the authority over the user token accounts
-4. `sourceA` - user token A account to transfer tokens into the swap pool token A account
-5. `sourceB` - user token B account to transfer tokens into the swap pool token B account
+4. `sourceA` - user token A account to transfer tokens into the swap pool token
+   A account
+5. `sourceB` - user token B account to transfer tokens into the swap pool token
+   B account
 6. `intoA` - swap pool token account A to receive user's token A
 7. `intoB` - swap pool token account B to receive user's token B
 8. `poolToken` - the LP-token mint address
@@ -315,7 +447,10 @@ We can deposit both tokens at the same time using the `TokenSwap.depositAllToken
 13. `maximumTokenA` - maximum amount of token A allowed to deposit
 14. `maximumTokenB` - maximum amount of token A allowed to deposit
 
-The `maximumTokenA` and `maximumTokenB` arguments are used to prevent slippage. The higher the number, the more slippage can possibly occur without a transaction failure. For simplicity, we'll use a very large number for these arguments.
+The `maximumTokenA` and `maximumTokenB` arguments are used to prevent slippage.
+The higher the number, the more slippage can possibly occur without a
+transaction failure. For simplicity, we'll use a very large number for these
+arguments.
 
 The instruction for depositing both token A and token B will look like this:
 
@@ -340,7 +475,13 @@ const instruction = TokenSwap.depositAllTokenTypesInstruction(
 transaction.add(instruction);
 ```
 
-We can deposit tokens to only one side of the swap pool in a similar way using the `TokenSwap.depositSingleTokenTypeExactAmountInInstruction`. The main difference is that the last argument in the instruction is `minimumPoolTokenAmount`. When depositing to only one side of the swap pool, the user specifies exactly how many tokens to deposit. In turn, the Token Swap Program calculates the amount of LP-tokens to mint the user for their deposit. An instruction depositing only Token A will look like this:
+We can deposit tokens to only one side of the swap pool in a similar way using
+the `TokenSwap.depositSingleTokenTypeExactAmountInInstruction`. The main
+difference is that the last argument in the instruction is
+`minimumPoolTokenAmount`. When depositing to only one side of the swap pool, the
+user specifies exactly how many tokens to deposit. In turn, the Token Swap
+Program calculates the amount of LP-tokens to mint the user for their deposit.
+An instruction depositing only Token A will look like this:
 
 ```tsx
 const instruction = TokenSwap.depositSingleTokenTypeExactAmountInInstruction(
@@ -362,11 +503,20 @@ transaction.add(instruction);
 
 ### Withdraw liquidity
 
-In exchange for providing liquidity, depositors receive LP-tokens representing their fractional ownership of all A and B tokens in the pool. At any time, liquidity providers may redeem their LP-token in exchange for tokens A and B at the current "fair" exchange rate as determined by the curve. When liquidity is withdrawn, tokens A and/or B are transferred into the user's token accounts and the user's LP-token are burned.
+In exchange for providing liquidity, depositors receive LP-tokens representing
+their fractional ownership of all A and B tokens in the pool. At any time,
+liquidity providers may redeem their LP-token in exchange for tokens A and B at
+the current "fair" exchange rate as determined by the curve. When liquidity is
+withdrawn, tokens A and/or B are transferred into the user's token accounts and
+the user's LP-token are burned.
 
-The Token Swap Program has two variations of withdraw instructions. One allows users to only withdraw tokens from one side of the swap pool at a time. The other allows for withdraws from both sides of the swap pool at the same time.
+The Token Swap Program has two variations of withdraw instructions. One allows
+users to only withdraw tokens from one side of the swap pool at a time. The
+other allows for withdraws from both sides of the swap pool at the same time.
 
-We can withdraw both tokens at the same time using the `TokenSwap.withdrawAllTokenTypesInstruction` helper function which requires the following arguements:
+We can withdraw both tokens at the same time using the
+`TokenSwap.withdrawAllTokenTypesInstruction` helper function which requires the
+following arguements:
 
 1. `tokenSwap` - the token swap state account
 2. `authority` - the swap pool authority
@@ -376,15 +526,19 @@ We can withdraw both tokens at the same time using the `TokenSwap.withdrawAllTok
 6. `sourcePoolAccount` - user LP-token account to burn pool tokens LP-token from
 7. `fromA` - swap pool token A account to withdraw from
 8. `fromB` - swap pool token B account to withdraw from
-9. `userAccountA` - user token A account to receive tokens withdrawn from swap pool token A account
-10. `userAccountB` - user token B account to receive tokens withdrawn from swap pool token B account
+9. `userAccountA` - user token A account to receive tokens withdrawn from swap
+   pool token A account
+10. `userAccountB` - user token B account to receive tokens withdrawn from swap
+    pool token B account
 11. `swapProgramId` - the address of the Token Swap Program
 12. `tokenProgramId` - the address of the Token Program
 13. `poolTokenAmount` - amount of LP-tokens the user expects to burn on withdraw
 14. `minimumTokenA` - minimum amount of token A to withdraw
 15. `minimumTokenB` - minimum amount of token B to withdraw
 
-The `minimumTokenA` and `minimumTokenB` arguments are used to prevent slippage. The lower the number, the more slippage can possibly occur. For simplicity, we will use 0 for these arguments.
+The `minimumTokenA` and `minimumTokenB` arguments are used to prevent slippage.
+The lower the number, the more slippage can possibly occur. For simplicity, we
+will use 0 for these arguments.
 
 The instruction for depositing both token A and token B will look like this:
 
@@ -410,7 +564,13 @@ const instruction = TokenSwap.withdrawAllTokenTypesInstruction(
 transaction.add(instruction);
 ```
 
-We can withdraw tokens from only one side of the swap pool in a similar way using the `TokenSwap.withdrawSingleTokenTypeExactAmountOut`. The main difference is that the last argument in the instruction is `maximumPoolTokenAmount`. When withdrawing only one side of the swap pool, the user specifies exact how many tokens to withdraw. In turn, the Token Swap Program calculates the amount of LP-tokens to mint the user must burn. An instruction withdrawing only Token B will look like this:
+We can withdraw tokens from only one side of the swap pool in a similar way
+using the `TokenSwap.withdrawSingleTokenTypeExactAmountOut`. The main difference
+is that the last argument in the instruction is `maximumPoolTokenAmount`. When
+withdrawing only one side of the swap pool, the user specifies exact how many
+tokens to withdraw. In turn, the Token Swap Program calculates the amount of
+LP-tokens to mint the user must burn. An instruction withdrawing only Token B
+will look like this:
 
 ```tsx
 const instruction = TokenSwap.depositSingleTokenTypeExactAmountInInstruction(
@@ -432,9 +592,17 @@ transaction.add(instruction);
 
 ## Curves
 
-Trading curves are at the core of how swap pools and AMMs (Automated Market Makers) operate. The trading curve is the function that the Token Swap Program uses to calculate how much of a destination token will be provided given an amount of source token. The curve effectively sets the market price of the tokens in the pool.
+Trading curves are at the core of how swap pools and AMMs (Automated Market
+Makers) operate. The trading curve is the function that the Token Swap Program
+uses to calculate how much of a destination token will be provided given an
+amount of source token. The curve effectively sets the market price of the
+tokens in the pool.
 
-The pool we’ll be interacting with in this lesson employs a [Constant Product](https://spl.solana.com/token-swap#curves) Curve Function. The constant product curve is the well-known Uniswap and Balancer style curve that preserves an invariant on all swaps. This invariant can be expressed as the product of the quantity of token A and token B in the swap pool.
+The pool we’ll be interacting with in this lesson employs a
+[Constant Product](https://spl.solana.com/token-swap#curves) Curve Function. The
+constant product curve is the well-known Uniswap and Balancer style curve that
+preserves an invariant on all swaps. This invariant can be expressed as the
+product of the quantity of token A and token B in the swap pool.
 
 ```tsx
 A_total * B_total = invariant
@@ -442,13 +610,15 @@ A_total * B_total = invariant
 
 If we have 100 token A and 5,000 token B, our invariant is 500,000.
 
-Now, if a trader wishes to put in a specific amount token A for some amount of token B, the calculation becomes a matter of resolving "B_out" where:
+Now, if a trader wishes to put in a specific amount token A for some amount of
+token B, the calculation becomes a matter of resolving "B_out" where:
 
 ```tsx
 (A_total + A_in) * (B_total - B_out) = invariant
 ```
 
-Putting in the 10 token A along with our invariant of half a million, we would need to solve for "B_out" like so:
+Putting in the 10 token A along with our invariant of half a million, we would
+need to solve for "B_out" like so:
 
 ```tsx
 (100 + 10) * (5,000 - B_out) = 500,000
@@ -457,13 +627,22 @@ Putting in the 10 token A along with our invariant of half a million, we would n
 B_out = 454.5454...
 ```
 
-The product of the amount of token A and token B must always equal a constant, hence the name ‘Constant Product’. More information can be found on the [Uniswap whitepaper](https://uniswap.org/whitepaper.pdf) and the [Balancer whitepaper](https://balancer.fi/whitepaper.pdf).
+The product of the amount of token A and token B must always equal a constant,
+hence the name ‘Constant Product’. More information can be found on the
+[Uniswap whitepaper](https://uniswap.org/whitepaper.pdf) and the
+[Balancer whitepaper](https://balancer.fi/whitepaper.pdf).
 
-If curves don't make a whole lot of sense, don't worry! While learning more about how they work doesn't hurt, you don't need to understand the entirety of the mathematics to be able to implement the common curves.
+If curves don't make a whole lot of sense, don't worry! While learning more
+about how they work doesn't hurt, you don't need to understand the entirety of
+the mathematics to be able to implement the common curves.
 
 # Demo
 
-For this demo, a token pool of two brand new tokens has been created and is live on Devnet. We'll walk through building out a frontend UI to interact with this swap pool! Since the pool is already made, we don't have to worry about initiating the pool and funding it with tokens. Instead, we'll focus on building out the instructions for
+For this demo, a token pool of two brand new tokens has been created and is live
+on Devnet. We'll walk through building out a frontend UI to interact with this
+swap pool! Since the pool is already made, we don't have to worry about
+initiating the pool and funding it with tokens. Instead, we'll focus on building
+out the instructions for
 
 - depositing liquidity to the pool
 - withdrawing your deposited liquidity
@@ -473,27 +652,47 @@ For this demo, a token pool of two brand new tokens has been created and is live
 
 ### 1. Download the starter code
 
-Before we get started, go ahead and download the [starter code](https://github.com/Unboxed-Software/solana-token-swap-frontend/tree/starter).
+Before we get started, go ahead and download the
+[starter code](https://github.com/Unboxed-Software/solana-token-swap-frontend/tree/starter).
 
-The project is a fairly simple Next.js application re-using a lot of what was previously built out for the demo in the [Token Program lesson](./token-program.md). As you can see from the image above, there are a few different text inputs and buttons - all of which will submit transactions to the blockchain on the user's behalf. Our focus in this demo will be creating the instructions that the last three buttons will submit.
+The project is a fairly simple Next.js application re-using a lot of what was
+previously built out for the demo in the
+[Token Program lesson](./token-program.md). As you can see from the image above,
+there are a few different text inputs and buttons - all of which will submit
+transactions to the blockchain on the user's behalf. Our focus in this demo will
+be creating the instructions that the last three buttons will submit.
 
-The airdrop buttons are already implemented and should work out of the box. They utilize an airdrop program that's deployed on Devnet at address [CPEV4ibq2VUv7UnNpkzUGL82VRzotbv2dy8vGwRfh3H3](https://explorer.solana.com/address/CPEV4ibq2VUv7UnNpkzUGL82VRzotbv2dy8vGwRfh3H3?cluster=devnet). You can mint as many tokens as you'd like to your wallet to interact with the pool.
+The airdrop buttons are already implemented and should work out of the box. They
+utilize an airdrop program that's deployed on Devnet at address
+[CPEV4ibq2VUv7UnNpkzUGL82VRzotbv2dy8vGwRfh3H3](https://explorer.solana.com/address/CPEV4ibq2VUv7UnNpkzUGL82VRzotbv2dy8vGwRfh3H3?cluster=devnet).
+You can mint as many tokens as you'd like to your wallet to interact with the
+pool.
 
 ### 2. Create the Deposit Instruction
 
-Of the two variations of deposit instructions on the Token Swap Program, we'll be using the variation that provides liquidity to both sides of the swap pool at once: `TokenSwap.depositAllTokenTypesInstruction`.
+Of the two variations of deposit instructions on the Token Swap Program, we'll
+be using the variation that provides liquidity to both sides of the swap pool at
+once: `TokenSwap.depositAllTokenTypesInstruction`.
 
-The deposit instruction should be added inside the `/components/Deposit.tsx` file inside the `handleTransactionSubmit` function. This function is called when the user clicks the Deposit button.
+The deposit instruction should be added inside the `/components/Deposit.tsx`
+file inside the `handleTransactionSubmit` function. This function is called when
+the user clicks the Deposit button.
 
 We’ll start by deriving three associated token account addresses:
 
-1. The associated token account corresponding to the user's wallet address and Krypt Coin
-2. The associated token account corresponding to the user's wallet address and Scrooge Coin
-3. The associated token account corresponding to the user's wallet address and the swap pools LP token
+1. The associated token account corresponding to the user's wallet address and
+   Krypt Coin
+2. The associated token account corresponding to the user's wallet address and
+   Scrooge Coin
+3. The associated token account corresponding to the user's wallet address and
+   the swap pools LP token
 
-There are a number of ways to do this, but we'll use the helper function `getAssociatedTokenAddress` from the `spl-token` library.
+There are a number of ways to do this, but we'll use the helper function
+`getAssociatedTokenAddress` from the `spl-token` library.
 
-We'll also need the data associated with the pool token mint to adjust the user input for the decimals of the pool token. To access a token mint's data, we'll use the helper function `getMint` from the `spl-token` library.
+We'll also need the data associated with the pool token mint to adjust the user
+input for the decimals of the pool token. To access a token mint's data, we'll
+use the helper function `getMint` from the `spl-token` library.
 
 ```tsx
 const handleTransactionSubmit = async (deposit: DepositAllSchema) => {
@@ -517,9 +716,15 @@ const handleTransactionSubmit = async (deposit: DepositAllSchema) => {
 };
 ```
 
-Next, we need to check if the `tokenAccountPool` address we just derived has been created. We'll use the `getAccountInfo` function from the `@solana/web3` library to get the account info associated with `tokenAccountPool`. This function will return an `AccountInfo` struct if the account exists or `null` otherwise. If `null` is returned, we'll need to create the account.
+Next, we need to check if the `tokenAccountPool` address we just derived has
+been created. We'll use the `getAccountInfo` function from the `@solana/web3`
+library to get the account info associated with `tokenAccountPool`. This
+function will return an `AccountInfo` struct if the account exists or `null`
+otherwise. If `null` is returned, we'll need to create the account.
 
-Since the `handleTransactionSubmit` function is already going to be submitting a transaction, we'll simply add the instruction for creating an associated account to the same transaction rather than submit multiple transactions.
+Since the `handleTransactionSubmit` function is already going to be submitting a
+transaction, we'll simply add the instruction for creating an associated account
+to the same transaction rather than submit multiple transactions.
 
 ```tsx
 const handleTransactionSubmit = async () => {
@@ -556,7 +761,9 @@ const handleTransactionSubmit = async () => {
 };
 ```
 
-Finally, we can create the deposit instruction using the `spl-token-swap` library's `TokenSwap.depositAllTokenTypesInstruction` helper function. We then add the instruction and submit the transaction.
+Finally, we can create the deposit instruction using the `spl-token-swap`
+library's `TokenSwap.depositAllTokenTypesInstruction` helper function. We then
+add the instruction and submit the transaction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
@@ -627,19 +834,33 @@ const handleTransactionSubmit = async () => {
 };
 ```
 
-With the exception of the user’s `publickey` and their derived associated token accounts (for Krypt Coin, Scrooge Coin, and the pool's LP-token), notice that all the accounts are constants for this swap pool and are defined in the `const.ts` file.
+With the exception of the user’s `publickey` and their derived associated token
+accounts (for Krypt Coin, Scrooge Coin, and the pool's LP-token), notice that
+all the accounts are constants for this swap pool and are defined in the
+`const.ts` file.
 
-At this point, you should be able to airdrop yourself some tokens and then deposit them into the swap pool!
+At this point, you should be able to airdrop yourself some tokens and then
+deposit them into the swap pool!
 
 ### 3. Create the Withdrawal Instruction
 
-The withdrawal instruction is very similar to the deposit instruction, but there are some subtle differences. Like deposits, the Token Swap Program accepts two variations of the withdrawal instruction. You can either withdraw liquidity from a single side of the swap pool, or you can withdraw your deposited liquidity from both sides at the same time.
+The withdrawal instruction is very similar to the deposit instruction, but there
+are some subtle differences. Like deposits, the Token Swap Program accepts two
+variations of the withdrawal instruction. You can either withdraw liquidity from
+a single side of the swap pool, or you can withdraw your deposited liquidity
+from both sides at the same time.
 
-Of the two variations of withdraw instructions on the Token Swap Program, we'll be using the variation that removes liquidity from both sides of the swap pool at once: `TokenSwap.withdrawAllTokenTypesInstruction`.
+Of the two variations of withdraw instructions on the Token Swap Program, we'll
+be using the variation that removes liquidity from both sides of the swap pool
+at once: `TokenSwap.withdrawAllTokenTypesInstruction`.
 
-The withdraw instruction should be added inside the `/components/Withdraw.tsx` file inside the `handleTransactionSubmit` function. This function is called when the user clicks the Withdraw button.
+The withdraw instruction should be added inside the `/components/Withdraw.tsx`
+file inside the `handleTransactionSubmit` function. This function is called when
+the user clicks the Withdraw button.
 
-We’ll start by deriving the three associated token account addresses, fetching the pool token mint data, and checking the `tokenAccountPool` address the same way we did for the deposit instruction.
+We’ll start by deriving the three associated token account addresses, fetching
+the pool token mint data, and checking the `tokenAccountPool` address the same
+way we did for the deposit instruction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
@@ -676,7 +897,9 @@ const handleTransactionSubmit = async () => {
 };
 ```
 
-Next, we create the withdraw instruction using the `spl-token-swap` library's `TokenSwap.withdrawAllTokenTypesInstruction` helper function. We then add the instruction and submit the transaction.
+Next, we create the withdraw instruction using the `spl-token-swap` library's
+`TokenSwap.withdrawAllTokenTypesInstruction` helper function. We then add the
+instruction and submit the transaction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
@@ -745,15 +968,26 @@ const handleTransactionSubmit = async () => {
 };
 ```
 
-Notice the ordering of accounts is different for the withdraw transaction and there is an additional `feeAccount` provided this time. This `feeAccount` is the destination for the fee that must be paid by the user for withdrawing liquidity from the pools.
+Notice the ordering of accounts is different for the withdraw transaction and
+there is an additional `feeAccount` provided this time. This `feeAccount` is the
+destination for the fee that must be paid by the user for withdrawing liquidity
+from the pools.
 
 ### 4. Create the Swap Instruction
 
-Now it's time to implement the actual purpose of this program - the swap instruction!
+Now it's time to implement the actual purpose of this program - the swap
+instruction!
 
-Note that our UI has a dropdown to allow users to select which token they would like to swap _from_, so we will have to create our instruction differently based on what the user selects.
+Note that our UI has a dropdown to allow users to select which token they would
+like to swap _from_, so we will have to create our instruction differently based
+on what the user selects.
 
-We’ll do this inside the `handleTransactionSubmit` function of the `/components/Swap.tsx` file. Once again, we will have to derive the user’s `Associated Token Addresses` for each token mint (Krypt Coin, Scrooge Coin, and Pool Token) and create the `tokenAccountPool` if it does not already exist. Additionally, we'll fetch the data for both the Krypt Coin and Scrooge Coin to account for the decimal precision of the tokens.
+We’ll do this inside the `handleTransactionSubmit` function of the
+`/components/Swap.tsx` file. Once again, we will have to derive the user’s
+`Associated Token Addresses` for each token mint (Krypt Coin, Scrooge Coin, and
+Pool Token) and create the `tokenAccountPool` if it does not already exist.
+Additionally, we'll fetch the data for both the Krypt Coin and Scrooge Coin to
+account for the decimal precision of the tokens.
 
 ```tsx
 const handleTransactionSubmit = async () => {
@@ -777,7 +1011,9 @@ const handleTransactionSubmit = async () => {
 };
 ```
 
-From here, the user’s input will determine our path of execution. The user's choice is saved to the `mint` property, so we'll use this to branch between each possible instruction.
+From here, the user’s input will determine our path of execution. The user's
+choice is saved to the `mint` property, so we'll use this to branch between each
+possible instruction.
 
 ```tsx
 const handleTransactionSubmit = async () => {
@@ -869,12 +1105,23 @@ const handleTransactionSubmit = async () => {
 };
 ```
 
-And that’s it! Once you have the swap instruction implemented, the UI should be fully functional and you can airdrop yourself tokens, deposit liquidity, withdraw your liquidity, and swap from token to token!
+And that’s it! Once you have the swap instruction implemented, the UI should be
+fully functional and you can airdrop yourself tokens, deposit liquidity,
+withdraw your liquidity, and swap from token to token!
 
-Please take your time with this code and the concepts in this lesson. Swap pools can get a lot more complicated than the one we have implemented today so it's important to understand the basics. If you need some more time with the demo, take it! And if you need, have a look at the [solution code here](https://github.com/Unboxed-Software/solana-token-swap-frontend).
+Please take your time with this code and the concepts in this lesson. Swap pools
+can get a lot more complicated than the one we have implemented today so it's
+important to understand the basics. If you need some more time with the demo,
+take it! And if you need, have a look at the
+[solution code here](https://github.com/Unboxed-Software/solana-token-swap-frontend).
 
 # Challenge
 
-Now that we've worked through the demo together, try and take it a step further with your own tokens!
+Now that we've worked through the demo together, try and take it a step further
+with your own tokens!
 
-In the [Token Program lesson](./token-program.md) you created some tokens. Now make a swap pool for those tokens and modify the code from this lesson's demo to use your tokens and newly created swap pool. There is no solution code for this since it's specific to your tokens, so go slow and take it one step at a time. You've got this!
+In the [Token Program lesson](./token-program.md) you created some tokens. Now
+make a swap pool for those tokens and modify the code from this lesson's demo to
+use your tokens and newly created swap pool. There is no solution code for this
+since it's specific to your tokens, so go slow and take it one step at a time.
+You've got this!

--- a/developers/courses/solana-course/content/type-cosplay.md
+++ b/developers/courses/solana-course/content/type-cosplay.md
@@ -10,7 +10,8 @@ objectives:
 # TL;DR
 
 - Use discriminators to distinguish between different account types
-- To implement a discriminator in Rust, include a field in the account struct to represent the account type
+- To implement a discriminator in Rust, include a field in the account struct to
+  represent the account type
 
   ```rust
   #[derive(BorshSerialize, BorshDeserialize)]
@@ -26,7 +27,8 @@ objectives:
   }
   ```
 
-- To implement a discriminator check in Rust, verify that the discriminator of the deserialized account data matches the expected value
+- To implement a discriminator check in Rust, verify that the discriminator of
+  the deserialized account data matches the expected value
 
   ```rust
   if user.discriminant != AccountDiscriminant::User {
@@ -34,20 +36,37 @@ objectives:
   }
   ```
 
-- In Anchor, program account types automatically implement the `Discriminator` trait which creates an 8 byte unique identifier for a type
-- Use Anchor’s `Account<'info, T>` type to automatically check the discriminator of the account when deserializing the account data
+- In Anchor, program account types automatically implement the `Discriminator`
+  trait which creates an 8 byte unique identifier for a type
+- Use Anchor’s `Account<'info, T>` type to automatically check the discriminator
+  of the account when deserializing the account data
 
 # Overview
 
-“Type cosplay” refers to an unexpected account type being used in place of an expected account type. Under the hood, account data is simply stored as an array of bytes that a program deserializes into a custom account type. Without implementing a way to explicitly distinguish between account types, account data from an unexpected account could result in an instruction being used in unintended ways.
+“Type cosplay” refers to an unexpected account type being used in place of an
+expected account type. Under the hood, account data is simply stored as an array
+of bytes that a program deserializes into a custom account type. Without
+implementing a way to explicitly distinguish between account types, account data
+from an unexpected account could result in an instruction being used in
+unintended ways.
 
 ### Unchecked account
 
-In the example below, both the `AdminConfig` and `UserConfig` account types store a single public key. The `admin_instruction` instruction deserializes the `admin_config` account as an `AdminConfig` type and then performs a owner check and data validation check.
+In the example below, both the `AdminConfig` and `UserConfig` account types
+store a single public key. The `admin_instruction` instruction deserializes the
+`admin_config` account as an `AdminConfig` type and then performs a owner check
+and data validation check.
 
-However, the `AdminConfig` and `UserConfig` account types have the same data structure. This means a `UserConfig` account type could be passed in as the `admin_config` account. As long as the public key stored on the account data matches the `admin` signing the transaction, the `admin_instruction` instruction would continue to process, even if the signer isn't actually an admin.
+However, the `AdminConfig` and `UserConfig` account types have the same data
+structure. This means a `UserConfig` account type could be passed in as the
+`admin_config` account. As long as the public key stored on the account data
+matches the `admin` signing the transaction, the `admin_instruction` instruction
+would continue to process, even if the signer isn't actually an admin.
 
-Note that the names of the fields stored on the account types (`admin` and `user`) make no difference when deserializing account data. The data is serialized and deserialized based on the order of fields rather than their names.
+Note that the names of the fields stored on the account types (`admin` and
+`user`) make no difference when deserializing account data. The data is
+serialized and deserialized based on the order of fields rather than their
+names.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -92,9 +111,12 @@ pub struct UserConfig {
 
 ### Add account discriminator
 
-To solve this, you can add a discriminant field for each account type and set the discriminant when initializing an account.
+To solve this, you can add a discriminant field for each account type and set
+the discriminant when initializing an account.
 
-The example below updates the `AdminConfig` and `UserConfig` account types with a `discriminant` field. The `admin_instruction` instruction includes an additional data validation check for the `discriminant` field.
+The example below updates the `AdminConfig` and `UserConfig` account types with
+a `discriminant` field. The `admin_instruction` instruction includes an
+additional data validation check for the `discriminant` field.
 
 ```rust
 if account_data.discriminant != AccountDiscriminant::Admin {
@@ -102,7 +124,11 @@ if account_data.discriminant != AccountDiscriminant::Admin {
 }
 ```
 
-If the `discriminant` field of the account passed into the instruction as the `admin_config` account does not match the expected `AccountDiscriminant`, then the transaction will fail. Simply make sure to set the appropriate value for `discriminant` when you initialize each account (not shown in the example), and then you can include these discriminant checks in every subsequent instruction.
+If the `discriminant` field of the account passed into the instruction as the
+`admin_config` account does not match the expected `AccountDiscriminant`, then
+the transaction will fail. Simply make sure to set the appropriate value for
+`discriminant` when you initialize each account (not shown in the example), and
+then you can include these discriminant checks in every subsequent instruction.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -158,13 +184,30 @@ pub enum AccountDiscriminant {
 
 ### Use Anchor’s `Account` wrapper
 
-Implementing these checks for every account needed for every instruction can be tedious. Fortunately, Anchor provides a `#[account]` attribute macro for automatically implementing traits that every account should have.
+Implementing these checks for every account needed for every instruction can be
+tedious. Fortunately, Anchor provides a `#[account]` attribute macro for
+automatically implementing traits that every account should have.
 
-Structs marked with `#[account]` can then be used with `Account` to validate that the passed in account is indeed the type you expect it to be. When initializing an account whose struct representation has the `#[account]` attribute, the first 8 bytes are automatically reserved for a discriminator unique to the account type. When deserializing the account data, Anchor will automatically check if the discriminator on the account matches the expected account type and throw and error if it does not match.
+Structs marked with `#[account]` can then be used with `Account` to validate
+that the passed in account is indeed the type you expect it to be. When
+initializing an account whose struct representation has the `#[account]`
+attribute, the first 8 bytes are automatically reserved for a discriminator
+unique to the account type. When deserializing the account data, Anchor will
+automatically check if the discriminator on the account matches the expected
+account type and throw and error if it does not match.
 
-In the example below, `Account<'info, AdminConfig>` specifies that the `admin_config` account should be of type `AdminConfig`. Anchor then automatically checks that the first 8 bytes of account data match the discriminator of the `AdminConfig` type.
+In the example below, `Account<'info, AdminConfig>` specifies that the
+`admin_config` account should be of type `AdminConfig`. Anchor then
+automatically checks that the first 8 bytes of account data match the
+discriminator of the `AdminConfig` type.
 
-The data validation check for the `admin` field is also moved from the instruction logic to the account validation struct using the `has_one` constraint. `#[account(has_one = admin)]` specifies that the `admin_config` account’s `admin` field must match the `admin` account passed into the instruction. Note that for the `has_one` constraint to work, the naming of the account in the struct must match the naming of field on the account you are validating.
+The data validation check for the `admin` field is also moved from the
+instruction logic to the account validation struct using the `has_one`
+constraint. `#[account(has_one = admin)]` specifies that the `admin_config`
+account’s `admin` field must match the `admin` account passed into the
+instruction. Note that for the `has_one` constraint to work, the naming of the
+account in the struct must match the naming of field on the account you are
+validating.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -200,26 +243,42 @@ pub struct UserConfig {
 }
 ```
 
-It’s important to note that this is a vulnerability you don’t really have to worry about when using Anchor - that’s the whole point of it in the first place! After going through how this can be exploited if not handled properly in a native rust program, hopefully you have a much better understanding of what the purpose of the account discriminator is in an Anchor account. The fact that Anchor sets and checks this discriminator automatically means that developers can spend more time focusing on their product, but it’s still very important to understand what Anchor is doing behind the scenes to develop robust Solana programs.
+It’s important to note that this is a vulnerability you don’t really have to
+worry about when using Anchor - that’s the whole point of it in the first place!
+After going through how this can be exploited if not handled properly in a
+native rust program, hopefully you have a much better understanding of what the
+purpose of the account discriminator is in an Anchor account. The fact that
+Anchor sets and checks this discriminator automatically means that developers
+can spend more time focusing on their product, but it’s still very important to
+understand what Anchor is doing behind the scenes to develop robust Solana
+programs.
 
 # Demo
 
-For this demo we’ll create two programs to demonstrate a type cosplay vulnerability.
+For this demo we’ll create two programs to demonstrate a type cosplay
+vulnerability.
 
 - The first program will initialize program accounts without a discriminator
-- The second program will initialize program accounts using Anchor’s `init` constraint which automatically sets an account discriminator
+- The second program will initialize program accounts using Anchor’s `init`
+  constraint which automatically sets an account discriminator
 
 ### 1. Starter
 
-To get started, download the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-type-cosplay/tree/starter). The starter code includes a program with three instructions and some tests.
+To get started, download the starter code from the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-type-cosplay/tree/starter). The
+starter code includes a program with three instructions and some tests.
 
 The three instructions are:
 
-1. `initialize_admin` - initializes an admin account and sets the admin authority of the program
+1. `initialize_admin` - initializes an admin account and sets the admin
+   authority of the program
 2. `initialize_user` - intializes a standard user account
-3. `update_admin` - allows the existing admin to update the admin authority of the program
+3. `update_admin` - allows the existing admin to update the admin authority of
+   the program
 
-Take a look at these three instructions in the `lib.rs` file. The last instruction should only be callable by the account matching the `admin` field on the admin account initialized using the `initialize_admin` instruction.
+Take a look at these three instructions in the `lib.rs` file. The last
+instruction should only be callable by the account matching the `admin` field on
+the admin account initialized using the `initialize_admin` instruction.
 
 ### 2. Test insecure `update_admin` instruction
 
@@ -237,11 +296,17 @@ pub struct User {
 }
 ```
 
-Because of this, it's possible to pass in a `User` account in place of the `admin` account in the `update_admin` instruction, thereby bypassing the requirement that one be an admin to call this instruction.
+Because of this, it's possible to pass in a `User` account in place of the
+`admin` account in the `update_admin` instruction, thereby bypassing the
+requirement that one be an admin to call this instruction.
 
-Take a look at the `solana-type-cosplay.ts` file in the `tests` directory. It contains some basic setup and two tests. One test initializes a user account, and the other invokes `update_admin` and passes in the user account in place of an admin account.
+Take a look at the `solana-type-cosplay.ts` file in the `tests` directory. It
+contains some basic setup and two tests. One test initializes a user account,
+and the other invokes `update_admin` and passes in the user account in place of
+an admin account.
 
-Run `anchor test` to see that invoking `update_admin` will complete successfully.
+Run `anchor test` to see that invoking `update_admin` will complete
+successfully.
 
 ```bash
   type-cosplay
@@ -251,11 +316,16 @@ Run `anchor test` to see that invoking `update_admin` will complete successfully
 
 ### 3. Create `type-checked` program
 
-Now we'll create a new program called `type-checked` by running `anchor new type-checked` from the root of the existing anchor program.
+Now we'll create a new program called `type-checked` by running
+`anchor new type-checked` from the root of the existing anchor program.
 
-Now in your `programs` folder you will have two programs. Run `anchor keys list` and you should see the program ID for the new program. Add it to the `lib.rs` file of the `type-checked` program and to the `type_checked` program in the `Anchor.toml` file.
+Now in your `programs` folder you will have two programs. Run `anchor keys list`
+and you should see the program ID for the new program. Add it to the `lib.rs`
+file of the `type-checked` program and to the `type_checked` program in the
+`Anchor.toml` file.
 
-Next, update the test file's setup to include the new program and two new keypairs for the accounts we'll be initializing for the new program.
+Next, update the test file's setup to include the new program and two new
+keypairs for the accounts we'll be initializing for the new program.
 
 ```tsx
 import * as anchor from "@project-serum/anchor";
@@ -281,9 +351,16 @@ describe("type-cosplay", () => {
 
 ### 4. Implement the `type-checked` program
 
-In the `type_checked` program, add two instructions using the `init` constraint to initialize an `AdminConfig` account and a `User` account. When using the `init` constraint to initialize new program accounts, Anchor will automatically set the first 8 bytes of account data as a unique discriminator for the account type.
+In the `type_checked` program, add two instructions using the `init` constraint
+to initialize an `AdminConfig` account and a `User` account. When using the
+`init` constraint to initialize new program accounts, Anchor will automatically
+set the first 8 bytes of account data as a unique discriminator for the account
+type.
 
-We’ll also add an `update_admin` instruction that validates the `admin_config` account as a `AdminConfig` account type using Anchor’s `Account` wrapper. For any account passed in as the `admin_config` account, Anchor will automatically check that the account discriminator matches the expected account type.
+We’ll also add an `update_admin` instruction that validates the `admin_config`
+account as a `AdminConfig` account type using Anchor’s `Account` wrapper. For
+any account passed in as the `admin_config` account, Anchor will automatically
+check that the account discriminator matches the expected account type.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -361,7 +438,9 @@ pub struct User {
 
 ### 5. Test secure `update_admin` instruction
 
-In the test file, we’ll initialize an `AdminConfig` account and a `User` account from the `type_checked` program. Then we’ll invoke the `updateAdmin` instruction twice passing in the newly created accounts.
+In the test file, we’ll initialize an `AdminConfig` account and a `User` account
+from the `type_checked` program. Then we’ll invoke the `updateAdmin` instruction
+twice passing in the newly created accounts.
 
 ```rust
 describe("type-cosplay", () => {
@@ -417,7 +496,9 @@ describe("type-cosplay", () => {
 })
 ```
 
-Run `anchor test`. For the transaction where we pass in the `User` account type, we expect the instruction and return an Anchor Error for the account not being of type `AdminConfig`.
+Run `anchor test`. For the transaction where we pass in the `User` account type,
+we expect the instruction and return an Anchor Error for the account not being
+of type `AdminConfig`.
 
 ```bash
 'Program EU66XDppFCf2Bg7QQr59nyykj9ejWaoW93TSkk1ufXh3 invoke [1]',
@@ -427,14 +508,24 @@ Run `anchor test`. For the transaction where we pass in the `User` account type,
 'Program EU66XDppFCf2Bg7QQr59nyykj9ejWaoW93TSkk1ufXh3 failed: custom program error: 0xbba'
 ```
 
-Following Anchor best practices and using Anchor types will ensure that your programs avoid this vulnerability. Always use the `#[account]` attribute when creating account structs, use the `init` constraint when initializing accounts, and use the `Account` type in your account validation structs.
+Following Anchor best practices and using Anchor types will ensure that your
+programs avoid this vulnerability. Always use the `#[account]` attribute when
+creating account structs, use the `init` constraint when initializing accounts,
+and use the `Account` type in your account validation structs.
 
-If you want to take a look at the final solution code you can find it on the `solution` branch of [the repository](https://github.com/Unboxed-Software/solana-type-cosplay/tree/solution).
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the repository](https://github.com/Unboxed-Software/solana-type-cosplay/tree/solution).
 
 # Challenge
 
-Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this module, your opportunity to practice avoiding
+this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that account types have a discriminator and that those are checked for each account and instruction. Since standard Anchor types handle this check automatically, you're more likely to find a vulnerability in a native program.
+Take some time to review at least one program and ensure that account types have
+a discriminator and that those are checked for each account and instruction.
+Since standard Anchor types handle this check automatically, you're more likely
+to find a vulnerability in a native program.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert
+them! If you find one in your own program, be sure to patch it right away.

--- a/developers/courses/solana-course/content/type-cosplay.md
+++ b/developers/courses/solana-course/content/type-cosplay.md
@@ -1,10 +1,10 @@
 ---
 title: Type Cosplay
 objectives:
-- Explain the security risks associated with not checking account types
-- Implement an account type discriminator using long-form Rust
-- Use Anchor's `init` constraint to initialize accounts
-- Use Anchor's `Account` type for account validation
+  - Explain the security risks associated with not checking account types
+  - Implement an account type discriminator using long-form Rust
+  - Use Anchor's `init` constraint to initialize accounts
+  - Use Anchor's `Account` type for account validation
 ---
 
 # TL;DR
@@ -12,27 +12,27 @@ objectives:
 - Use discriminators to distinguish between different account types
 - To implement a discriminator in Rust, include a field in the account struct to represent the account type
 
-    ```rust
-    #[derive(BorshSerialize, BorshDeserialize)]
-    pub struct User {
-        discriminant: AccountDiscriminant,
-        user: Pubkey,
-    }
+  ```rust
+  #[derive(BorshSerialize, BorshDeserialize)]
+  pub struct User {
+      discriminant: AccountDiscriminant,
+      user: Pubkey,
+  }
 
-    #[derive(BorshSerialize, BorshDeserialize, PartialEq)]
-    pub enum AccountDiscriminant {
-        User,
-        Admin,
-    }
-    ```
+  #[derive(BorshSerialize, BorshDeserialize, PartialEq)]
+  pub enum AccountDiscriminant {
+      User,
+      Admin,
+  }
+  ```
 
 - To implement a discriminator check in Rust, verify that the discriminator of the deserialized account data matches the expected value
 
-    ```rust
-    if user.discriminant != AccountDiscriminant::User {
-        return Err(ProgramError::InvalidAccountData.into());
-    }
-    ```
+  ```rust
+  if user.discriminant != AccountDiscriminant::User {
+      return Err(ProgramError::InvalidAccountData.into());
+  }
+  ```
 
 - In Anchor, program account types automatically implement the `Discriminator` trait which creates an 8 byte unique identifier for a type
 - Use Anchor’s `Account<'info, T>` type to automatically check the discriminator of the account when deserializing the account data
@@ -258,25 +258,25 @@ Now in your `programs` folder you will have two programs. Run `anchor keys list`
 Next, update the test file's setup to include the new program and two new keypairs for the accounts we'll be initializing for the new program.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
-import { TypeCosplay } from "../target/types/type_cosplay"
-import { TypeChecked } from "../target/types/type_checked"
-import { expect } from "chai"
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { TypeCosplay } from "../target/types/type_cosplay";
+import { TypeChecked } from "../target/types/type_checked";
+import { expect } from "chai";
 
 describe("type-cosplay", () => {
-  const provider = anchor.AnchorProvider.env()
-  anchor.setProvider(provider)
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
 
-  const program = anchor.workspace.TypeCosplay as Program<TypeCosplay>
-  const programChecked = anchor.workspace.TypeChecked as Program<TypeChecked>
+  const program = anchor.workspace.TypeCosplay as Program<TypeCosplay>;
+  const programChecked = anchor.workspace.TypeChecked as Program<TypeChecked>;
 
-  const userAccount = anchor.web3.Keypair.generate()
-  const newAdmin = anchor.web3.Keypair.generate()
+  const userAccount = anchor.web3.Keypair.generate();
+  const newAdmin = anchor.web3.Keypair.generate();
 
-  const userAccountChecked = anchor.web3.Keypair.generate()
-  const adminAccountChecked = anchor.web3.Keypair.generate()
-})
+  const userAccountChecked = anchor.web3.Keypair.generate();
+  const adminAccountChecked = anchor.web3.Keypair.generate();
+});
 ```
 
 ### 4. Implement the `type-checked` program

--- a/developers/courses/solana-course/content/versioned-transaction.md
+++ b/developers/courses/solana-course/content/versioned-transaction.md
@@ -1,16 +1,16 @@
 ---
 title: Versioned Transactions and Lookup Tables
 objectives:
-- Create versioned transactions
-- Create lookup tables
-- Extend lookup tables
-- Use lookup tables with versioned transactions
+  - Create versioned transactions
+  - Create lookup tables
+  - Extend lookup tables
+  - Use lookup tables with versioned transactions
 ---
 
 # TL;DR
 
--   **Versioned Transactions** refers to a way to support both legacy versions and newer versions of transaction formats. The original transaction format is "legacy" and new transaction versions start at version 0. Versioned transactions were implemented in order to support the use of Address Lookup Tables (also called lookup tables or LUTs).
--   **Address Lookup Tables** are accounts used to store addresses of other accounts, which can then be referenced in versioned transactions using a 1 byte index instead of the full 32 bytes per address. This enables the creation of more complex transactions than what was possible prior to the introduction of LUTs.
+- **Versioned Transactions** refers to a way to support both legacy versions and newer versions of transaction formats. The original transaction format is "legacy" and new transaction versions start at version 0. Versioned transactions were implemented in order to support the use of Address Lookup Tables (also called lookup tables or LUTs).
+- **Address Lookup Tables** are accounts used to store addresses of other accounts, which can then be referenced in versioned transactions using a 1 byte index instead of the full 32 bytes per address. This enables the creation of more complex transactions than what was possible prior to the introduction of LUTs.
 
 # Overview
 
@@ -23,9 +23,9 @@ To help get around the transaction size limitation, Solana released a new transa
 
 Versioned transactions don't require any modifications to existing Solana programs, but any client-side code created prior to the release of versioned transactions should be updated. In this lesson, we'll cover the basics of versioned transactions and how to use them, including:
 
--   Creating versioned transactions
--   Creating and managing lookup tables
--   Using lookup tables in versioned transactions
+- Creating versioned transactions
+- Creating and managing lookup tables
+- Using lookup tables in versioned transactions
 
 ## Versioned Transactions
 
@@ -39,9 +39,9 @@ Even if you don't need to use lookup tables, you'll need to know how to support 
 
 To create a versioned transaction, you simply create a `TransactionMessage` with the following parameters:
 
--   `payerKey` - the public key of the account that will pay for the transaction
--   `recentBlockhash` - a recent blockhash from the network
--   `instructions` - the instructions to include in the transaction
+- `payerKey` - the public key of the account that will pay for the transaction
+- `recentBlockhash` - a recent blockhash from the network
+- `instructions` - the instructions to include in the transaction
 
 You then transform this message object into a version `0` transaction using the `compileToV0Message()` method.
 
@@ -50,11 +50,11 @@ import * as web3 from "@solana/web3.js";
 
 // Example transfer instruction
 const transferInstruction = [
-    web3.SystemProgram.transfer({
-        fromPubkey: payer.publicKey, // Public key of account that will send the funds
-        toPubkey: toAccount.publicKey, // Public key of the account that will receive the funds
-        lamports: 1 * LAMPORTS_PER_SOL, // Amount of lamports to be transferred
-    }),
+  web3.SystemProgram.transfer({
+    fromPubkey: payer.publicKey, // Public key of account that will send the funds
+    toPubkey: toAccount.publicKey, // Public key of the account that will receive the funds
+    lamports: 1 * LAMPORTS_PER_SOL, // Amount of lamports to be transferred
+  }),
 ];
 
 // Get the latest blockhash
@@ -62,9 +62,9 @@ let { blockhash } = await connection.getLatestBlockhash();
 
 // Create the transaction message
 const message = new web3.TransactionMessage({
-    payerKey: payer.publicKey, // Public key of the account that will pay for the transaction
-    recentBlockhash: blockhash, // Latest blockhash
-    instructions: transferInstruction, // Instructions included in transaction
+  payerKey: payer.publicKey, // Public key of the account that will pay for the transaction
+  recentBlockhash: blockhash, // Latest blockhash
+  instructions: transferInstruction, // Instructions included in transaction
 }).compileToV0Message();
 ```
 
@@ -89,19 +89,19 @@ Versioned transactions can include the address of an LUT account and then refere
 
 To simplify the process of working with LUTs, the `@solana/web3.js` library includes an `AddressLookupTableProgram` class which provides a set of methods to create instructions for managing LUTs. These methods include:
 
--   `createLookupTable` - creates a new LUT account
--   `freezeLookupTable` - makes an existing LUT immutable
--   `extendLookupTable` - adds addresses to an existing LUT
--   `deactivateLookupTable` - puts an LUT in a “deactivation” period before it can be closed
--   `closeLookupTable` - permanently closes an LUT account
+- `createLookupTable` - creates a new LUT account
+- `freezeLookupTable` - makes an existing LUT immutable
+- `extendLookupTable` - adds addresses to an existing LUT
+- `deactivateLookupTable` - puts an LUT in a “deactivation” period before it can be closed
+- `closeLookupTable` - permanently closes an LUT account
 
 ### Create a lookup table
 
 You use the `createLookupTable` method to construct the instruction that creates a lookup table. The function requires the following parameters:
 
--   `authority` - the account that will have permission to modify the lookup table
--   `payer` - the account that will pay for the account creation
--   `recentSlot` - a recent slot to derive the lookup table's address
+- `authority` - the account that will have permission to modify the lookup table
+- `payer` - the account that will pay for the account creation
+- `recentSlot` - a recent slot to derive the lookup table's address
 
 The function returns both the instruction to create the lookup table and the address of the lookup table.
 
@@ -112,19 +112,19 @@ const slot = await connection.getSlot();
 // Create an instruction for creating a lookup table
 // and retrieve the address of the new lookup table
 const [lookupTableInst, lookupTableAddress] =
-    web3.AddressLookupTableProgram.createLookupTable({
-        authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-        payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-        recentSlot: slot - 1, // The recent slot to derive lookup table's address
-    });
+  web3.AddressLookupTableProgram.createLookupTable({
+    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+    payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+    recentSlot: slot - 1, // The recent slot to derive lookup table's address
+  });
 ```
 
 Under the hood, the lookup table address is simply a PDA derived using the `authority` and `recentSlot` as seeds.
 
 ```ts
 const [lookupTableAddress, bumpSeed] = PublicKey.findProgramAddressSync(
-    [params.authority.toBuffer(), toBufferLE(BigInt(params.recentSlot), 8)],
-    this.programId,
+  [params.authority.toBuffer(), toBufferLE(BigInt(params.recentSlot), 8)],
+  this.programId,
 );
 ```
 
@@ -140,26 +140,26 @@ Note that using the most recent slot sometimes results in an error after sending
 
 You use the `extendLookupTable` method to create an instruction that adds addresses to an existing lookup table. It takes the following parameters:
 
--   `payer` - the account that will pay for the transaction fees and any increased rent
--   `authority` - the account that has permission to change the lookup table
--   `lookupTable` - the address of the lookup table to extend
--   `addresses` - the addresses to add to the lookup table
+- `payer` - the account that will pay for the transaction fees and any increased rent
+- `authority` - the account that has permission to change the lookup table
+- `lookupTable` - the address of the lookup table to extend
+- `addresses` - the addresses to add to the lookup table
 
 The function returns an instruction to extend the lookup table.
 
 ```ts
 const addresses = [
-    new web3.PublicKey("31Jy3nFeb5hKVdB4GS4Y7MhU7zhNMFxwF7RGVhPc1TzR"),
-    new web3.PublicKey("HKSeapcvwJ7ri6mf3HwBtspLFTDKqaJrMsozdfXfg5y2"),
-    // add more addresses
+  new web3.PublicKey("31Jy3nFeb5hKVdB4GS4Y7MhU7zhNMFxwF7RGVhPc1TzR"),
+  new web3.PublicKey("HKSeapcvwJ7ri6mf3HwBtspLFTDKqaJrMsozdfXfg5y2"),
+  // add more addresses
 ];
 
 // Create an instruction to extend a lookup table with the provided addresses
 const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
-    payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-    lookupTable: lookupTableAddress, // The address of the lookup table to extend
-    addresses: addresses, // The addresses to add to the lookup table
+  payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+  authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+  lookupTable: lookupTableAddress, // The address of the lookup table to extend
+  addresses: addresses, // The addresses to add to the lookup table
 });
 ```
 
@@ -175,9 +175,9 @@ let { blockhash } = await connection.getLatestBlockhash();
 
 // Create the transaction message
 const message = new web3.TransactionMessage({
-    payerKey: payer.publicKey, // Public key of the account that will pay for the transaction
-    recentBlockhash: blockhash, // Latest blockhash
-    instructions: [lookupTableInst, extendInstruction], // Instructions included in transaction
+  payerKey: payer.publicKey, // Public key of the account that will pay for the transaction
+  recentBlockhash: blockhash, // Latest blockhash
+  instructions: [lookupTableInst, extendInstruction], // Instructions included in transaction
 }).compileToV0Message();
 
 // Create the versioned transaction using the message
@@ -204,30 +204,30 @@ When an lookup table is no longer needed, you can deactivate and close it to rec
 
 To deactivate an LUT, use the `deactivateLookupTable` method and pass in the following parameters:
 
--   `lookupTable` - the address of the LUT to be deactivated
--   `authority` - the account with permission to deactivate the LUT
+- `lookupTable` - the address of the LUT to be deactivated
+- `authority` - the account with permission to deactivate the LUT
 
 ```ts
 const deactivateInstruction =
-    web3.AddressLookupTableProgram.deactivateLookupTable({
-        lookupTable: lookupTableAddress, // The address of the lookup table to deactivate
-        authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-    });
+  web3.AddressLookupTableProgram.deactivateLookupTable({
+    lookupTable: lookupTableAddress, // The address of the lookup table to deactivate
+    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+  });
 ```
 
 ### Close a lookup table
 
 To close a lookup table after its deactivation period, use the `closeLookupTable` method. This method creates an instruction to close a deactivated lookup table and reclaim its rent balance. It takes the following parameters:
 
--   `lookupTable` - the address of the LUT to be closed
--   `authority` - the account with permission to close the LUT
--   `recipient` - the account that will receive the reclaimed rent balance
+- `lookupTable` - the address of the LUT to be closed
+- `authority` - the account with permission to close the LUT
+- `recipient` - the account that will receive the reclaimed rent balance
 
 ```ts
 const closeInstruction = web3.AddressLookupTableProgram.closeLookupTable({
-    lookupTable: lookupTableAddress, // The address of the lookup table to close
-    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-    recipient: user.publicKey, // The recipient of closed account lamports
+  lookupTable: lookupTableAddress, // The address of the lookup table to close
+  authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+  recipient: user.publicKey, // The recipient of closed account lamports
 });
 ```
 
@@ -245,13 +245,13 @@ In addition to standard CRUD operations, you can "freeze" a lookup table. This m
 
 You freeze a lookup table with the `freezeLookupTable` method. It takes the following parameters:
 
--   `lookupTable` - the address of the LUT to be frozen
--   `authority` - the account with permission to freeze the LUT
+- `lookupTable` - the address of the LUT to be frozen
+- `authority` - the account with permission to freeze the LUT
 
 ```ts
 const freezeInstruction = web3.AddressLookupTableProgram.freezeLookupTable({
-    lookupTable: lookupTableAddress, // The address of the lookup table to freeze
-    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+  lookupTable: lookupTableAddress, // The address of the lookup table to freeze
+  authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
 });
 ```
 
@@ -269,7 +269,7 @@ To use a lookup table in a versioned transaction, you need to retrieve the looku
 
 ```ts
 const lookupTableAccount = (
-    await connection.getAddressLookupTable(lookupTableAddress)
+  await connection.getAddressLookupTable(lookupTableAddress)
 ).value;
 ```
 
@@ -277,9 +277,9 @@ You can then create a list of instructions to include in a transaction as usual.
 
 ```ts
 const message = new web3.TransactionMessage({
-    payerKey: payer.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-    recentBlockhash: blockhash, // The blockhash of the most recent block
-    instructions: instructions, // The instructions to include in the transaction
+  payerKey: payer.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+  recentBlockhash: blockhash, // The blockhash of the most recent block
+  instructions: instructions, // The instructions to include in the transaction
 }).compileToV0Message([lookupTableAccount]); // Include lookup table accounts
 
 // Create the versioned transaction using the message
@@ -313,52 +313,52 @@ import { initializeKeypair } from "./initializeKeypair";
 import * as web3 from "@solana/web3.js";
 
 async function main() {
-    // Connect to the devnet cluster
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  // Connect to the devnet cluster
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
 
-    // Initialize the user's keypair
-    const user = await initializeKeypair(connection);
-    console.log("PublicKey:", user.publicKey.toBase58());
+  // Initialize the user's keypair
+  const user = await initializeKeypair(connection);
+  console.log("PublicKey:", user.publicKey.toBase58());
 
-    // Generate 22 addresses
-    const recipients = [];
-    for (let i = 0; i < 22; i++) {
-        recipients.push(web3.Keypair.generate().publicKey);
-    }
+  // Generate 22 addresses
+  const recipients = [];
+  for (let i = 0; i < 22; i++) {
+    recipients.push(web3.Keypair.generate().publicKey);
+  }
 
-    // Create an array of transfer instructions
-    const transferInstructions = [];
+  // Create an array of transfer instructions
+  const transferInstructions = [];
 
-    // Add a transfer instruction for each address
-    for (const address of recipients) {
-        transferInstructions.push(
-            web3.SystemProgram.transfer({
-                fromPubkey: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-                toPubkey: address, // The destination account for the transfer
-                lamports: web3.LAMPORTS_PER_SOL * 0.01, // The amount of lamports to transfer
-            }),
-        );
-    }
+  // Add a transfer instruction for each address
+  for (const address of recipients) {
+    transferInstructions.push(
+      web3.SystemProgram.transfer({
+        fromPubkey: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+        toPubkey: address, // The destination account for the transfer
+        lamports: web3.LAMPORTS_PER_SOL * 0.01, // The amount of lamports to transfer
+      }),
+    );
+  }
 
-    // Create a transaction and add the transfer instructions
-    const transaction = new web3.Transaction().add(...transferInstructions);
+  // Create a transaction and add the transfer instructions
+  const transaction = new web3.Transaction().add(...transferInstructions);
 
-    // Send the transaction to the cluster (this will fail in this example if addresses > 21)
-    const txid = await connection.sendTransaction(transaction, [user]);
+  // Send the transaction to the cluster (this will fail in this example if addresses > 21)
+  const txid = await connection.sendTransaction(transaction, [user]);
 
-    // Get the latest blockhash and last valid block height
-    const { lastValidBlockHeight, blockhash } =
-        await connection.getLatestBlockhash();
+  // Get the latest blockhash and last valid block height
+  const { lastValidBlockHeight, blockhash } =
+    await connection.getLatestBlockhash();
 
-    // Confirm the transaction
-    await connection.confirmTransaction({
-        blockhash: blockhash,
-        lastValidBlockHeight: lastValidBlockHeight,
-        signature: txid,
-    });
+  // Confirm the transaction
+  await connection.confirmTransaction({
+    blockhash: blockhash,
+    lastValidBlockHeight: lastValidBlockHeight,
+    signature: txid,
+  });
 
-    // Log the transaction URL on the Solana Explorer
-    console.log(`https://explorer.solana.com/tx/${txid}?cluster=devnet`);
+  // Log the transaction URL on the Solana Explorer
+  console.log(`https://explorer.solana.com/tx/${txid}?cluster=devnet`);
 }
 ```
 
@@ -379,18 +379,18 @@ Before we start, go ahead and delete the content of the `main` function to leave
 
 ```ts
 async function main() {
-    // Connect to the devnet cluster
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  // Connect to the devnet cluster
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
 
-    // Initialize the user's keypair
-    const user = await initializeKeypair(connection);
-    console.log("PublicKey:", user.publicKey.toBase58());
+  // Initialize the user's keypair
+  const user = await initializeKeypair(connection);
+  console.log("PublicKey:", user.publicKey.toBase58());
 
-    // Generate 22 addresses
-    const addresses = [];
-    for (let i = 0; i < 22; i++) {
-        addresses.push(web3.Keypair.generate().publicKey);
-    }
+  // Generate 22 addresses
+  const addresses = [];
+  for (let i = 0; i < 22; i++) {
+    addresses.push(web3.Keypair.generate().publicKey);
+  }
 }
 ```
 
@@ -402,54 +402,52 @@ This function should take parameters for a connection, a user's keypair, an arra
 
 The function then performs the following tasks:
 
--   Retrieves the latest blockhash and last valid block height from the Solana network
--   Creates a new transaction message using the provided instructions
--   Signs the transaction using the user's keypair
--   Sends the transaction to the Solana network
--   Confirms the transaction
--   Logs the transaction URL on the Solana Explorer
+- Retrieves the latest blockhash and last valid block height from the Solana network
+- Creates a new transaction message using the provided instructions
+- Signs the transaction using the user's keypair
+- Sends the transaction to the Solana network
+- Confirms the transaction
+- Logs the transaction URL on the Solana Explorer
 
 ```ts
 async function sendV0Transaction(
-    connection: web3.Connection,
-    user: web3.Keypair,
-    instructions: web3.TransactionInstruction[],
-    lookupTableAccounts?: web3.AddressLookupTableAccount[],
+  connection: web3.Connection,
+  user: web3.Keypair,
+  instructions: web3.TransactionInstruction[],
+  lookupTableAccounts?: web3.AddressLookupTableAccount[],
 ) {
-    // Get the latest blockhash and last valid block height
-    const { lastValidBlockHeight, blockhash } =
-        await connection.getLatestBlockhash();
+  // Get the latest blockhash and last valid block height
+  const { lastValidBlockHeight, blockhash } =
+    await connection.getLatestBlockhash();
 
-    // Create a new transaction message with the provided instructions
-    const messageV0 = new web3.TransactionMessage({
-        payerKey: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-        recentBlockhash: blockhash, // The blockhash of the most recent block
-        instructions, // The instructions to include in the transaction
-    }).compileToV0Message(
-        lookupTableAccounts ? lookupTableAccounts : undefined,
-    );
+  // Create a new transaction message with the provided instructions
+  const messageV0 = new web3.TransactionMessage({
+    payerKey: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+    recentBlockhash: blockhash, // The blockhash of the most recent block
+    instructions, // The instructions to include in the transaction
+  }).compileToV0Message(lookupTableAccounts ? lookupTableAccounts : undefined);
 
-    // Create a new transaction object with the message
-    const transaction = new web3.VersionedTransaction(messageV0);
+  // Create a new transaction object with the message
+  const transaction = new web3.VersionedTransaction(messageV0);
 
-    // Sign the transaction with the user's keypair
-    transaction.sign([user]);
+  // Sign the transaction with the user's keypair
+  transaction.sign([user]);
 
-    // Send the transaction to the cluster
-    const txid = await connection.sendTransaction(transaction);
+  // Send the transaction to the cluster
+  const txid = await connection.sendTransaction(transaction);
 
-    // Confirm the transaction
-    await connection.confirmTransaction(
-        {
-            blockhash: blockhash,
-            lastValidBlockHeight: lastValidBlockHeight,
-            signature: txid,
-        },
-        "finalized",
-    );
+  // Confirm the transaction
+  await connection.confirmTransaction(
+    {
+      blockhash: blockhash,
+      lastValidBlockHeight: lastValidBlockHeight,
+      signature: txid,
+    },
+    "finalized",
+  );
 
-    // Log the transaction URL on the Solana Explorer
-    console.log(`https://explorer.solana.com/tx/${txid}?cluster=devnet`);
+  // Log the transaction URL on the Solana Explorer
+  console.log(`https://explorer.solana.com/tx/${txid}?cluster=devnet`);
 }
 ```
 
@@ -461,26 +459,26 @@ This function will have parameters for a connection and a target block height. I
 
 ```ts
 function waitForNewBlock(connection: web3.Connection, targetHeight: number) {
-    console.log(`Waiting for ${targetHeight} new blocks`);
-    return new Promise(async (resolve: any) => {
-        // Get the last valid block height of the blockchain
-        const { lastValidBlockHeight } = await connection.getLatestBlockhash();
+  console.log(`Waiting for ${targetHeight} new blocks`);
+  return new Promise(async (resolve: any) => {
+    // Get the last valid block height of the blockchain
+    const { lastValidBlockHeight } = await connection.getLatestBlockhash();
 
-        // Set an interval to check for new blocks every 1000ms
-        const intervalId = setInterval(async () => {
-            // Get the new valid block height
-            const { lastValidBlockHeight: newValidBlockHeight } =
-                await connection.getLatestBlockhash();
-            // console.log(newValidBlockHeight)
+    // Set an interval to check for new blocks every 1000ms
+    const intervalId = setInterval(async () => {
+      // Get the new valid block height
+      const { lastValidBlockHeight: newValidBlockHeight } =
+        await connection.getLatestBlockhash();
+      // console.log(newValidBlockHeight)
 
-            // Check if the new valid block height is greater than the target block height
-            if (newValidBlockHeight > lastValidBlockHeight + targetHeight) {
-                // If the target block height is reached, clear the interval and resolve the promise
-                clearInterval(intervalId);
-                resolve();
-            }
-        }, 1000);
-    });
+      // Check if the new valid block height is greater than the target block height
+      if (newValidBlockHeight > lastValidBlockHeight + targetHeight) {
+        // If the target block height is reached, clear the interval and resolve the promise
+        clearInterval(intervalId);
+        resolve();
+      }
+    }, 1000);
+  });
 }
 ```
 
@@ -496,37 +494,37 @@ Now that we have some helper functions ready to go, declare a function named `in
 
 ```ts
 async function initializeLookupTable(
-    user: web3.Keypair,
-    connection: web3.Connection,
-    addresses: web3.PublicKey[],
+  user: web3.Keypair,
+  connection: web3.Connection,
+  addresses: web3.PublicKey[],
 ): Promise<web3.PublicKey> {
-    // Get the current slot
-    const slot = await connection.getSlot();
+  // Get the current slot
+  const slot = await connection.getSlot();
 
-    // Create an instruction for creating a lookup table
-    // and retrieve the address of the new lookup table
-    const [lookupTableInst, lookupTableAddress] =
-        web3.AddressLookupTableProgram.createLookupTable({
-            authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-            payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-            recentSlot: slot - 1, // The recent slot to derive lookup table's address
-        });
-    console.log("lookup table address:", lookupTableAddress.toBase58());
-
-    // Create an instruction to extend a lookup table with the provided addresses
-    const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
-        payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-        authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-        lookupTable: lookupTableAddress, // The address of the lookup table to extend
-        addresses: addresses.slice(0, 30), // The addresses to add to the lookup table
+  // Create an instruction for creating a lookup table
+  // and retrieve the address of the new lookup table
+  const [lookupTableInst, lookupTableAddress] =
+    web3.AddressLookupTableProgram.createLookupTable({
+      authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+      payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+      recentSlot: slot - 1, // The recent slot to derive lookup table's address
     });
+  console.log("lookup table address:", lookupTableAddress.toBase58());
 
-    await sendV0Transaction(connection, user, [
-        lookupTableInst,
-        extendInstruction,
-    ]);
+  // Create an instruction to extend a lookup table with the provided addresses
+  const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
+    payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+    lookupTable: lookupTableAddress, // The address of the lookup table to extend
+    addresses: addresses.slice(0, 30), // The addresses to add to the lookup table
+  });
 
-    return lookupTableAddress;
+  await sendV0Transaction(connection, user, [
+    lookupTableInst,
+    extendInstruction,
+  ]);
+
+  return lookupTableAddress;
 }
 ```
 
@@ -542,46 +540,46 @@ Now that we can initialize a lookup table with all of the recipients' addresses,
 
 ```ts
 async function main() {
-    // Connect to the devnet cluster
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+  // Connect to the devnet cluster
+  const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
 
-    // Initialize the user's keypair
-    const user = await initializeKeypair(connection);
-    console.log("PublicKey:", user.publicKey.toBase58());
+  // Initialize the user's keypair
+  const user = await initializeKeypair(connection);
+  console.log("PublicKey:", user.publicKey.toBase58());
 
-    // Generate 22 addresses
-    const recipients = [];
-    for (let i = 0; i < 22; i++) {
-        recipients.push(web3.Keypair.generate().publicKey);
-    }
+  // Generate 22 addresses
+  const recipients = [];
+  for (let i = 0; i < 22; i++) {
+    recipients.push(web3.Keypair.generate().publicKey);
+  }
 
-    const lookupTableAddress = await initializeLookupTable(
-        user,
-        connection,
-        recipients,
-    );
+  const lookupTableAddress = await initializeLookupTable(
+    user,
+    connection,
+    recipients,
+  );
 
-    await waitForNewBlock(connection, 1);
+  await waitForNewBlock(connection, 1);
 
-    const lookupTableAccount = (
-        await connection.getAddressLookupTable(lookupTableAddress)
-    ).value;
+  const lookupTableAccount = (
+    await connection.getAddressLookupTable(lookupTableAddress)
+  ).value;
 
-    if (!lookupTableAccount) {
-        throw new Error("Lookup table not found");
-    }
+  if (!lookupTableAccount) {
+    throw new Error("Lookup table not found");
+  }
 
-    const transferInstructions = recipients.map((recipient) => {
-        return web3.SystemProgram.transfer({
-            fromPubkey: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-            toPubkey: recipient, // The destination account for the transfer
-            lamports: web3.LAMPORTS_PER_SOL * 0.01, // The amount of lamports to transfer
-        });
+  const transferInstructions = recipients.map(recipient => {
+    return web3.SystemProgram.transfer({
+      fromPubkey: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+      toPubkey: recipient, // The destination account for the transfer
+      lamports: web3.LAMPORTS_PER_SOL * 0.01, // The amount of lamports to transfer
     });
+  });
 
-    await sendV0Transaction(connection, user, transferInstructions, [
-        lookupTableAccount,
-    ]);
+  await sendV0Transaction(connection, user, transferInstructions, [
+    lookupTableAccount,
+  ]);
 }
 ```
 
@@ -614,53 +612,52 @@ All we need to do is go into `initializeLookupTable` and do two things:
 
 ```ts
 async function initializeLookupTable(
-    user: web3.Keypair,
-    connection: web3.Connection,
-    addresses: web3.PublicKey[],
+  user: web3.Keypair,
+  connection: web3.Connection,
+  addresses: web3.PublicKey[],
 ): Promise<web3.PublicKey> {
-    // Get the current slot
-    const slot = await connection.getSlot();
+  // Get the current slot
+  const slot = await connection.getSlot();
 
-    // Create an instruction for creating a lookup table
-    // and retrieve the address of the new lookup table
-    const [lookupTableInst, lookupTableAddress] =
-        web3.AddressLookupTableProgram.createLookupTable({
-            authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-            payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-            recentSlot: slot - 1, // The recent slot to derive lookup table's address
-        });
-    console.log("lookup table address:", lookupTableAddress.toBase58());
+  // Create an instruction for creating a lookup table
+  // and retrieve the address of the new lookup table
+  const [lookupTableInst, lookupTableAddress] =
+    web3.AddressLookupTableProgram.createLookupTable({
+      authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+      payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+      recentSlot: slot - 1, // The recent slot to derive lookup table's address
+    });
+  console.log("lookup table address:", lookupTableAddress.toBase58());
 
-    // Create an instruction to extend a lookup table with the provided addresses
+  // Create an instruction to extend a lookup table with the provided addresses
+  const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
+    payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+    authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+    lookupTable: lookupTableAddress, // The address of the lookup table to extend
+    addresses: addresses.slice(0, 30), // The addresses to add to the lookup table
+  });
+
+  await sendV0Transaction(connection, user, [
+    lookupTableInst,
+    extendInstruction,
+  ]);
+
+  var remaining = addresses.slice(30);
+
+  while (remaining.length > 0) {
+    const toAdd = remaining.slice(0, 30);
+    remaining = remaining.slice(30);
     const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
-        payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-        authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-        lookupTable: lookupTableAddress, // The address of the lookup table to extend
-        addresses: addresses.slice(0, 30), // The addresses to add to the lookup table
+      payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
+      authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
+      lookupTable: lookupTableAddress, // The address of the lookup table to extend
+      addresses: toAdd, // The addresses to add to the lookup table
     });
 
-    await sendV0Transaction(connection, user, [
-        lookupTableInst,
-        extendInstruction,
-    ]);
+    await sendV0Transaction(connection, user, [extendInstruction]);
+  }
 
-    var remaining = addresses.slice(30);
-
-    while (remaining.length > 0) {
-        const toAdd = remaining.slice(0, 30);
-        remaining = remaining.slice(30);
-        const extendInstruction =
-            web3.AddressLookupTableProgram.extendLookupTable({
-                payer: user.publicKey, // The payer (i.e., the account that will pay for the transaction fees)
-                authority: user.publicKey, // The authority (i.e., the account with permission to modify the lookup table)
-                lookupTable: lookupTableAddress, // The address of the lookup table to extend
-                addresses: toAdd, // The addresses to add to the lookup table
-            });
-
-        await sendV0Transaction(connection, user, [extendInstruction]);
-    }
-
-    return lookupTableAddress;
+  return lookupTableAddress;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "contentlayer:build": "npx contentlayer build --clearCache",
-    "test": "yarn contentlayer:build"
+    "test": "yarn contentlayer:build",
+    "prettier": "npx prettier -w developers"
   },
   "devDependencies": {
     "contentlayer": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "contentlayer": "0.3.0",
     "eslint": "^8.38.0",
+    "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,14 +4,14 @@
 
 "@babel/runtime@^7.16.3":
   version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
   dependencies:
     regenerator-runtime "^0.13.11"
 
 "@contentlayer/cli@0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@contentlayer/cli/-/cli-0.3.0.tgz#59ef411f3405cb58524962f043e54e42104969db"
+  resolved "https://registry.npmjs.org/@contentlayer/cli/-/cli-0.3.0.tgz"
   integrity sha512-Mqb6NlIKINt2qsPKft+o8m5tJhJXVgVSd0zP1BH+CQRmvR/zwTT3maz1bDCPHBYGKgGCQKtvgM66IjvH+dmC6Q==
   dependencies:
     "@contentlayer/core" "0.3.0"
@@ -21,14 +21,14 @@
 
 "@contentlayer/client@0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@contentlayer/client/-/client-0.3.0.tgz#a5d1f3c598697383b93beff53489918c57e93faa"
+  resolved "https://registry.npmjs.org/@contentlayer/client/-/client-0.3.0.tgz"
   integrity sha512-yzDYiZtqOJwWrsykieA1LMnhKbaYcJhAy7s8Xs7zU5wFfyBTO258gvmK5dVi4LuzmOOPVMJn6FpEofT/RAKVtg==
   dependencies:
     "@contentlayer/core" "0.3.0"
 
 "@contentlayer/core@0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@contentlayer/core/-/core-0.3.0.tgz#67c6cf5fdcacdef9e957bb14fb90510fe671cd82"
+  resolved "https://registry.npmjs.org/@contentlayer/core/-/core-0.3.0.tgz"
   integrity sha512-5cL4W0nK9kNqxgBkIgauUko0SRAHf8oPoxRhdsSPQ7FSCgZGz2crMeSJOFmj3a3govh863/mKhXfkoUJBoDgnA==
   dependencies:
     "@contentlayer/utils" "0.3.0"
@@ -47,7 +47,7 @@
 
 "@contentlayer/source-files@0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@contentlayer/source-files/-/source-files-0.3.0.tgz#84cd220a664c34568396ce5cbbe1dadf880fa9ed"
+  resolved "https://registry.npmjs.org/@contentlayer/source-files/-/source-files-0.3.0.tgz"
   integrity sha512-6crNuRdWGYFec0Kn/DpbrzpOu8bttFmOmOpX1HIYQz4iPisg+8biybLBiNU7Y6aCUjEZLOnM7AaHpMFvhrYWsw==
   dependencies:
     "@contentlayer/core" "0.3.0"
@@ -64,7 +64,7 @@
 
 "@contentlayer/source-remote-files@0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@contentlayer/source-remote-files/-/source-remote-files-0.3.0.tgz#c081acd2692d46ca7bc332b2dc921c36d8ee65f5"
+  resolved "https://registry.npmjs.org/@contentlayer/source-remote-files/-/source-remote-files-0.3.0.tgz"
   integrity sha512-4PnaK5cfQiduMUEO6nzqsD4ttD5RG4ffcyeSp5MLhpU0DTEZcfGXFRO777ddEI8PZ0/NJuhfz9MGbdO90QYlsw==
   dependencies:
     "@contentlayer/core" "0.3.0"
@@ -73,7 +73,7 @@
 
 "@contentlayer/utils@0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@contentlayer/utils/-/utils-0.3.0.tgz#6846e47a0998ecd144515c597d930cb52da0806e"
+  resolved "https://registry.npmjs.org/@contentlayer/utils/-/utils-0.3.0.tgz"
   integrity sha512-GJF8Z67bf8KJbMqtZgt3G/m4Um93XrcryMJ+2Q1SUBRCEDuMcm8iLPaSbMQ0+gjxyW0GWHnR1oM+qyzaWTPgdg==
   dependencies:
     "@effect-ts/core" "^0.60.2"
@@ -97,45 +97,45 @@
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@effect-ts/core@^0.60.2":
   version "0.60.5"
-  resolved "https://registry.yarnpkg.com/@effect-ts/core/-/core-0.60.5.tgz#df79049e1be4a576ab6b45abbe92c831bda62361"
+  resolved "https://registry.npmjs.org/@effect-ts/core/-/core-0.60.5.tgz"
   integrity sha512-qi1WrtJA90XLMnj2hnUszW9Sx4dXP03ZJtCc5DiUBIOhF4Vw7plfb65/bdBySPoC9s7zy995TdUX1XBSxUkl5w==
   dependencies:
     "@effect-ts/system" "^0.57.5"
 
 "@effect-ts/otel-exporter-trace-otlp-grpc@^0.14.0":
   version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@effect-ts/otel-exporter-trace-otlp-grpc/-/otel-exporter-trace-otlp-grpc-0.14.1.tgz#c4ae560a820d15780a285cfe8cb1f7558217ae9d"
+  resolved "https://registry.npmjs.org/@effect-ts/otel-exporter-trace-otlp-grpc/-/otel-exporter-trace-otlp-grpc-0.14.1.tgz"
   integrity sha512-eb6dJhVKnjS1v8afdPm+wuZ3JeX2Gt3GJA9Vw5D2aESE7wa3mrpElsNNbDXn6rhgyjZq3VWYY/NXVtLAFOQIbQ==
   dependencies:
     "@effect-ts/otel" "^0.14.1"
 
 "@effect-ts/otel-sdk-trace-node@^0.14.0":
   version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@effect-ts/otel-sdk-trace-node/-/otel-sdk-trace-node-0.14.1.tgz#306aeacf3109141ee8675250d9cc34aa2fc5eb09"
+  resolved "https://registry.npmjs.org/@effect-ts/otel-sdk-trace-node/-/otel-sdk-trace-node-0.14.1.tgz"
   integrity sha512-j5ynRvd0H+Fp9aH/5NOtBd1ogNMpNB3r7uiXOKRPlfKUOtdx4KsCt2cPBjChMvyLstj8dkjtWE4loLSTYkWPuA==
   dependencies:
     "@effect-ts/otel" "^0.14.1"
 
 "@effect-ts/otel@^0.14.0", "@effect-ts/otel@^0.14.1":
   version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@effect-ts/otel/-/otel-0.14.1.tgz#ccea2deabb9d87e380fd5197546a9edb5ad104fe"
+  resolved "https://registry.npmjs.org/@effect-ts/otel/-/otel-0.14.1.tgz"
   integrity sha512-WtkxdoM1M8bl7F1mrSwBZQJAIaUXcupePrllL7iZnvSfUVhYXV98gRTV6EiVT+prX7rzCW4wPkF/XsyWbtMDtA==
 
 "@effect-ts/system@^0.57.5":
   version "0.57.5"
-  resolved "https://registry.yarnpkg.com/@effect-ts/system/-/system-0.57.5.tgz#921e9b39dcea2d1728e0f49a0af233472efdc6cb"
+  resolved "https://registry.npmjs.org/@effect-ts/system/-/system-0.57.5.tgz"
   integrity sha512-/crHGujo0xnuHIYNc1VgP0HGJGFSoSqq88JFXe6FmFyXPpWt8Xu39LyLg7rchsxfXFeEdA9CrIZvLV5eswXV5g==
 
 "@esbuild-plugins/node-resolve@^0.1.4":
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-resolve/-/node-resolve-0.1.4.tgz#2257ef3b233c9cb3acd2ebde7d5a3d6874046d38"
+  resolved "https://registry.npmjs.org/@esbuild-plugins/node-resolve/-/node-resolve-0.1.4.tgz"
   integrity sha512-haFQ0qhxEpqtWWY0kx1Y5oE3sMyO1PcoSiWEPrAw6tm/ZOOLXjSs6Q+v1v9eyuVF0nNt50YEvrcrvENmyoMv5g==
   dependencies:
     "@types/resolve" "^1.17.1"
@@ -143,131 +143,26 @@
     escape-string-regexp "^4.0.0"
     resolve "^1.19.0"
 
-"@esbuild/android-arm64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz#164b054d58551f8856285f386e1a8f45d9ba3a31"
-  integrity sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==
-
-"@esbuild/android-arm@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.17.tgz#1b3b5a702a69b88deef342a7a80df4c894e4f065"
-  integrity sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==
-
-"@esbuild/android-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.17.tgz#6781527e3c4ea4de532b149d18a2167f06783e7f"
-  integrity sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==
-
 "@esbuild/darwin-arm64@0.17.17":
   version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz#c5961ef4d3c1cc80dafe905cc145b5a71d2ac196"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz"
   integrity sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==
-
-"@esbuild/darwin-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz#b81f3259cc349691f67ae30f7b333a53899b3c20"
-  integrity sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==
-
-"@esbuild/freebsd-arm64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz#db846ad16cf916fd3acdda79b85ea867cb100e87"
-  integrity sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==
-
-"@esbuild/freebsd-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz#4dd99acbaaba00949d509e7c144b1b6ef9e1815b"
-  integrity sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==
-
-"@esbuild/linux-arm64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz#7f9274140b2bb9f4230dbbfdf5dc2761215e30f6"
-  integrity sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==
-
-"@esbuild/linux-arm@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz#5c8e44c2af056bb2147cf9ad13840220bcb8948b"
-  integrity sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==
-
-"@esbuild/linux-ia32@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz#18a6b3798658be7f46e9873fa0c8d4bec54c9212"
-  integrity sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==
-
-"@esbuild/linux-loong64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz#a8d93514a47f7b4232716c9f02aeb630bae24c40"
-  integrity sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==
-
-"@esbuild/linux-mips64el@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz#4784efb1c3f0eac8133695fa89253d558149ee1b"
-  integrity sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==
-
-"@esbuild/linux-ppc64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz#ef6558ec5e5dd9dc16886343e0ccdb0699d70d3c"
-  integrity sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==
-
-"@esbuild/linux-riscv64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz#13a87fdbcb462c46809c9d16bcf79817ecf9ce6f"
-  integrity sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==
-
-"@esbuild/linux-s390x@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz#83cb16d1d3ac0dca803b3f031ba3dc13f1ec7ade"
-  integrity sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==
-
-"@esbuild/linux-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz#7bc400568690b688e20a0c94b2faabdd89ae1a79"
-  integrity sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==
-
-"@esbuild/netbsd-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz#1b5dcfbc4bfba80e67a11e9148de836af5b58b6c"
-  integrity sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==
-
-"@esbuild/openbsd-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz#e275098902291149a5dcd012c9ea0796d6b7adff"
-  integrity sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==
-
-"@esbuild/sunos-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz#10603474866f64986c0370a2d4fe5a2bb7fee4f5"
-  integrity sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==
-
-"@esbuild/win32-arm64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz#521a6d97ee0f96b7c435930353cc4e93078f0b54"
-  integrity sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==
-
-"@esbuild/win32-ia32@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz#56f88462ebe82dad829dc2303175c0e0ccd8e38e"
-  integrity sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==
-
-"@esbuild/win32-x64@0.17.17":
-  version "0.17.17"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz#2b577b976e6844106715bbe0cdc57cd1528063f9"
-  integrity sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.4.0":
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.0.tgz#f6f729b02feee2c749f57e334b7a1b5f40a81724"
+  resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz"
   integrity sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==
 
 "@eslint/eslintrc@^2.0.2":
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.2.tgz#01575e38707add677cf73ca1589abba8da899a02"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz"
   integrity sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==
   dependencies:
     ajv "^6.12.4"
@@ -282,17 +177,17 @@
 
 "@eslint/js@8.38.0":
   version "8.38.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.38.0.tgz#73a8a0d8aa8a8e6fe270431c5e72ae91b5337892"
+  resolved "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz"
   integrity sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==
 
 "@fal-works/esbuild-plugin-global-externals@^2.1.2":
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
+  resolved "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz"
   integrity sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==
 
 "@grpc/grpc-js@^1.5.9":
   version "1.8.14"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.14.tgz#4fe0f9917d6f094cf59245763c275442b182e9ad"
+  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz"
   integrity sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
@@ -300,7 +195,7 @@
 
 "@grpc/proto-loader@^0.6.9":
   version "0.6.13"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.6.13.tgz#008f989b72a40c60c96cd4088522f09b05ac66bc"
+  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz"
   integrity sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==
   dependencies:
     "@types/long" "^4.0.1"
@@ -311,7 +206,7 @@
 
 "@grpc/proto-loader@^0.7.0":
   version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.6.tgz#b71fdf92b184af184b668c4e9395a5ddc23d61de"
+  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz"
   integrity sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==
   dependencies:
     "@types/long" "^4.0.1"
@@ -322,7 +217,7 @@
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
+  resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz"
   integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
@@ -331,27 +226,27 @@
 
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  resolved "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
@@ -359,7 +254,7 @@
 
 "@js-temporal/polyfill@^0.4.3":
   version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
+  resolved "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.3.tgz"
   integrity sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==
   dependencies:
     jsbi "^4.1.0"
@@ -367,7 +262,7 @@
 
 "@mdx-js/esbuild@^2.0.0":
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@mdx-js/esbuild/-/esbuild-2.3.0.tgz#97f2f1b854d904c50bcd0a219b3664657f4fe8c3"
+  resolved "https://registry.npmjs.org/@mdx-js/esbuild/-/esbuild-2.3.0.tgz"
   integrity sha512-r/vsqsM0E+U4Wr0DK+0EfmABE/eg+8ITW4DjvYdh3ve/tK2safaqHArNnaqbOk1DjYGrhxtoXoGaM3BY8fGBTA==
   dependencies:
     "@mdx-js/mdx" "^2.0.0"
@@ -376,7 +271,7 @@
 
 "@mdx-js/mdx@^2.0.0":
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-2.3.0.tgz#d65d8c3c28f3f46bb0e7cb3bf7613b39980671a9"
+  resolved "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.3.0.tgz"
   integrity sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -399,20 +294,20 @@
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
   integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
@@ -420,36 +315,31 @@
 
 "@opentelemetry/api-metrics@0.31.0":
   version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.31.0.tgz#0ed4cf4d7c731f968721c2b303eaf5e9fd42f736"
+  resolved "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.31.0.tgz"
   integrity sha512-PcL1x0kZtMie7NsNy67OyMvzLEXqf3xd0TZJKHHPMGTe89oMpNVrD1zJB1kZcwXOxLlHHb6tz21G3vvXPdXyZg==
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
-"@opentelemetry/api@^1.0.0":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f"
-  integrity sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==
-
-"@opentelemetry/api@~1.1.0":
+"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.1.0", "@opentelemetry/api@>=1.0.0 <1.2.0", "@opentelemetry/api@~1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.1.0.tgz#563539048255bbe1a5f4f586a4a10a1bb737f44a"
+  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz"
   integrity sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==
 
 "@opentelemetry/context-async-hooks@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-1.5.0.tgz#4955313e7f0ec0fe17c813328a2a7f39f262c0fa"
+  resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.5.0.tgz"
   integrity sha512-mhBPP0BU0RaH2HB8U4MDd5OjWA1y7SoLOovCT0iEpJAltaq2z04uxRJVzIs91vkpNnV0utUZowQQD3KElgU+VA==
 
-"@opentelemetry/core@1.5.0", "@opentelemetry/core@~1.5.0":
+"@opentelemetry/core@^1.5.0", "@opentelemetry/core@~1.5.0", "@opentelemetry/core@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.5.0.tgz#717bceee15d4c69d4c7321c1fe0f5a562b60eb81"
+  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-1.5.0.tgz"
   integrity sha512-B3DIMkQN0DANrr7XrMLS4pR6d2o/jqT09x4nZJz6wSJ9SHr4eQIqeFBNeEUQG1I+AuOcH2UbJtgFm7fKxLqd+w==
   dependencies:
     "@opentelemetry/semantic-conventions" "1.5.0"
 
-"@opentelemetry/exporter-trace-otlp-grpc@~0.31.0":
+"@opentelemetry/exporter-trace-otlp-grpc@^0.31.0", "@opentelemetry/exporter-trace-otlp-grpc@~0.31.0":
   version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.31.0.tgz#64b2f4c08e3f54015522e9eeeb0613f7d853e1e8"
+  resolved "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.31.0.tgz"
   integrity sha512-WapHtHPLOFObRMvtfRJX/EBRZS4YLpRY8E/OtIQmmAqwImDMAnMVF9fAjP6DSE/thOIN3Ot0/PLK5zFZUVV8SA==
   dependencies:
     "@grpc/grpc-js" "^1.5.9"
@@ -462,14 +352,14 @@
 
 "@opentelemetry/otlp-exporter-base@0.31.0":
   version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.31.0.tgz#0fa36e129ea6a239adb999578960e0f4e57f1eda"
+  resolved "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.31.0.tgz"
   integrity sha512-MI+LtGo/ZYL/g7ldWTAY9vMjMqlcWMj2undgcnq8Y5BoDLI8oBwGn//Lizjk4NikF+SkcolKB3+U05nCeT5djg==
   dependencies:
     "@opentelemetry/core" "1.5.0"
 
 "@opentelemetry/otlp-grpc-exporter-base@0.31.0":
   version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.31.0.tgz#d203ff79ecc5a18b6d5b3ec680af7ea5238046f3"
+  resolved "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.31.0.tgz"
   integrity sha512-TfNZsQhWNd05CAaOwgN2lVthC8mkxvoArV6LfSyKyqSZ6srCnYPuW64yS/9buEhNvTkT3y63dzkVSnnv/1b3ow==
   dependencies:
     "@grpc/grpc-js" "^1.5.9"
@@ -479,7 +369,7 @@
 
 "@opentelemetry/otlp-transformer@0.31.0":
   version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.31.0.tgz#c4ec628c60f2d7ef9e82769a5cd9c3f44bb18eb2"
+  resolved "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.31.0.tgz"
   integrity sha512-xCEsB0gTs7s/FMEv8+DWE6awfHJ5oHkFKSGePr6tT5Mh95rd1845WTefvLc++mYpewY8KnQ7tyo/zEfwywCIhw==
   dependencies:
     "@opentelemetry/api-metrics" "0.31.0"
@@ -490,21 +380,21 @@
 
 "@opentelemetry/propagator-b3@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-1.5.0.tgz#7fc1876f11e0a92fc93185d14e0dae99f42bb135"
+  resolved "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.5.0.tgz"
   integrity sha512-38iGIScgU9OLhoPKAV3p2rEf4RmmQC/Lo4LvpQ6TaSQrRht/oDgnpsPJnmNQLFboklmukKataJO+FhAieOc7mg==
   dependencies:
     "@opentelemetry/core" "1.5.0"
 
 "@opentelemetry/propagator-jaeger@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.5.0.tgz#b4ccffc0fa59f94ea67e0884c543d39bbbd1c18d"
+  resolved "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.5.0.tgz"
   integrity sha512-aSUH5RDEZj+lmy4PbXAJ26E+yJcZloyPUBWgqYX+JBS4NnbriIznCF/tXV5s/RUXeVABibi/+yAZndv+2XBg4w==
   dependencies:
     "@opentelemetry/core" "1.5.0"
 
-"@opentelemetry/resources@1.5.0", "@opentelemetry/resources@~1.5.0":
+"@opentelemetry/resources@~1.5.0", "@opentelemetry/resources@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.5.0.tgz#ce7fbdaec3494e41bc279ddbed3c478ee2570b03"
+  resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.5.0.tgz"
   integrity sha512-YeEfC6IY54U3xL3P2+UAiom+r50ZF2jM0J47RV5uTFGF19Xjd5zazSwDPgmxtAd6DwLX0/5S5iqrsH4nEXMYoA==
   dependencies:
     "@opentelemetry/core" "1.5.0"
@@ -512,7 +402,7 @@
 
 "@opentelemetry/sdk-metrics-base@0.31.0":
   version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.31.0.tgz#f797da702c8d9862a2fff55a1e7c70aa6845e535"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.31.0.tgz"
   integrity sha512-4R2Bjl3wlqIGcq4bCoI9/pD49ld+tEoM9n85UfFzr/aUe+2huY2jTPq/BP9SVB8d2Zfg7mGTIFeapcEvAdKK7g==
   dependencies:
     "@opentelemetry/api-metrics" "0.31.0"
@@ -520,18 +410,18 @@
     "@opentelemetry/resources" "1.5.0"
     lodash.merge "4.6.2"
 
-"@opentelemetry/sdk-trace-base@1.5.0", "@opentelemetry/sdk-trace-base@~1.5.0":
+"@opentelemetry/sdk-trace-base@^1.5.0", "@opentelemetry/sdk-trace-base@~1.5.0", "@opentelemetry/sdk-trace-base@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.5.0.tgz#259439009fff5637e7a379ece7446ce5beb84b77"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.5.0.tgz"
   integrity sha512-6lx7YDf67HSQYuWnvq3XgSrWikDJLiGCbrpUP6UWJ5Z47HLcJvwZPRH+cQGJu1DFS3dT2cV3GpAR75/OofPNHQ==
   dependencies:
     "@opentelemetry/core" "1.5.0"
     "@opentelemetry/resources" "1.5.0"
     "@opentelemetry/semantic-conventions" "1.5.0"
 
-"@opentelemetry/sdk-trace-node@~1.5.0":
+"@opentelemetry/sdk-trace-node@^1.5.0", "@opentelemetry/sdk-trace-node@~1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.5.0.tgz#8a6af64b8e6fb970b998844f99349e654327a60d"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.5.0.tgz"
   integrity sha512-MzS+urf2KufpwgaHbGcUgccHr6paxI98lHFMgJAkK6w76AmPYavsxSwjiVPrchy/24d2J9svDirSgui3NNZo8g==
   dependencies:
     "@opentelemetry/context-async-hooks" "1.5.0"
@@ -541,34 +431,34 @@
     "@opentelemetry/sdk-trace-base" "1.5.0"
     semver "^7.3.5"
 
-"@opentelemetry/semantic-conventions@1.5.0", "@opentelemetry/semantic-conventions@~1.5.0":
+"@opentelemetry/semantic-conventions@~1.5.0", "@opentelemetry/semantic-conventions@1.5.0":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz#cea9792bfcf556c87ded17c6ac729348697bb632"
+  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz"
   integrity sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz"
   integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
 
 "@protobufjs/base64@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  resolved "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz"
   integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
 
 "@protobufjs/codegen@^2.0.4":
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz"
   integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  resolved "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz"
   integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
@@ -576,142 +466,142 @@
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  resolved "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
 "@protobufjs/inquire@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  resolved "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz"
   integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  resolved "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz"
   integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
 
 "@protobufjs/pool@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  resolved "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz"
   integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
 
 "@protobufjs/utf8@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz"
   integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
 
 "@tsconfig/node12@^1.0.7":
   version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz"
   integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
 "@tsconfig/node14@^1.0.0":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  resolved "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz"
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/node16@^1.0.2":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/acorn@^4.0.0":
   version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
+  resolved "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz"
   integrity sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==
   dependencies:
     "@types/estree" "*"
 
 "@types/debug@^4.0.0":
   version "4.1.7"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
   dependencies:
     "@types/ms" "*"
 
 "@types/estree-jsx@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-1.0.0.tgz#7bfc979ab9f692b492017df42520f7f765e98df1"
+  resolved "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz"
   integrity sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==
   dependencies:
     "@types/estree" "*"
 
 "@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz"
   integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
 
 "@types/hast@^2.0.0":
   version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
+  resolved "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz"
   integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==
   dependencies:
     "@types/unist" "*"
 
 "@types/long@^4.0.1":
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  resolved "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/mdast@^3.0.0":
   version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.11.tgz#dc130f7e7d9306124286f6d6cee40cf4d14a3dc0"
+  resolved "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz"
   integrity sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==
   dependencies:
     "@types/unist" "*"
 
 "@types/mdx@^2.0.0":
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.4.tgz#d1cad61ccc803b3c248c3d9990a2a6880bef537f"
+  resolved "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.4.tgz"
   integrity sha512-qCYrNdpKwN6YO6FVnx+ulfqifKlE3lQGsNhvDaW9Oxzyob/cRLBJWow8GHBBD4NxQ7BVvtsATgLsX0vZAWmtrg==
 
 "@types/ms@*":
   version "0.7.31"
-  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  resolved "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "18.15.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
-  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
+  version "20.4.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz"
+  integrity sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==
 
 "@types/parse5@^6.0.0":
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
+  resolved "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz"
   integrity sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==
 
 "@types/resolve@^1.17.1":
   version "1.20.2"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
+  resolved "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
+  resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
 acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^8.1.1:
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.0.0, acorn@^8.4.1, acorn@^8.8.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.0.0, acorn@^8.4.1, acorn@^8.8.0:
   version "8.8.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -721,19 +611,19 @@ ajv@^6.10.0, ajv@^6.12.4:
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
 
 anymatch@~3.1.2:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
@@ -741,49 +631,49 @@ anymatch@~3.1.2:
 
 arg@^4.1.0:
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-timsort@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-timsort/-/array-timsort-1.0.3.tgz#3c9e4199e54fb2b9c3fe5976396a21614ef0d926"
+  resolved "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz"
   integrity sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==
 
 astring@^1.8.0:
   version "1.8.4"
-  resolved "https://registry.yarnpkg.com/astring/-/astring-1.8.4.tgz#6d4c5d8de7be2ead9e4a3cc0e2efb8d759378904"
+  resolved "https://registry.npmjs.org/astring/-/astring-1.8.4.tgz"
   integrity sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw==
 
 bail@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  resolved "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz"
   integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
@@ -791,24 +681,24 @@ brace-expansion@^1.1.7:
 
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
 
 buffer-from@^1.0.0:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 callsites@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camel-case@^4.1.2:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  resolved "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz"
   integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
   dependencies:
     pascal-case "^3.1.2"
@@ -816,12 +706,12 @@ camel-case@^4.1.2:
 
 ccount@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
 chalk@^4.0.0:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
@@ -829,27 +719,27 @@ chalk@^4.0.0:
 
 character-entities-html4@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  resolved "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz"
   integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
 
 character-entities-legacy@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  resolved "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz"
   integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
 
 character-entities@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  resolved "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
 
 character-reference-invalid@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  resolved "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz"
   integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
 chokidar@^3.5.3:
   version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
@@ -864,14 +754,14 @@ chokidar@^3.5.3:
 
 clipanion@^3.2.0-rc.14:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/clipanion/-/clipanion-3.2.0.tgz#ea55ce3fe27becb4ddd4915df6fb3de0f9e79a5c"
+  resolved "https://registry.npmjs.org/clipanion/-/clipanion-3.2.0.tgz"
   integrity sha512-XaPQiJQZKbyaaDbv5yR/cAt/ORfZfENkr4wGQj+Go/Uf/65ofTQBCPirgWFeJctZW24V3mxrFiEnEmqBflrJYA==
   dependencies:
     typanion "^3.8.0"
 
 cliui@^7.0.2:
   version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
   integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
   dependencies:
     string-width "^4.2.0"
@@ -880,24 +770,24 @@ cliui@^7.0.2:
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
 comment-json@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-4.2.3.tgz#50b487ebbf43abe44431f575ebda07d30d015365"
+  resolved "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz"
   integrity sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==
   dependencies:
     array-timsort "^1.0.3"
@@ -908,12 +798,12 @@ comment-json@^4.2.3:
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 contentlayer@0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/contentlayer/-/contentlayer-0.3.0.tgz#98c9a0b6aba50c807695cc94434eab4541b1e2bc"
+  resolved "https://registry.npmjs.org/contentlayer/-/contentlayer-0.3.0.tgz"
   integrity sha512-3LEF5HMHjSytlT8SErC3U59Pt2LP80a6Z2f/0mSIPeA4xty0LNChyHqzALySSM0osAEz32RY56Fifk5P+2dCIA==
   dependencies:
     "@contentlayer/cli" "0.3.0"
@@ -925,17 +815,17 @@ contentlayer@0.3.0:
 
 core-util-is@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 create-require@^1.1.0:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.2:
   version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
@@ -944,58 +834,58 @@ cross-spawn@^7.0.2:
 
 data-uri-to-buffer@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
 debug@^4.0.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
 decode-named-character-reference@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  resolved "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz"
   integrity sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==
   dependencies:
     character-entities "^2.0.0"
 
 deep-is@^0.1.3:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 dequal@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
 diff@^4.0.1:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  resolved "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 doctrine@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-esbuild@0.17.x:
+esbuild@*, esbuild@>=0.11.0, esbuild@0.*, esbuild@0.17.x:
   version "0.17.17"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.17.tgz#fa906ab11b11d2ed4700f494f4f764229b25c916"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz"
   integrity sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==
   optionalDependencies:
     "@esbuild/android-arm" "0.17.17"
@@ -1023,17 +913,17 @@ esbuild@0.17.x:
 
 escalade@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-scope@^7.1.1:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz"
   integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
   dependencies:
     esrecurse "^4.3.0"
@@ -1041,12 +931,12 @@ eslint-scope@^7.1.1:
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.0:
   version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz"
   integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
 
-eslint@^8.38.0:
+"eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^8.38.0:
   version "8.38.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.38.0.tgz#a62c6f36e548a5574dd35728ac3c6209bd1e2f1a"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz"
   integrity sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
@@ -1092,7 +982,7 @@ eslint@^8.38.0:
 
 espree@^9.5.1:
   version "9.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.1.tgz#4f26a4d5f18905bf4f2e0bd99002aab807e96dd4"
+  resolved "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz"
   integrity sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==
   dependencies:
     acorn "^8.8.0"
@@ -1101,38 +991,38 @@ espree@^9.5.1:
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.4.2:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  resolved "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
 esrecurse@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
 
 estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 estree-util-attach-comments@^2.0.0:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/estree-util-attach-comments/-/estree-util-attach-comments-2.1.1.tgz#ee44f4ff6890ee7dfb3237ac7810154c94c63f84"
+  resolved "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-2.1.1.tgz"
   integrity sha512-+5Ba/xGGS6mnwFbXIuQiDPTbuTxuMCooq3arVv7gPZtYpjp+VXH/NkHAP35OOefPhNG/UGqU3vt/LTABwcHX0w==
   dependencies:
     "@types/estree" "^1.0.0"
 
 estree-util-build-jsx@^2.0.0:
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/estree-util-build-jsx/-/estree-util-build-jsx-2.2.2.tgz#32f8a239fb40dc3f3dca75bb5dcf77a831e4e47b"
+  resolved "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-2.2.2.tgz"
   integrity sha512-m56vOXcOBuaF+Igpb9OPAy7f9w9OIkb5yhjsZuaPm7HoGi4oTOQi0h2+yZ+AtKklYFZ+rPC4n0wYCJCEU1ONqg==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -1141,17 +1031,17 @@ estree-util-build-jsx@^2.0.0:
 
 estree-util-is-identifier-name@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz#2e3488ea06d9ea2face116058864f6370b37456d"
+  resolved "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz"
   integrity sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==
 
 estree-util-is-identifier-name@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.1.0.tgz#fb70a432dcb19045e77b05c8e732f1364b4b49b2"
+  resolved "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.1.0.tgz"
   integrity sha512-bEN9VHRyXAUOjkKVQVvArFym08BTWB0aJPppZZr0UNyAqWsLaVfAqP7hbaTJjzHifmB5ebnR8Wm7r7yGN/HonQ==
 
 estree-util-to-js@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/estree-util-to-js/-/estree-util-to-js-1.2.0.tgz#0f80d42443e3b13bd32f7012fffa6f93603f4a36"
+  resolved "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-1.2.0.tgz"
   integrity sha512-IzU74r1PK5IMMGZXUVZbmiu4A1uhiPgW5hm1GjcOfr4ZzHaMPpLNJjR7HjXiIOzi25nZDrgFTobHTkV5Q6ITjA==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -1160,14 +1050,14 @@ estree-util-to-js@^1.1.0:
 
 estree-util-value-to-estree@^1.0.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/estree-util-value-to-estree/-/estree-util-value-to-estree-1.3.0.tgz#1d3125594b4d6680f666644491e7ac1745a3df49"
+  resolved "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-1.3.0.tgz"
   integrity sha512-Y+ughcF9jSUJvncXwqRageavjrNPAI+1M/L3BI3PyLp1nmgYTGUXU6t5z1Y7OWuThoDdhPME07bQU+d5LxdJqw==
   dependencies:
     is-plain-obj "^3.0.0"
 
 estree-util-visit@^1.0.0:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/estree-util-visit/-/estree-util-visit-1.2.1.tgz#8bc2bc09f25b00827294703835aabee1cc9ec69d"
+  resolved "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-1.2.1.tgz"
   integrity sha512-xbgqcrkIVbIG+lI/gzbvd9SGTJL4zqJKBFttUl5pP27KhAjtMKbX/mQXJ7qgyXpMgVy/zvpm0xoQQaGL8OloOw==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -1175,36 +1065,36 @@ estree-util-visit@^1.0.0:
 
 estree-walker@^3.0.0:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz"
   integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
   dependencies:
     "@types/estree" "^1.0.0"
 
 esutils@^2.0.2:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 extend-shallow@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
   integrity sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==
   dependencies:
     is-extendable "^0.1.0"
 
 extend@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.12:
   version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
@@ -1215,31 +1105,31 @@ fast-glob@^3.2.12:
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
   version "1.15.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz"
   integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
 
 fault@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fault/-/fault-2.0.1.tgz#d47ca9f37ca26e4bd38374a7c500b5a384755b6c"
+  resolved "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz"
   integrity sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==
   dependencies:
     format "^0.2.0"
 
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  resolved "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz"
   integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
   dependencies:
     node-domexception "^1.0.0"
@@ -1247,21 +1137,21 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
 
 fill-range@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
 
 find-up@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
     locate-path "^6.0.0"
@@ -1269,7 +1159,7 @@ find-up@^5.0.0:
 
 flat-cache@^3.0.4:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"
   integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
     flatted "^3.1.0"
@@ -1277,58 +1167,58 @@ flat-cache@^3.0.4:
 
 flatted@^3.1.0:
   version "3.2.7"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 format@^0.2.0:
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  resolved "https://registry.npmjs.org/format/-/format-0.2.2.tgz"
   integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  resolved "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz"
   integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
   dependencies:
     fetch-blob "^3.1.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
 glob-parent@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
 
 glob@^7.1.3:
   version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
   dependencies:
     fs.realpath "^1.0.0"
@@ -1340,19 +1230,19 @@ glob@^7.1.3:
 
 globals@^13.19.0:
   version "13.20.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz"
   integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
   dependencies:
     type-fest "^0.20.2"
 
 grapheme-splitter@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 gray-matter@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.3.tgz#e893c064825de73ea1f5f7d88c7a9f7274288798"
+  resolved "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz"
   integrity sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==
   dependencies:
     js-yaml "^3.13.1"
@@ -1362,29 +1252,29 @@ gray-matter@^4.0.3:
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-own-prop@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-own-prop/-/has-own-prop-2.0.0.tgz#f0f95d58f65804f5d218db32563bb85b8e0417af"
+  resolved "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz"
   integrity sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==
 
 has@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
 
 hash-wasm@^4.9.0:
   version "4.9.0"
-  resolved "https://registry.yarnpkg.com/hash-wasm/-/hash-wasm-4.9.0.tgz#7e9dcc9f7d6bd0cc802f2a58f24edce999744206"
+  resolved "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz"
   integrity sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w==
 
 hast-util-from-parse5@^7.0.0:
   version "7.1.2"
-  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz#aecfef73e3ceafdfa4550716443e4eb7b02e22b0"
+  resolved "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz"
   integrity sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -1397,14 +1287,14 @@ hast-util-from-parse5@^7.0.0:
 
 hast-util-parse-selector@^3.0.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz#25ab00ae9e75cbc62cf7a901f68a247eade659e2"
+  resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz"
   integrity sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==
   dependencies:
     "@types/hast" "^2.0.0"
 
 hast-util-raw@^7.0.0:
   version "7.2.3"
-  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-7.2.3.tgz#dcb5b22a22073436dbdc4aa09660a644f4991d99"
+  resolved "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz"
   integrity sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -1421,7 +1311,7 @@ hast-util-raw@^7.0.0:
 
 hast-util-to-estree@^2.0.0:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/hast-util-to-estree/-/hast-util-to-estree-2.3.2.tgz#11ab0cd2e70ecf0305151af56e636b1cdfbba0bf"
+  resolved "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-2.3.2.tgz"
   integrity sha512-YYDwATNdnvZi3Qi84iatPIl1lWpXba1MeNrNbDfJfVzEBZL8uUmtR7mt7bxKBC8kuAuvb0bkojXYZzsNHyHCLg==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -1442,7 +1332,7 @@ hast-util-to-estree@^2.0.0:
 
 hast-util-to-html@^8.0.0:
   version "8.0.4"
-  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz#0269ef33fa3f6599b260a8dc94f733b8e39e41fc"
+  resolved "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz"
   integrity sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -1459,7 +1349,7 @@ hast-util-to-html@^8.0.0:
 
 hast-util-to-parse5@^7.0.0:
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz#c49391bf8f151973e0c9adcd116b561e8daf29f3"
+  resolved "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz"
   integrity sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -1471,12 +1361,12 @@ hast-util-to-parse5@^7.0.0:
 
 hast-util-whitespace@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz#0ec64e257e6fc216c7d14c8a1b74d27d650b4557"
+  resolved "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz"
   integrity sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==
 
 hastscript@^7.0.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-7.2.0.tgz#0eafb7afb153d047077fa2a833dc9b7ec604d10b"
+  resolved "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz"
   integrity sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -1487,22 +1377,22 @@ hastscript@^7.0.0:
 
 html-void-elements@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-2.0.1.tgz#29459b8b05c200b6c5ee98743c41b979d577549f"
+  resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz"
   integrity sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==
 
 ignore@^5.2.0:
   version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 imagescript@^1.2.15:
   version "1.2.16"
-  resolved "https://registry.yarnpkg.com/imagescript/-/imagescript-1.2.16.tgz#2272f535816bdcbaec9da4448de5c89a488756bd"
+  resolved "https://registry.npmjs.org/imagescript/-/imagescript-1.2.16.tgz"
   integrity sha512-hhy8OVNymU+cYYj8IwCbdNlXJRoMr4HRd7+efkH32eBVfybVU/5SbzDYf3ZSiiF9ye/ghfBrI/ujec/nwl+fOQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
@@ -1510,17 +1400,17 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 inflection@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inflection/-/inflection-2.0.1.tgz#bdf3a4c05d4275f41234910cbbe9a102ac72c99b"
+  resolved "https://registry.npmjs.org/inflection/-/inflection-2.0.1.tgz"
   integrity sha512-wzkZHqpb4eGrOKBl34xy3umnYHx8Si5R1U4fwmdxLo5gdH6mEK8gclckTj/qWqy4Je0bsDYe/qazZYuO7xe3XQ==
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
   integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
@@ -1528,22 +1418,22 @@ inflight@^1.0.4:
 
 inherits@2:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 inline-style-parser@0.1.1:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  resolved "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 is-alphabetical@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  resolved "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz"
   integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
 
 is-alphanumerical@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  resolved "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz"
   integrity sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==
   dependencies:
     is-alphabetical "^2.0.0"
@@ -1551,95 +1441,95 @@ is-alphanumerical@^2.0.0:
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
 
 is-buffer@^2.0.0:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-core-module@^2.12.0:
   version "2.12.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz"
   integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
   dependencies:
     has "^1.0.3"
 
 is-decimal@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  resolved "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz"
   integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
 
 is-extendable@^0.1.0:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
   integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
 is-hexadecimal@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  resolved "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz"
   integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-path-inside@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-obj@^4.0.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-reference@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.1.tgz#d400f4260f7e55733955e60d361d827eb4d3b831"
+  resolved "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz"
   integrity sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==
   dependencies:
     "@types/estree" "*"
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 js-sdsl@^4.1.4:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.0.tgz#8b437dbe642daa95760400b602378ed8ffea8430"
+  resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz"
   integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
 
 js-yaml@^3.13.1:
   version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
@@ -1647,44 +1537,44 @@ js-yaml@^3.13.1:
 
 js-yaml@^4.0.0, js-yaml@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
 
 jsbi@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
+  resolved "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz"
   integrity sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^2.2.2:
   version "2.2.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 kleur@^4.0.3:
   version "4.1.5"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
 
 levn@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
   integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   dependencies:
     prelude-ls "^1.2.1"
@@ -1692,63 +1582,63 @@ levn@^0.4.1:
 
 locate-path@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
-lodash.merge@4.6.2, lodash.merge@^4.6.2:
+lodash.merge@^4.6.2, lodash.merge@4.6.2:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 long@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  resolved "https://registry.npmjs.org/long/-/long-4.0.0.tgz"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 long@^5.0.0:
   version "5.2.3"
-  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  resolved "https://registry.npmjs.org/long/-/long-5.2.3.tgz"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 longest-streak@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  resolved "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz"
   integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
 lower-case@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  resolved "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz"
   integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
   dependencies:
     tslib "^2.0.3"
 
 lru-cache@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
 
 make-error@^1.1.1:
   version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 markdown-extensions@^1.0.0:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
+  resolved "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz"
   integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
 
 mdast-util-definitions@^5.0.0:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz#9910abb60ac5d7115d6819b57ae0bcef07a3f7a7"
+  resolved "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz"
   integrity sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -1757,7 +1647,7 @@ mdast-util-definitions@^5.0.0:
 
 mdast-util-from-markdown@^1.0.0, mdast-util-from-markdown@^1.1.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz#0214124154f26154a2b3f9d401155509be45e894"
+  resolved "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz"
   integrity sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -1775,7 +1665,7 @@ mdast-util-from-markdown@^1.0.0, mdast-util-from-markdown@^1.1.0:
 
 mdast-util-frontmatter@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz#79c46d7414eb9d3acabe801ee4a70a70b75e5af1"
+  resolved "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz"
   integrity sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -1784,7 +1674,7 @@ mdast-util-frontmatter@^1.0.0:
 
 mdast-util-mdx-expression@^1.0.0:
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.3.2.tgz#d027789e67524d541d6de543f36d51ae2586f220"
+  resolved "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.3.2.tgz"
   integrity sha512-xIPmR5ReJDu/DHH1OoIT1HkuybIfRGYRywC+gJtI7qHjCJp/M9jrmBEJW22O8lskDWm562BX2W8TiAwRTb0rKA==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -1795,7 +1685,7 @@ mdast-util-mdx-expression@^1.0.0:
 
 mdast-util-mdx-jsx@^2.0.0:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.1.2.tgz#694a46164db10c0e9d674a3772b8748dfddd0817"
+  resolved "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.1.2.tgz"
   integrity sha512-o9vBCYQK5ZLGEj3tCGISJGjvafyHRVJlZmfJzSE7xjiogSzIeph/Z4zMY65q4WGRMezQBeAwPlrdymDYYYx0tA==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -1813,7 +1703,7 @@ mdast-util-mdx-jsx@^2.0.0:
 
 mdast-util-mdx@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdx/-/mdast-util-mdx-2.0.1.tgz#49b6e70819b99bb615d7223c088d295e53bb810f"
+  resolved "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-2.0.1.tgz"
   integrity sha512-38w5y+r8nyKlGvNjSEqWrhG0w5PmnRA+wnBvm+ulYCct7nsGYhFVb0lljS9bQav4psDAS1eGkP2LMVcZBi/aqw==
   dependencies:
     mdast-util-from-markdown "^1.0.0"
@@ -1824,7 +1714,7 @@ mdast-util-mdx@^2.0.0:
 
 mdast-util-mdxjs-esm@^1.0.0:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.3.1.tgz#645d02cd607a227b49721d146fd81796b2e2d15b"
+  resolved "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.3.1.tgz"
   integrity sha512-SXqglS0HrEvSdUEfoXFtcg7DRl7S2cwOXc7jkuusG472Mmjag34DUDeOJUZtl+BVnyeO1frIgVpHlNRWc2gk/w==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -1835,7 +1725,7 @@ mdast-util-mdxjs-esm@^1.0.0:
 
 mdast-util-phrasing@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz#c7c21d0d435d7fb90956038f02e8702781f95463"
+  resolved "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz"
   integrity sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -1843,7 +1733,7 @@ mdast-util-phrasing@^3.0.0:
 
 mdast-util-to-hast@^12.1.0:
   version "12.3.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz#045d2825fb04374e59970f5b3f279b5700f6fb49"
+  resolved "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz"
   integrity sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -1857,7 +1747,7 @@ mdast-util-to-hast@^12.1.0:
 
 mdast-util-to-markdown@^1.0.0, mdast-util-to-markdown@^1.3.0:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz#c13343cb3fc98621911d33b5cd42e7d0731171c6"
+  resolved "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz"
   integrity sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -1871,14 +1761,14 @@ mdast-util-to-markdown@^1.0.0, mdast-util-to-markdown@^1.3.0:
 
 mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
+  resolved "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz"
   integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
   dependencies:
     "@types/mdast" "^3.0.0"
 
 mdx-bundler@^9.2.1:
   version "9.2.1"
-  resolved "https://registry.yarnpkg.com/mdx-bundler/-/mdx-bundler-9.2.1.tgz#917dbd986ac3e7f7f14ac635c2dfc224eafdd42d"
+  resolved "https://registry.npmjs.org/mdx-bundler/-/mdx-bundler-9.2.1.tgz"
   integrity sha512-hWEEip1KU9MCNqeH2rqwzAZ1pdqPPbfkx9OTJjADqGPQz4t9BO85fhI7AP9gVYrpmfArf9/xJZUN0yBErg/G/Q==
   dependencies:
     "@babel/runtime" "^7.16.3"
@@ -1893,12 +1783,12 @@ mdx-bundler@^9.2.1:
 
 merge2@^1.3.0:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz#edff4c72e5993d93724a3c206970f5a15b0585ad"
+  resolved "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz"
   integrity sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==
   dependencies:
     decode-named-character-reference "^1.0.0"
@@ -1920,7 +1810,7 @@ micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
 
 micromark-extension-frontmatter@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.0.tgz#f8da3c2d880266c809dcf07eb0606448b2f837c5"
+  resolved "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.0.tgz"
   integrity sha512-0nLelmvXR5aZ+F2IL6/Ed4cDnHLpL/VD/EELKuclsTWHrLI8UgxGHEmeoumeX2FXiM6z2WrBIOEcbKUZR8RYNg==
   dependencies:
     fault "^2.0.0"
@@ -1930,7 +1820,7 @@ micromark-extension-frontmatter@^1.0.0:
 
 micromark-extension-mdx-expression@^1.0.0:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.4.tgz#33fe2c6ee214738255de175a084281c11894ddda"
+  resolved "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.4.tgz"
   integrity sha512-TCgLxqW6ReQ3AJgtj1P0P+8ZThBTloLbeb7jNaqr6mCOLDpxUiBFE/9STgooMZttEwOQu5iEcCCa3ZSDhY9FGw==
   dependencies:
     micromark-factory-mdx-expression "^1.0.0"
@@ -1943,7 +1833,7 @@ micromark-extension-mdx-expression@^1.0.0:
 
 micromark-extension-mdx-jsx@^1.0.0:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.3.tgz#9f196be5f65eb09d2a49b237a7b3398bba2999be"
+  resolved "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.3.tgz"
   integrity sha512-VfA369RdqUISF0qGgv2FfV7gGjHDfn9+Qfiv5hEwpyr1xscRj/CiVRkU7rywGFCO7JwJ5L0e7CJz60lY52+qOA==
   dependencies:
     "@types/acorn" "^4.0.0"
@@ -1958,14 +1848,14 @@ micromark-extension-mdx-jsx@^1.0.0:
 
 micromark-extension-mdx-md@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.0.tgz#382f5df9ee3706dd120b51782a211f31f4760d22"
+  resolved "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.0.tgz"
   integrity sha512-xaRAMoSkKdqZXDAoSgp20Azm0aRQKGOl0RrS81yGu8Hr/JhMsBmfs4wR7m9kgVUIO36cMUQjNyiyDKPrsv8gOw==
   dependencies:
     micromark-util-types "^1.0.0"
 
 micromark-extension-mdxjs-esm@^1.0.0:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-1.0.3.tgz#630d9dc9db2c2fd470cac8c1e7a824851267404d"
+  resolved "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-1.0.3.tgz"
   integrity sha512-2N13ol4KMoxb85rdDwTAC6uzs8lMX0zeqpcyx7FhS7PxXomOnLactu8WI8iBNXW8AVyea3KIJd/1CKnUmwrK9A==
   dependencies:
     micromark-core-commonmark "^1.0.0"
@@ -1979,7 +1869,7 @@ micromark-extension-mdxjs-esm@^1.0.0:
 
 micromark-extension-mdxjs@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.0.tgz#772644e12fc8299a33e50f59c5aa15727f6689dd"
+  resolved "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.0.tgz"
   integrity sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==
   dependencies:
     acorn "^8.0.0"
@@ -1993,7 +1883,7 @@ micromark-extension-mdxjs@^1.0.0:
 
 micromark-factory-destination@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz#fef1cb59ad4997c496f887b6977aa3034a5a277e"
+  resolved "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz"
   integrity sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==
   dependencies:
     micromark-util-character "^1.0.0"
@@ -2002,7 +1892,7 @@ micromark-factory-destination@^1.0.0:
 
 micromark-factory-label@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz#6be2551fa8d13542fcbbac478258fb7a20047137"
+  resolved "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz"
   integrity sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==
   dependencies:
     micromark-util-character "^1.0.0"
@@ -2012,7 +1902,7 @@ micromark-factory-label@^1.0.0:
 
 micromark-factory-mdx-expression@^1.0.0:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.7.tgz#e38298dc1f7eaf6ba1d9f210531ceae17155c00f"
+  resolved "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.7.tgz"
   integrity sha512-QAdFbkQagTZ/eKb8zDGqmjvgevgJH3+aQpvvKrXWxNJp3o8/l2cAbbrBd0E04r0Gx6nssPpqWIjnbHFvZu5qsQ==
   dependencies:
     micromark-factory-space "^1.0.0"
@@ -2026,7 +1916,7 @@ micromark-factory-mdx-expression@^1.0.0:
 
 micromark-factory-space@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz#cebff49968f2b9616c0fcb239e96685cb9497633"
+  resolved "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz"
   integrity sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==
   dependencies:
     micromark-util-character "^1.0.0"
@@ -2034,7 +1924,7 @@ micromark-factory-space@^1.0.0:
 
 micromark-factory-title@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz#7e09287c3748ff1693930f176e1c4a328382494f"
+  resolved "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz"
   integrity sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==
   dependencies:
     micromark-factory-space "^1.0.0"
@@ -2045,7 +1935,7 @@ micromark-factory-title@^1.0.0:
 
 micromark-factory-whitespace@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz#e991e043ad376c1ba52f4e49858ce0794678621c"
+  resolved "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz"
   integrity sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==
   dependencies:
     micromark-factory-space "^1.0.0"
@@ -2055,7 +1945,7 @@ micromark-factory-whitespace@^1.0.0:
 
 micromark-util-character@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.1.0.tgz#d97c54d5742a0d9611a68ca0cd4124331f264d86"
+  resolved "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz"
   integrity sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==
   dependencies:
     micromark-util-symbol "^1.0.0"
@@ -2063,14 +1953,14 @@ micromark-util-character@^1.0.0:
 
 micromark-util-chunked@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz#5b40d83f3d53b84c4c6bce30ed4257e9a4c79d06"
+  resolved "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz"
   integrity sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==
   dependencies:
     micromark-util-symbol "^1.0.0"
 
 micromark-util-classify-character@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz#cbd7b447cb79ee6997dd274a46fc4eb806460a20"
+  resolved "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz"
   integrity sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==
   dependencies:
     micromark-util-character "^1.0.0"
@@ -2079,7 +1969,7 @@ micromark-util-classify-character@^1.0.0:
 
 micromark-util-combine-extensions@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz#91418e1e74fb893e3628b8d496085639124ff3d5"
+  resolved "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz"
   integrity sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==
   dependencies:
     micromark-util-chunked "^1.0.0"
@@ -2087,14 +1977,14 @@ micromark-util-combine-extensions@^1.0.0:
 
 micromark-util-decode-numeric-character-reference@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz#dcc85f13b5bd93ff8d2868c3dba28039d490b946"
+  resolved "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz"
   integrity sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==
   dependencies:
     micromark-util-symbol "^1.0.0"
 
 micromark-util-decode-string@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz#942252ab7a76dec2dbf089cc32505ee2bc3acf02"
+  resolved "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz"
   integrity sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==
   dependencies:
     decode-named-character-reference "^1.0.0"
@@ -2104,12 +1994,12 @@ micromark-util-decode-string@^1.0.0:
 
 micromark-util-encode@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz#2c1c22d3800870ad770ece5686ebca5920353383"
+  resolved "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz"
   integrity sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==
 
 micromark-util-events-to-acorn@^1.0.0:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.2.1.tgz#d5b9dfbc589ece7917de24de0a57b909c0d36583"
+  resolved "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.2.1.tgz"
   integrity sha512-mkg3BaWlw6ZTkQORrKVBW4o9ICXPxLtGz51vml5mQpKFdo9vqIX68CAx5JhTOdjQyAHH7JFmm4rh8toSPQZUmg==
   dependencies:
     "@types/acorn" "^4.0.0"
@@ -2122,26 +2012,26 @@ micromark-util-events-to-acorn@^1.0.0:
 
 micromark-util-html-tag-name@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz#eb227118befd51f48858e879b7a419fc0df20497"
+  resolved "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz"
   integrity sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==
 
 micromark-util-normalize-identifier@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz#4a3539cb8db954bbec5203952bfe8cedadae7828"
+  resolved "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz"
   integrity sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==
   dependencies:
     micromark-util-symbol "^1.0.0"
 
 micromark-util-resolve-all@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz#a7c363f49a0162e931960c44f3127ab58f031d88"
+  resolved "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz"
   integrity sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==
   dependencies:
     micromark-util-types "^1.0.0"
 
 micromark-util-sanitize-uri@^1.0.0, micromark-util-sanitize-uri@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz#f12e07a85106b902645e0364feb07cf253a85aee"
+  resolved "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz"
   integrity sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==
   dependencies:
     micromark-util-character "^1.0.0"
@@ -2150,7 +2040,7 @@ micromark-util-sanitize-uri@^1.0.0, micromark-util-sanitize-uri@^1.1.0:
 
 micromark-util-subtokenize@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz#ff6f1af6ac836f8bfdbf9b02f40431760ad89105"
+  resolved "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz"
   integrity sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==
   dependencies:
     micromark-util-chunked "^1.0.0"
@@ -2160,17 +2050,17 @@ micromark-util-subtokenize@^1.0.0:
 
 micromark-util-symbol@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz#b90344db62042ce454f351cf0bebcc0a6da4920e"
+  resolved "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz"
   integrity sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==
 
 micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.0.2.tgz#f4220fdb319205812f99c40f8c87a9be83eded20"
+  resolved "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz"
   integrity sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==
 
 micromark@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.1.0.tgz#eeba0fe0ac1c9aaef675157b52c166f125e89f62"
+  resolved "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz"
   integrity sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==
   dependencies:
     "@types/debug" "^4.0.0"
@@ -2193,7 +2083,7 @@ micromark@^3.0.0:
 
 micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
     braces "^3.0.2"
@@ -2201,34 +2091,34 @@ micromatch@^4.0.4, micromatch@^4.0.5:
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.6:
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mri@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 no-case@^3.0.4:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  resolved "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz"
   integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
   dependencies:
     lower-case "^2.0.2"
@@ -2236,12 +2126,12 @@ no-case@^3.0.4:
 
 node-domexception@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  resolved "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
 node-fetch@^3.0.0:
   version "3.3.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.1.tgz#b3eea7b54b3a48020e46f4f88b9c5a7430d20b2e"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz"
   integrity sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==
   dependencies:
     data-uri-to-buffer "^4.0.0"
@@ -2250,24 +2140,24 @@ node-fetch@^3.0.0:
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 once@^1.3.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
 oo-ascii-tree@^1.73.0:
   version "1.80.0"
-  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.80.0.tgz#81557f5ed86559a4c62e9592fafa69de3c6311d1"
+  resolved "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.80.0.tgz"
   integrity sha512-jEfsnu53QsI0VcGrbCR9eS8QuuSp6Ddf1oFc3GK9WP6Ao49/dVWwxk4ijk/YyX2HJDluBSM82yez313rzhI7rw==
 
 optionator@^0.9.1:
   version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz"
   integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
   dependencies:
     deep-is "^0.1.3"
@@ -2279,28 +2169,28 @@ optionator@^0.9.1:
 
 p-limit@^3.0.2:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
 
 p-locate@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
 
 parent-module@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
 
 parse-entities@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.1.tgz#4e2a01111fb1c986549b944af39eeda258fc9e4e"
+  resolved "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz"
   integrity sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2314,12 +2204,12 @@ parse-entities@^4.0.0:
 
 parse5@^6.0.0:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 pascal-case@^3.1.2:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  resolved "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz"
   integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
   dependencies:
     no-case "^3.0.4"
@@ -2327,27 +2217,27 @@ pascal-case@^3.1.2:
 
 path-exists@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.7:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 periscopic@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-3.1.0.tgz#7e9037bf51c5855bd33b48928828db4afa79d97a"
+  resolved "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz"
   integrity sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -2356,22 +2246,27 @@ periscopic@^3.0.0:
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 property-information@^6.0.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.2.0.tgz#b74f522c31c097b5149e3c3cb8d7f3defd986a1d"
+  resolved "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz"
   integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
 protobufjs@^6.11.3:
   version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
+  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz"
   integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
@@ -2390,7 +2285,7 @@ protobufjs@^6.11.3:
 
 protobufjs@^7.0.0:
   version "7.2.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.3.tgz#01af019e40d9c6133c49acbb3ff9e30f4f0f70b2"
+  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz"
   integrity sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
@@ -2408,29 +2303,29 @@ protobufjs@^7.0.0:
 
 punycode@^2.1.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 readdirp@~3.6.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 rehype-stringify@^9.0.3:
   version "9.0.3"
-  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-9.0.3.tgz#70e3bd6d4d29e7acf36b802deed350305d2c3c17"
+  resolved "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz"
   integrity sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -2439,7 +2334,7 @@ rehype-stringify@^9.0.3:
 
 remark-frontmatter@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz#84560f7ccef114ef076d3d3735be6d69f8922309"
+  resolved "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz"
   integrity sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -2449,7 +2344,7 @@ remark-frontmatter@^4.0.1:
 
 remark-mdx-frontmatter@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/remark-mdx-frontmatter/-/remark-mdx-frontmatter-1.1.1.tgz#54cfb3821fbb9cb6057673e0570ae2d645f6fe32"
+  resolved "https://registry.npmjs.org/remark-mdx-frontmatter/-/remark-mdx-frontmatter-1.1.1.tgz"
   integrity sha512-7teX9DW4tI2WZkXS4DBxneYSY7NHiXl4AKdWDO9LXVweULlCT8OPWsOjLEnMIXViN1j+QcY8mfbq3k0EK6x3uA==
   dependencies:
     estree-util-is-identifier-name "^1.0.0"
@@ -2459,7 +2354,7 @@ remark-mdx-frontmatter@^1.1.1:
 
 remark-mdx@^2.0.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-2.3.0.tgz#efe678025a8c2726681bde8bf111af4a93943db4"
+  resolved "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.3.0.tgz"
   integrity sha512-g53hMkpM0I98MU266IzDFMrTD980gNF3BJnkyFcmN+dD873mQeD5rdMO3Y2X+x8umQfbSE0PcoEDl7ledSA+2g==
   dependencies:
     mdast-util-mdx "^2.0.0"
@@ -2467,7 +2362,7 @@ remark-mdx@^2.0.0:
 
 remark-parse@^10.0.0, remark-parse@^10.0.1:
   version "10.0.1"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  resolved "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz"
   integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
   dependencies:
     "@types/mdast" "^3.0.0"
@@ -2476,7 +2371,7 @@ remark-parse@^10.0.0, remark-parse@^10.0.1:
 
 remark-rehype@^10.0.0, remark-rehype@^10.1.0:
   version "10.1.0"
-  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-10.1.0.tgz#32dc99d2034c27ecaf2e0150d22a6dcccd9a6279"
+  resolved "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz"
   integrity sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==
   dependencies:
     "@types/hast" "^2.0.0"
@@ -2486,22 +2381,22 @@ remark-rehype@^10.0.0, remark-rehype@^10.1.0:
 
 repeat-string@^1.6.1:
   version "1.6.1"
-  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
 require-directory@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 resolve-from@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve@^1.19.0:
   version "1.22.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.3.tgz#4b4055349ffb962600972da1fdc33c46a4eb3283"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz"
   integrity sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==
   dependencies:
     is-core-module "^2.12.0"
@@ -2510,33 +2405,33 @@ resolve@^1.19.0:
 
 reusify@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
 run-parallel@^1.1.9:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
 
 sade@^1.7.3:
   version "1.8.1"
-  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  resolved "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz"
   integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
   dependencies:
     mri "^1.1.0"
 
 section-matter@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
+  resolved "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz"
   integrity sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==
   dependencies:
     extend-shallow "^2.0.1"
@@ -2544,26 +2439,26 @@ section-matter@^1.0.0:
 
 semver@^7.3.5:
   version "7.4.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.4.0.tgz#8481c92feffc531ab1e012a8ffc15bdd3a0f4318"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz"
   integrity sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==
   dependencies:
     lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 source-map-support@^0.5.21:
   version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
@@ -2571,27 +2466,27 @@ source-map-support@^0.5.21:
 
 source-map@^0.6.0:
   version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@^0.7.0:
   version "0.7.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz"
   integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -2600,7 +2495,7 @@ string-width@^4.1.0, string-width@^4.2.0:
 
 stringify-entities@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.3.tgz#cfabd7039d22ad30f3cc435b0ca2c1574fc88ef8"
+  resolved "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz"
   integrity sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==
   dependencies:
     character-entities-html4 "^2.0.0"
@@ -2608,75 +2503,75 @@ stringify-entities@^4.0.0:
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
 
 strip-bom-string@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
+  resolved "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz"
   integrity sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==
 
 strip-bom@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
   integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 style-to-object@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.4.1.tgz#53cf856f7cf7f172d72939d9679556469ba5de37"
+  resolved "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz"
   integrity sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==
   dependencies:
     inline-style-parser "0.1.1"
 
 supports-color@^7.1.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 text-table@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
 toml@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  resolved "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz"
   integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
 trim-lines@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  resolved "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
 trough@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  resolved "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz"
   integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
 ts-node@^10.9.1:
   version "10.9.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
@@ -2695,12 +2590,12 @@ ts-node@^10.9.1:
 
 ts-pattern@^4.1.3:
   version "4.2.2"
-  resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-4.2.2.tgz#e6fae2aa1ff1a7ff2ce3166f8c329a4f252f78d6"
+  resolved "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.2.2.tgz"
   integrity sha512-qzJMo2pbkUJWusRH5o8xR+xogn6RmvViyUgwBFTtRENLse470clCGjHDf6haWGZ1AOmk8XkEohUoBW8Uut6Scg==
 
 tsconfig-paths@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
+  resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz"
   integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
   dependencies:
     json5 "^2.2.2"
@@ -2709,39 +2604,39 @@ tsconfig-paths@^4.2.0:
 
 tslib@^2.0.3, tslib@^2.3.1:
   version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 typanion@^3.12.1, typanion@^3.8.0:
   version "3.12.1"
-  resolved "https://registry.yarnpkg.com/typanion/-/typanion-3.12.1.tgz#d33deb130aba23ef6f2a3c69e7fb28148dd9089a"
+  resolved "https://registry.npmjs.org/typanion/-/typanion-3.12.1.tgz"
   integrity sha512-3SJF/czpzqq6G3lprGFLa6ps12yb1uQ1EmitNnep2fDMNh1aO/Zbq9sWY+3lem0zYb2oHJnQWyabTGUZ+L1ScQ==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
 
 type-fest@^0.20.2:
   version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^3.5.2:
   version "3.8.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.8.0.tgz#ce80d1ca7c7d11c5540560999cbd410cb5b3a385"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz"
   integrity sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==
 
-typescript@^5.0.4:
+typescript@^5.0.4, typescript@>=2.7:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 unified@^10.0.0, unified@^10.1.2:
   version "10.1.2"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
+  resolved "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz"
   integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2754,33 +2649,33 @@ unified@^10.0.0, unified@^10.1.2:
 
 unist-util-generated@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-2.0.1.tgz#e37c50af35d3ed185ac6ceacb6ca0afb28a85cae"
+  resolved "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz"
   integrity sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==
 
 unist-util-is@^5.0.0:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.2.1.tgz#b74960e145c18dcb6226bc57933597f5486deae9"
+  resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz"
   integrity sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==
   dependencies:
     "@types/unist" "^2.0.0"
 
 unist-util-position-from-estree@^1.0.0, unist-util-position-from-estree@^1.1.0:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-position-from-estree/-/unist-util-position-from-estree-1.1.2.tgz#8ac2480027229de76512079e377afbcabcfcce22"
+  resolved "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-1.1.2.tgz"
   integrity sha512-poZa0eXpS+/XpoQwGwl79UUdea4ol2ZuCYguVaJS4qzIOMDzbqz8a3erUCOmubSZkaOuGamb3tX790iwOIROww==
   dependencies:
     "@types/unist" "^2.0.0"
 
 unist-util-position@^4.0.0:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-4.0.4.tgz#93f6d8c7d6b373d9b825844645877c127455f037"
+  resolved "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz"
   integrity sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==
   dependencies:
     "@types/unist" "^2.0.0"
 
 unist-util-remove-position@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz#a89be6ea72e23b1a402350832b02a91f6a9afe51"
+  resolved "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz"
   integrity sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2788,14 +2683,14 @@ unist-util-remove-position@^4.0.0:
 
 unist-util-stringify-position@^3.0.0:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz#03ad3348210c2d930772d64b489580c13a7db39d"
+  resolved "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz"
   integrity sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==
   dependencies:
     "@types/unist" "^2.0.0"
 
 unist-util-visit-parents@^5.1.1:
   version "5.1.3"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
+  resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz"
   integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2803,7 +2698,7 @@ unist-util-visit-parents@^5.1.1:
 
 unist-util-visit@^4.0.0:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
+  resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz"
   integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2812,19 +2707,19 @@ unist-util-visit@^4.0.0:
 
 uri-js@^4.2.2:
   version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
 uuid@^8.3.2:
   version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 uvu@^0.5.0:
   version "0.5.6"
-  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
+  resolved "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz"
   integrity sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==
   dependencies:
     dequal "^2.0.0"
@@ -2834,12 +2729,12 @@ uvu@^0.5.0:
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 vfile-location@^4.0.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-4.1.0.tgz#69df82fb9ef0a38d0d02b90dd84620e120050dd0"
+  resolved "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz"
   integrity sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2847,7 +2742,7 @@ vfile-location@^4.0.0:
 
 vfile-message@^3.0.0:
   version "3.1.4"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.4.tgz#15a50816ae7d7c2d1fa87090a7f9f96612b59dea"
+  resolved "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz"
   integrity sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2855,7 +2750,7 @@ vfile-message@^3.0.0:
 
 vfile@^5.0.0, vfile@^5.3.2:
   version "5.3.7"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.3.7.tgz#de0677e6683e3380fafc46544cfe603118826ab7"
+  resolved "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz"
   integrity sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -2865,29 +2760,29 @@ vfile@^5.0.0, vfile@^5.3.2:
 
 web-namespaces@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 web-streams-polyfill@^3.0.3:
   version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -2896,32 +2791,32 @@ wrap-ansi@^7.0.0:
 
 wrappy@1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 y18n@^5.0.5:
   version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.2:
   version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^20.2.2:
   version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs@^16.2.0:
   version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
   dependencies:
     cliui "^7.0.2"
@@ -2934,20 +2829,20 @@ yargs@^16.2.0:
 
 yn@3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 zod@^3.20.2:
   version "3.21.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz"
   integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
 
 zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  resolved "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
For a while I've noticed some of the JS examples are formatted oddly. There's already prettier rules set up, it looks like it hasn't been run for a while.

Re-run prettier. ~Turn off `proseWrap` option since this PR would be much larger if we left it on.~ What's left is roughly:
 - 80% JS/TS formatted using Rust conventions
 - 20% minor markdown bits