### PR TITLE
Update URL to QuickNode's Faucet

### DIFF
--- a/content/guides/getstarted/solana-token-airdrop-and-faucets.md
+++ b/content/guides/getstarted/solana-token-airdrop-and-faucets.md
@@ -63,7 +63,7 @@ here_
 Currently Supported:
 
 1. [Helius](https://www.helius.dev/)
-2. [QuickNode](https://www.quicknode.com/chains/sol)
+2. [QuickNode](https://faucet.quicknode.com/solana/devnet)
 
 ### Using the Solana CLI
 


### PR DESCRIPTION
- Quick fix to update the QuickNode Faucet URL ([https://faucet.quicknode.com/solana/devnet](https://faucet.quicknode.com/solana/devnet)) on the [How to get Solana devnet SOL](https://solana.com/developers/guides/getstarted/solana-token-airdrop-and-faucets) page.