### PR TITLE
Terminology

### DIFF
--- a/developers/courses/solana-course/content/cpi.md
+++ b/developers/courses/solana-course/content/cpi.md
@@ -222,7 +222,7 @@ if a signature is required on behalf of a PDA. For that, you'll need to use
 Using `invoke_signed` is a little different just because there is an additional
 field that requires the seeds used to derive any PDAs that must sign the
 transaction. You may recall from previous lessons that PDAs do not lie on the
-Ed25519 curve and, therefore, do not have a corresponding private key. You’ve
+Ed25519 curve and, therefore, do not have a corresponding secret key. You’ve
 been told that programs can provide signatures for their PDAs, but have not
 learned how that actually happens - until now. Programs provide signatures for
 their PDAs with the `invoke_signed` function. The first two fields of
@@ -239,7 +239,7 @@ invoke_signed(
 )?;
 ```
 
-While PDAs have no private keys of their own, they can be used by a program to
+While PDAs have no secret keys of their own, they can be used by a program to
 issue an instruction that includes the PDA as a signer. The only way for the
 runtime to verify that the PDA belongs to the calling program is for the calling
 program to supply the seeds used to generate the address in the `signers_seeds`

--- a/developers/courses/solana-course/content/deserialize-custom-data.md
+++ b/developers/courses/solana-course/content/deserialize-custom-data.md
@@ -10,7 +10,7 @@ objectives:
 # TL;DR
 
 - **Program Derived Addresses**, or PDAs, are addresses that do not have a
-  corresponding private key. The concept of PDAs allows for programs to sign for
+  corresponding secret key. The concept of PDAs allows for programs to sign for
   transactions themselves and allows for storing and locating data.
 - You can derive a PDA using the `findProgramAddress(seeds, programid)` method.
 - You can get an array of all the accounts belonging to a program using
@@ -41,8 +41,8 @@ development.
 
 PDA stands for Program Derived Address. As the name suggests, it refers to an
 address (public key) derived from a program and some seeds. In a previous
-lesson, we discussed public/private keys and how they are used on Solana. Unlike
-a keypair, a PDA _does not_ have a corresponding private key. The purpose of a
+lesson, we discussed public/secret keys and how they are used on Solana. Unlike
+a keypair, a PDA _does not_ have a corresponding secret key. The purpose of a
 PDA is to create an address that a program can sign for in the same way a user
 may sign for a transaction with their wallet.
 
@@ -66,10 +66,10 @@ one or more input seeds.
 
 Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic
 function ensures that every point along the curve has a corresponding point
-somewhere else on the curve, allowing for public/private keys. PDAs are
-addresses that lie _off_ the ed2559 Elliptic curve and therefore cannot be
-signed for by a private key (since there isn’t one). This ensures that the
-program is the only valid signer for that address.
+somewhere else on the curve, allowing for public/secret keys. PDAs are addresses
+that lie _off_ the ed2559 Elliptic curve and therefore cannot be signed for by a
+secret key (since there isn’t one). This ensures that the program is the only
+valid signer for that address.
 
 To find a public key that does not lie on the ed2559 curve, the program ID and
 seeds of the developer’s choice (like a string of text) are passed through the

--- a/developers/courses/solana-course/content/deserialize-instruction-data.md
+++ b/developers/courses/solana-course/content/deserialize-instruction-data.md
@@ -7,7 +7,7 @@ objectives:
   - Add implementations to Rust types
   - Deserialize instruction data into Rust data types
   - Execute different program logic for different types of instructions
-  - Explain the structure of a smart contract on Solana
+  - Explain the structure of an on-chain program on Solana
 ---
 
 # TL;DR

--- a/developers/courses/solana-course/content/pda.md
+++ b/developers/courses/solana-course/content/pda.md
@@ -31,7 +31,7 @@ PDAs serve two main functions:
 
 1. Provide a deterministic way to find the address of a program-owned account
 2. Authorize the program from which a PDA was derived to sign on its behalf in
-   the same way a user may sign with their private key
+   the same way a user may sign with their secret key
 
 In this lesson we'll focus on using PDAs to find and store data. We'll discuss
 signing with a PDA more thoroughly in a future lesson where we cover Cross
@@ -44,11 +44,10 @@ a program ID and one or more input seeds.
 
 Solana keypairs can be found on what is called the Ed25519 Elliptic Curve
 (Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to
-generate corresponding public and private keys. Together, we call these
-keypairs.
+generate corresponding public and secret keys. Together, we call these keypairs.
 
 Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. This
-effectively means they are public keys _without_ a corresponding private key.
+effectively means they are public keys _without_ a corresponding secret key.
 This property of PDAs is essential for programs to be able to sign on their
 behalf, but we'll cover that in a future lesson.
 
@@ -73,7 +72,7 @@ While you, the developer, determine the seeds to pass into the
 called a "bump seed." The cryptographic function for deriving a PDA results in a
 key that lies _on_ the Ed25519 curve about 50% of the time. In order to ensure
 that the result _is not_ on the Ed25519 curve and therefore does not have a
-private key, the `find_program_address` function adds a numeric seed called a
+secret key, the `find_program_address` function adds a numeric seed called a
 bump seed.
 
 The function starts by using the value `255` as the bump seed, then checks to

--- a/developers/courses/solana-course/content/program-state-management.md
+++ b/developers/courses/solana-course/content/program-state-management.md
@@ -205,7 +205,7 @@ pub fn invoke_signed(
 ```
 
 For this lesson we will use `invoke_signed`. Unlike a regular signature where a
-private key is used to sign, `invoke_signed` uses the optional seeds, bump seed,
+secret key is used to sign, `invoke_signed` uses the optional seeds, bump seed,
 and program ID to derive a PDA and sign an instruction. This is done by
 comparing the derived PDA against all accounts passed into the instruction. If
 any of the accounts match the PDA, then the signer field for that account is set

--- a/developers/courses/solana-course/content/serialize-instruction-data.md
+++ b/developers/courses/solana-course/content/serialize-instruction-data.md
@@ -80,10 +80,10 @@ It is not just an array of the accounts’ public keys. Each object in the array
 includes the account’s public key, whether or not it is a signer on the
 transaction, and whether or not it is writable. Including whether or not an
 account is writable during the execution of an instruction allows the runtime to
-facilitate parallel processing of smart contracts. Because you must define which
-accounts are read-only and which you will write to, the runtime can determine
-which transactions are non-overlapping or read-only and allow them to execute
-concurrently. To learn more about the Solana’s runtime, check out this
+facilitate parallel processing of on-chain programs. Because you must define
+which accounts are read-only and which you will write to, the runtime can
+determine which transactions are non-overlapping or read-only and allow them to
+execute concurrently. To learn more about the Solana’s runtime, check out this
 [blog post](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts).
 
 ### Instruction Data

--- a/developers/courses/solana-course/content/serialize-instruction-data.md
+++ b/developers/courses/solana-course/content/serialize-instruction-data.md
@@ -16,7 +16,7 @@ objectives:
   order and atomically, meaning that if any of the instructions fail for any
   reason, the entire transaction will fail to be processed.
 - Every _instruction_ is made up of 3 components: the intended program's ID, an
-  array of all account’s involved, and a byte buffer of instruction data.
+  array of all accounts involved, and a byte buffer of instruction data.
 - Every _transaction_ contains: an array of all accounts it intends to read from
   or write to, one or more instructions, a recent blockhash, and one or more
   signatures.

--- a/developers/courses/solana-course/content/serialize-instruction-data.md
+++ b/developers/courses/solana-course/content/serialize-instruction-data.md
@@ -11,10 +11,11 @@ objectives:
 # TL;DR
 
 - Transactions are made up of an array of instructions, a single transaction can
-  have any number of instructions in it, each targeting its own program. When a
-  transaction is submitted, the Solana runtime will process its instructions in
-  order and atomically, meaning that if any of the instructions fail for any
-  reason, the entire transaction will fail to be processed.
+  have one or more instructions in it, each targeting its own program. When a
+  transaction is submitted, the Solana runtime will process all the
+  transaction's instructions in order and atomically, meaning that if any of the
+  instructions fail for any reason, the entire transaction will fail to be
+  processed.
 - Every _instruction_ is made up of 3 components: the intended program's ID, an
   array of all accounts involved, and a byte buffer of instruction data.
 - Every _transaction_ contains: an array of all accounts it intends to read from

--- a/developers/courses/solana-course/content/solana-pay.md
+++ b/developers/courses/solana-course/content/solana-pay.md
@@ -393,7 +393,7 @@ Now that you've got a conceptual grasp on Solana Pay, let's put it into
 practice. We'll use Solana Pay to generate a series of QR codes for a scavenger
 hunt. Participants must visit each scavenger hunt location in order. At each
 location, they'll use the provided QR code to submit the appropriate transaction
-to the scavenger hunt's smart contract that keeps track of user progress.
+to the scavenger hunt's on-chain program that keeps track of user progress.
 
 ### 1. Starter
 

--- a/developers/courses/solana-course/content/solana-pay.md
+++ b/developers/courses/solana-course/content/solana-pay.md
@@ -482,7 +482,7 @@ Now that you're up and running, it's time to create an endpoint that supports
 transaction requests for location check-in using the Scavenger Hunt program.
 
 Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper
-function for initializing `eventOrganizer` from a private key environment
+function for initializing `eventOrganizer` from a secret key environment
 variable. The first thing we'll do in this file is the following:
 
 1. Export a `handler` function to handle an arbitrary HTTP request

--- a/developers/guides/explainers/wallets-explained.md
+++ b/developers/guides/explainers/wallets-explained.md
@@ -142,9 +142,8 @@ indeed the user; there are two problems:
 
 ![An image showing a simplified version of a transactions stored on a ledger](https://solana.ghost.io/content/images/2022/06/Wallets---8.1-A-node-s-dairy.png)
 
-Yes! The key is signing using the private key! We can "password protect our
-data" without communicating the password, thanks to asymmetric cryptography
-magic.
+Yes! The key is signing using the secret key! We can "password protect our data"
+without communicating the password, thanks to asymmetric cryptography magic.
 
 > What's asymmetric? _Think SSH keys_.
 
@@ -152,7 +151,7 @@ Can't wrap your head around it? Well, just think about the real world. For
 example, if a malicious imposter wants to withdraw money from your bank account,
 he would need your signature to do it. Well, that's precisely the same here: any
 modification to data identified by a public key also needs to be signed by the
-corresponding private key.
+corresponding secret key.
 
 > Yes, there was a world like that when mobile banking did not exist.
 
@@ -168,8 +167,8 @@ Congrats! You discovered the nature of trustless and decentralized systems.
 ## Puzzle Piece 4: Transaction
 
 We just uncovered the true nature of wallets just above. But what exactly do we
-sign? Private keys are used to sign transactions. A transaction is how we can
-ask a blockchain to do something.
+sign? secret keys are used to sign transactions. A transaction is how we can ask
+a blockchain to do something.
 
 And the good thing for us is that blockchains are all ears to receive orders.
 Grossly speaking, a blockchain, or more precisely a blockchain node, stores logs
@@ -211,14 +210,14 @@ impersonate Claire to send himself some extra SOL from Claire's wallet
 And finally, to complete the circle, let's talk about wallet apps such as
 [Phantom](https://phantom.app/) or [Solflare](https://solflare.com/). As you now
 understand, the secret sauce to the world of blockchain is really about the
-public key and the signing using the private key.
+public key and the signing using the secret key.
 
 Wallets Apps are really just apps regardless of if it is a mobile wallet, a
 browser extension, or a desktop app, it really is just an app.
 
 These apps just wrap around your keys and add UX niceties such as:
 
-- Storing your private key encrypted and with a password lock.
+- Storing your secret key encrypted and with a password lock.
 - Adding a recovery passphrase to restore the key.
 - Fetching data from the blockchain to display your wallet's balance.
 - Letting you swap a token by connecting with exchanges.
@@ -229,9 +228,9 @@ _An example of how the recovery and balance feature work:_
 ![A diagram showing an example of how the recovery and balance features on a wallet work](https://solana.ghost.io/content/images/2022/06/Wallets---10-Wallet-Apps.png)
 
 As you can see, the essential data live in the blockchain. Wallets are just
-convenience vaults that store your private key encrypted. This is just standard
+convenience vaults that store your secret key encrypted. This is just standard
 industry encryption and has nothing to do with the blockchain. The most
-important feature it provides really is signing using the private key.
+important feature it provides really is signing using the secret key.
 
 ## Putting things back in order
 
@@ -243,21 +242,21 @@ important feature it provides really is signing using the private key.
 4. To avoid chaos, we need a way to determine who can change what: this is where
    signing comes into play.
 5. Thanks to cryptography, we can sign a transaction (change) using a
-   public/private key pair: this stamp (or signature) allows us to "password
+   public/secret key pair: this stamp (or signature) allows us to "password
    lock" some data without communicating the password to the world.
 6. A blockchain is a state machine that stores an infinite list of records,
    logs, or journals of every transaction. The blockchain verifies access to
    data by checking a transaction signature.
 7. **That's why wallets exist! To authenticate and authorize access by signing
-   with a private key!**
-8. A wallet is purely a convenience we created to wrap the private key and add
-   niceties such as; securely storing the private key (with a password lock) or
+   with a secret key!**
+8. A wallet is purely a convenience we created to wrap the secret key and add
+   niceties such as; securely storing the secret key (with a password lock) or
    showing the token account balance. So yes, wallets store an encrypted version
-   of your private key.
+   of your secret key.
 9. You can totally interact with the blockchain without a wallet app like
    Solflare or Phantom! It would just be a harrowing user experience. ;)
 
-_So here you have it, public/private key pairs provide a way for the blockchain
+_So here you have it, public/secret key pairs provide a way for the blockchain
 to identify you and make sure you got the permission to do what you claim you
 should be able to do!_
 
@@ -297,7 +296,7 @@ have a public address:
 
 - So your SOL balance is actually stored in an account whose public address is
   your public key!  
-  Modification access to that account is locked by the corresponding private key
+  Modification access to that account is locked by the corresponding secret key
   signature!
 
 ### Authentication

--- a/developers/guides/explainers/wallets-explained.md
+++ b/developers/guides/explainers/wallets-explained.md
@@ -167,7 +167,7 @@ Congrats! You discovered the nature of trustless and decentralized systems.
 ## Puzzle Piece 4: Transaction
 
 We just uncovered the true nature of wallets just above. But what exactly do we
-sign? secret keys are used to sign transactions. A transaction is how we can ask
+sign? Secret keys are used to sign transactions. A transaction is how we can ask
 a blockchain to do something.
 
 And the good thing for us is that blockchains are all ears to receive orders.

--- a/developers/guides/explainers/wallets-explained.md
+++ b/developers/guides/explainers/wallets-explained.md
@@ -261,7 +261,7 @@ to identify you and make sure you got the permission to do what you claim you
 should be able to do!_
 
 **Wallets are called wallets because the first usage was to lock your balance
-historically. But in an on-chain programs world, it is still about locking your
+historically. But in the on-chain program world, it is still about locking your
 data, not just balances. If anything, wallets should really be called stamps or
 signature pens! ✍️.**
 

--- a/developers/guides/explainers/wallets-explained.md
+++ b/developers/guides/explainers/wallets-explained.md
@@ -261,7 +261,7 @@ to identify you and make sure you got the permission to do what you claim you
 should be able to do!_
 
 **Wallets are called wallets because the first usage was to lock your balance
-historically. But in a smart contracts world, it is still about locking your
+historically. But in an on-chain programs world, it is still about locking your
 data, not just balances. If anything, wallets should really be called stamps or
 signature pens! ✍️.**
 

--- a/developers/guides/solang/solang-getting-started.md
+++ b/developers/guides/solang/solang-getting-started.md
@@ -23,7 +23,7 @@ keywords:
 
 Welcome to this beginner’s guide on getting started with Solang!
 [Solang](https://solang.readthedocs.io/en/v0.3.1/) is a Solidity Compiler that
-allows you to write Solana programs - referrd to in other blockchains as 'smart
+allows you to write Solana programs - referred to in other blockchains as 'smart
 contracts' - using the Solidity programming language.
 
 If you’re an EVM developer that’s interested in leveraging the high speed and
@@ -74,8 +74,9 @@ with the following command:
 anchor init project_name --solidity
 ```
 
-This command generates a new project with a basic Solang on-chain program and a
-test file that demonstrate how to interact with the contract from the client.
+This command generates a new project with a basic Solang on-chain program
+(equivalent to a smart contract on EVM) and a test file that demonstrate how to
+interact with the program from the client.
 
 ## On-chain program Overview
 
@@ -120,7 +121,7 @@ notice:
 1. The `@program_id` annotation:
 
    On Solana, smart contracts are referred to as “programs”. The `@program_id`
-   annotation is used to specify the on-chain address of the contract.
+   annotation is used to specify the on-chain address of the program.
 
 ```solidity
 @program_id("F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC") // on-chain program address

--- a/developers/guides/solang/solang-getting-started.md
+++ b/developers/guides/solang/solang-getting-started.md
@@ -228,8 +228,8 @@ contract.
 Here, the `payer` is specified as `wallet.publicKey`, and the address of the
 `dataAccount` that we plan to create is provided. The generated `dataAccount`
 Keypair is included as an additional signer on the transaction, as it's being
-used to create a new account. Essentially, this verifies that we hold the
-private key corresponding to the address of the new account we're creating.
+used to create a new account. Essentially, this verifies that we hold the secret
+key corresponding to the address of the new account we're creating.
 
 ```jsx
 // Client

--- a/developers/guides/solang/solang-getting-started.md
+++ b/developers/guides/solang/solang-getting-started.md
@@ -23,7 +23,8 @@ keywords:
 
 Welcome to this beginner’s guide on getting started with Solang!
 [Solang](https://solang.readthedocs.io/en/v0.3.1/) is a Solidity Compiler that
-allows you to write Solana programs using the Solidity programming language.
+allows you to write Solana programs - referrd to in other blockchains as 'smart
+contracts' - using the Solidity programming language.
 
 If you’re an EVM developer that’s interested in leveraging the high speed and
 low fees of the Solana network, then Solang is the perfect tool for you. With
@@ -73,14 +74,14 @@ with the following command:
 anchor init project_name --solidity
 ```
 
-This command generates a new project with a basic Solang smart contract and a
+This command generates a new project with a basic Solang on-chain program and a
 test file that demonstrate how to interact with the contract from the client.
 
-## Smart Contract Overview
+## On-chain program Overview
 
-Next, let’s go over the starter code beginning with the contract itself. Within
-your project's `./solidity` directory, you’ll find the following contract below,
-which includes:
+Next, let’s go over the starter code beginning with the on-chain program itself.
+Within your project's `./solidity` directory, you’ll find the following contract
+below, which includes:
 
 - A `constructor` to initialize a state variable
 - A `print` function to print messages to the program logs
@@ -113,8 +114,8 @@ contract starter {
 
 ### Important Differences
 
-Compared to a standard EVM smart contract, there are two important differences
-you might notice:
+Compared to an EVM smart contract, there are two important differences you might
+notice:
 
 1. The `@program_id` annotation:
 
@@ -122,7 +123,7 @@ you might notice:
    annotation is used to specify the on-chain address of the contract.
 
 ```solidity
-@program_id("F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC") // on-chain contract address
+@program_id("F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC") // on-chain program address
 ```
 
 2. The `@payer` annotation:
@@ -144,9 +145,9 @@ An important distinction between EVM smart contracts and Solana programs is how
 each stores "state" variables/data:
 
 - EVM smart contracts can directly store state variables.
-- Solana programs (or smart contracts), on the other hand, create separate
-  accounts to hold state data. These are often referred to as "data accounts"
-  and are "owned" by a program.
+- Solana on-chain programs, on the other hand, create separate accounts to hold
+  state data. These are often referred to as "data accounts" and are "owned" by
+  a program.
 
 In this example, when the contract is deployed, it is deployed to the address
 specified in `@program_id`. When the `constructor` is called after the program
@@ -239,7 +240,7 @@ const tx = await program.methods
   .signers([dataAccount])
   .rpc()
 
-// Smart contract
+// on-chain program
 @payer(payer)
 constructor(address payer) {
     print("Hello, World!");
@@ -256,7 +257,7 @@ const val1 = await program.methods
   .accounts({ dataAccount: dataAccount.publicKey })
   .view()
 
-// Smart contract
+// on-chain program
 function get() public view returns (bool) {
         return value;
 }
@@ -272,7 +273,7 @@ await program.methods
   .accounts({ dataAccount: dataAccount.publicKey })
   .rpc()
 
-// Smart contract
+// on-chain program
 function flip() public {
         value = !value;
 }
@@ -283,7 +284,7 @@ To run the test, use the `anchor test` command in the terminal.
 The `anchor test` command performs the following tasks:
 
 - Start a local Solana validator
-- Build and deploy your smart contract to the local validator
+- Build and deploy your on-chain program to the local validator
 - Run the test file
 
 The following output should then be displayed in the console:

--- a/developers/guides/solang/solang-getting-started.md
+++ b/developers/guides/solang/solang-getting-started.md
@@ -22,7 +22,7 @@ keywords:
 # Getting Started with Solang
 
 Welcome to this beginner’s guide on getting started with Solang!
-[Solang](https://solang.readthedocs.io/en/v0.3.1/) is a Solidity Compiler that
+[Solang](https://solang.readthedocs.io/) is a Solidity Compiler that
 allows you to write Solana programs - referred to in other blockchains as 'smart
 contracts' - using the Solidity programming language.
 

--- a/developers/guides/solang/solang-getting-started.md
+++ b/developers/guides/solang/solang-getting-started.md
@@ -4,7 +4,7 @@ date: Jul 17, 2023
 difficulty: intro
 title: "Getting started with Solang"
 description:
-  "Quickstart guide on how to build your first Solana Program with Solidity
+  "Quickstart guide on how to build your first Solana program with Solidity
   using Solang"
 tags:
   - quickstart

--- a/developers/resources/sdks/anchor.md
+++ b/developers/resources/sdks/anchor.md
@@ -4,7 +4,7 @@ category: framework
 title: Anchor Framework
 description:
   "Anchor is a framework for Solana's Sealevel runtime providing several
-  convenient developer tools for writing smart contracts."
+  convenient developer tools for writing on-chain programs."
 keywords:
   - rust
   - docs

--- a/developers/resources/tooling/solana-playground.md
+++ b/developers/resources/tooling/solana-playground.md
@@ -3,7 +3,7 @@ featured: true
 category: tool
 title: Solana Playground
 description:
-  "Easily build, deploy and test Solana programs and smart contracts from a
+  "Easily build, deploy and test Solana programs and on-chain programs from a
   browser IDE."
 tags:
   - IDE

--- a/docs/intro/overview.md
+++ b/docs/intro/overview.md
@@ -69,7 +69,7 @@ can communicate with each other to update the state and query the blockchain.
 
 ## Wallets
 
-A wallet is a pair of public and private keys that are used to verify actions on
+A wallet is a pair of public and secret keys that are used to verify actions on
 the blockchain. The public key is used to identify the account and the private
 key is used to sign transactions.
 

--- a/docs/intro/wallets.md
+++ b/docs/intro/wallets.md
@@ -15,8 +15,8 @@ file system, a piece of paper, or a specialized device called a _hardware
 wallet_. There are also various smartphone apps and computer programs that
 provide a user-friendly way to create and manage wallets.
 
-A _keypair_ is a securely generated _private key_ and its
-cryptographically-derived _public key_. A private key and its corresponding
+A _keypair_ is a securely generated _secret key_ and its
+cryptographically-derived _public key_. A secret key and its corresponding
 public key are together known as a _keypair_. A wallet contains a collection of
 one or more keypairs and provides some means to interact with them.
 
@@ -28,16 +28,16 @@ Depending on a blockchain's implementation, the address can also be used to view
 certain information about a wallet, such as viewing the balance, but has no
 ability to change anything about the wallet or withdraw any tokens.
 
-The _private key_ is required to digitally sign any transactions to send
+The _secret key_ is required to digitally sign any transactions to send
 cryptocurrencies to another address or to make any changes to the wallet. The
-private key **must never be shared**. If someone gains access to the private key
-to a wallet, they can withdraw all the tokens it contains. If the private key
-for a wallet is lost, any tokens that have been sent to that wallet's address
-are **permanently lost**.
+secret key **must never be shared**. If someone gains access to the secret key
+to a wallet, they can withdraw all the tokens it contains. If the secret key for
+a wallet is lost, any tokens that have been sent to that wallet's address are
+**permanently lost**.
 
 Different wallet solutions offer different approaches to keypair security,
 interacting with the keypair, and signing transactions to use/spend the tokens.
-Some are easier to use than others. Some store and back up private keys more
+Some are easier to use than others. Some store and back up secret keys more
 securely. Solana supports multiple types of wallets so you can choose the right
 balance of security and convenience.
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -476,7 +476,7 @@ non-overlapping, comprising roughly equal real-world time as per
 ## smart contract
 
 Another term for [on chain programs](#programs). Solana programs should use the
-term [on chain programs](#programs).
+term ["on-chain programs"](#program) or simply ["programs"](#program).
 
 ## sol
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -611,7 +611,7 @@ back. See the
 
 ## wallet name
 
-A unique memorable name used to refer to a [wallet address](@wallet-address).
+A unique memorable name used to refer to a [wallet address](#wallet-address).
 
 ## warmup period
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -424,7 +424,7 @@ The secret key of a [keypair](#keypair).
 
 ## Sealevel
 
-Solana's parallel run-time for [on-chain programs](#on-chain-program).
+Solana's parallel runtime for [on-chain programs](#on-chain-program).
 
 ## shred
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -599,7 +599,7 @@ A collection of [keypairs](#keypair) that allows users to manage their funds.
 ## wallet address
 
 The unique [public key](#public-key-pubkey) of a wallet. These are usually
-displayed to programs as a [base58](#base58) string.
+displayed to programs or user interfaces as a [base58](#base58) string.
 
 ## wallet app
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -605,7 +605,7 @@ displayed to programs as a [base58](#base58) string.
 
 An end-user program with a user interface (UI) to interact with a blockchain. A
 wallet typically includes a UI to send and recieve tokens and NFTs, check
-balances of diffferent tokens, view NFTs, stake, and on.off ramp into fiat and
+balances of diffferent tokens, view NFTs, stake, and on/off ramp into fiat and
 back. See the
 [wallet apps on a Solana ecosytstem page](https://solana.com/ecosystem/explore?categories=wallet).
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -38,11 +38,24 @@ capable of modifying the account.
 
 A front-end application that interacts with a Solana cluster.
 
+## associated token account
+
+An account that stores tokens belonging to a particular `mint`. When sending
+tokens, the sender can create associated token accounts for the recipient on
+demand, so the recipient can recieve the token in the receipent's associated
+token account.
+
 ## bank state
 
 The result of interpreting all programs on the ledger at a given
 [tick height](#tick-height). It includes at least the set of all
 [accounts](#account) holding nonzero [native tokens](#native-token).
+
+## base58
+
+A way of representing binary values as strings. Unlike similar systems like
+base64, base58 omits similar-appearing characters to avoid confusion. Solana
+commonly uses base58 to refer to [wallet addresses](#wallet-address)
 
 ## block
 
@@ -259,6 +272,15 @@ on-chain programs.
 The duration of time for which a [validator](#validator) is unable to
 [vote](#ledger-vote) on another [fork](#fork).
 
+## major unit
+
+The 'main' unit of a currency. For example, among fiat currencies, the dollar
+(for USD), pound (for GBP) and Euro (for EUR) are major units. Solana's SOL
+token has a major unit called the [Sol](#sol). Each Sol is worth 1 billion of
+[lamports](#lamport). Since computers aren't good at decimal maths, transactions
+usually use [minor-units](#minor-unit), converting to major units only for user
+display.
+
 ## message
 
 The structured contents of a [transaction](#transaction). Generally containing a
@@ -268,6 +290,32 @@ of [instructions](#instruction).
 Learn more about the
 [message formatting inside of transactions](./developing/programming-model/transactions.md#message-format)
 here.
+
+## memo
+
+The [memo program](https://spl.solana.com/memo) provides a way to write text to
+the blockchain. The Memo program is often added as an instruction to transfer
+transactions as a text description by the sender of what the transfer is for.
+For example, 'Thanks!❤️ '.
+
+## minor unit
+
+The lesser unit of a currency. Well known minor units include US cents (for
+USD), pence (for GBP) and Eurocents (for EUR). Solana's Sol
+[cryptocurrency](#cryptocurrency) has a minor unit called the
+[Lamport](#lamport).
+
+## mint
+
+Verb. Minting tokens increases the supply of the tokens and transfers the new
+tokens to a specific [token account](#token-account).
+
+## mint account
+
+An [account](#account) used to [mint](#mint) tokens to store in a separate
+[token account](#token-account). Each token mint is unique for that network. For
+example, [USDC on Solana mainnet](https://www.circle.com/en/usdc/developers) has
+the mint address `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.
 
 ## native token
 
@@ -469,6 +517,12 @@ The Nth [tick](#tick) in the [ledger](#ledger).
 
 A digitally transferable asset.
 
+## token account
+
+An [account](#account) that holds the balance for newly [mint](#mint)ed
+[token](#token)s. Each token account is associated with a single
+[mint account](#mint-account).
+
 ## tps
 
 [Transactions](#transaction) per second.
@@ -529,6 +583,23 @@ validator in its vote account when the validator reaches a [root](#root).
 ## wallet
 
 A collection of [keypairs](#keypair) that allows users to manage their funds.
+
+## wallet address
+
+The unique [public key](#public-key-pubkey) of a wallet. These are usually
+displayed to programs as a [base58](#base58) string.
+
+## wallet app
+
+An end-user program with a user interface to interfact with a blockchain. A
+wallet typically includes a UI to send and recieve tokens and NFTs, check
+balances of diffferent tokens, view NFTs, stake, and on.off ramp into fiat and
+back. See the
+[wallet apps on a Solana ecosytstem page](https://solana.com/ecosystem/explore?categories=wallet).
+
+## wallet name
+
+A unique memorable name used to refer to a [wallet address](@wallet-address).
 
 ## warmup period
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -68,8 +68,8 @@ a block chain.
 ## BPF loader
 
 The Solana program that owns and loads
-[BPF](developing/on-chain-programs/faq#berkeley-packet-filter-bpf) smart
-contract programs, allowing the program to interface with the runtime.
+[BPF](developing/on-chain-programs/faq#berkeley-packet-filter-bpf) on-chain
+programs, allowing the program to interface with the runtime.
 
 ## client
 
@@ -119,7 +119,8 @@ See [vote credit](#vote-credit).
 
 ## cross-program invocation (CPI)
 
-A call from one smart contract program to another. For more information, see
+A call from one on-chain [program](@program) to another. For more information,
+see
 [calling between programs](developing/programming-model/calling-between-programs.md).
 
 ## data plane
@@ -280,6 +281,11 @@ A computer participating in a [cluster](#cluster).
 
 The number of [validators](#validator) participating in a [cluster](#cluster).
 
+## on-chain program
+
+A programthat runs on a blockchain that can read and modify accounts over which
+the on-chain program has control.
+
 ## PoH
 
 See [Proof of History](#proof-of-history-poh).
@@ -296,12 +302,13 @@ owed to a [stake](#stake) during redemption is the product of the
 Another word for the [#secret-key]. Solana tools and documentation generally use
 the term 'secret key' instead.
 
-## program
+## program (or on-chain program)
 
 The executable code that interprets the [instructions](#instruction) sent inside
-of each [transaction](#transaction) on the Solana. These programs are often
-referred to as "[_smart contracts_](./developing//intro/programs.md)" on other
-blockchains.
+of each [transaction](#transaction) on the Solana.
+
+These programs are often referred to as
+"[_smart contracts_](./developing//intro/programs.md)" on other blockchains.
 
 ## program derived account (PDA)
 
@@ -369,7 +376,7 @@ The secret key of a [keypair](#keypair).
 
 ## Sealevel
 
-Solana's parallel smart contracts run-time.
+Solana's parallel run-time for [on-chain programs](#on-chain-program).
 
 ## shred
 
@@ -416,8 +423,8 @@ non-overlapping, comprising roughly equal real-world time as per
 
 ## smart contract
 
-A program on a blockchain that can read and modify accounts over which it has
-control.
+Another term for [on chain programs](#programs). Solana programs should use the
+term [on chain programs](#programs).
 
 ## sol
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -215,6 +215,10 @@ program. A [client](#client) can include one or multiple instructions in a
 [transaction](#transaction). An instruction may contain one or more
 [cross-program invocations](#cross-program-invocation-cpi).
 
+## ix
+
+Short for [instruction](#instruction).
+
 ## keypair
 
 A [public key](#public-key-pubkey) and corresponding [secret key](#private-key)
@@ -492,6 +496,10 @@ behavior can be proven.
 
 2/3 of a [cluster](#cluster).
 
+## sx
+
+Short for [signature](#signature).
+
 ## sysvar
 
 A system [account](#account).
@@ -555,6 +563,10 @@ A set of [transactions](#transaction) that may be executed in parallel.
 ## tvu
 
 [Transaction validation unit](validator/tvu.md).
+
+## tx
+
+Short for [transaction](#transaction).
 
 ## validator
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -129,7 +129,7 @@ consensus.
 
 ## drone
 
-An off-chain service that acts as a custodian for a user's private key. It
+An off-chain service that acts as a custodian for a user's secret key. It
 typically serves to validate and sign transactions.
 
 ## entry
@@ -203,7 +203,7 @@ program. A [client](#client) can include one or multiple instructions in a
 
 ## keypair
 
-A [public key](#public-key-pubkey) and corresponding [private key](#private-key)
+A [public key](#public-key-pubkey) and corresponding [secret key](#private-key)
 for accessing an account.
 
 ## lamport
@@ -293,7 +293,8 @@ owed to a [stake](#stake) during redemption is the product of the
 
 ## private key
 
-The private key of a [keypair](#keypair).
+Another word for the [#secret-key]. Solana tools and documentation generally use
+the term 'secret key' instead.
 
 ## program
 
@@ -305,7 +306,7 @@ blockchains.
 ## program derived account (PDA)
 
 An account whose signing authority is a program and thus is not controlled by a
-private key like other accounts.
+secret key like other accounts.
 
 ## program id
 
@@ -361,6 +362,10 @@ root are excluded from consideration for consensus and can be discarded.
 
 The component of a [validator](#validator) responsible for [program](#program)
 execution.
+
+## secret key
+
+The secret key of a [keypair](#keypair).
 
 ## Sealevel
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -603,7 +603,7 @@ displayed to programs as a [base58](#base58) string.
 
 ## wallet app
 
-An end-user program with a user interface to interfact with a blockchain. A
+An end-user program with a user interface (UI) to interact with a blockchain. A
 wallet typically includes a UI to send and recieve tokens and NFTs, check
 balances of diffferent tokens, view NFTs, stake, and on.off ramp into fiat and
 back. See the


### PR DESCRIPTION
 - fix: a transaction must have at least one instruction
 -  fix: minor grammar fixes
 - feat: add definitions for base58, memo, major unit, minor unit, mint, mint account, token account, wallet address, wallet name.
 - fix: use 'programs' or 'on chain programs' unless explicitly referring to other blockchains
 -  fix: solana tools use 'secret key' so be consistent with that
 - feat: add definitions for tx, ix and sx