### PR TITLE
[docs] fix: assorted typos

### DIFF
--- a/content/guides/javascript/compressed-nfts.md
+++ b/content/guides/javascript/compressed-nfts.md
@@ -613,7 +613,8 @@ The response fields to pay special attention to are:
 
 Transferring compressed NFTs is different from transferring uncompressed NFTs.
 Aside from using a different on-chain program, compressed NFTs require the use
-of a asset's "merkle proof" (or `proof` for short) to actually change ownership.
+of an asset's "merkle proof" (or `proof` for short) to actually change
+ownership.
 
 ### What is a merkle proof?
 
@@ -813,7 +814,7 @@ helper function.
 Since each of these hash values resemble and are formatted similar to
 PublicKeys, we can use the
 [`PublicKey`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html)
-class in web3.js to convert them into a accepted byte array format.
+class in web3.js to convert them into an accepted byte array format.
 
 #### Send the transaction
 

--- a/docs/economics/staking/index.md
+++ b/docs/economics/staking/index.md
@@ -93,7 +93,8 @@ information. Do your own due diligence.
 
 #### Delegate your Stake
 
-Follow the wallet's instructions for delegating your to your chosen validator.
+Follow the wallet's instructions for delegating your stake to your chosen
+validator.
 
 ## Stake Account Details
 

--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -19,9 +19,9 @@ keywords:
 
 Welcome to the Solana developer docs!
 
-This guide contains step-by-step instructions on how to get started. Before we
-get into the hands on part of the guide, we'll cover basic concepts that all
-developers need to be familiar with to build on Solana:
+This guide contains step-by-step instructions on how to get started. Before the
+hands-on part of the guide, we'll cover basic concepts that all developers need
+to be familiar with to build on Solana:
 
 - Transactions
 - Accounts
@@ -48,7 +48,7 @@ easy-to-understand way.
 
 ### Program development
 
-The first development workflow allows you to to create and deploy custom Rust, C
+The first development workflow allows you to create and deploy custom Rust, C
 and C++ programs directly to the blockchain. Once these programs are deployed,
 anyone who knows how to communicate with them can use them.
 

--- a/docs/intro/transaction_fees.md
+++ b/docs/intro/transaction_fees.md
@@ -21,8 +21,8 @@ on the Solana blockchain are known as "_transaction fees_".
 As each transaction (which contains one or more instructions) is sent through
 the network, it gets processed by the current leader validation-client. Once
 confirmed as a global state transaction, this _transaction fee_ is paid to the
-network to help support the [economic design](#economic-design) of the Solana
-blockchain.
+network to help support the [economic design](#basic-economic-design) of the
+Solana blockchain.
 
 > **NOTE:** Transaction fees are different from
 > [account rent](/docs/terminology.md#rent)! While transaction fees are paid to
@@ -92,7 +92,7 @@ Transactions fees are calculated based on two main parts:
   "[_compute units_](/docs/terminology.md#compute-units)"
 
 Since each transaction may require a different amount of computational
-resources, they are alloted a maximum number of _compute units_ per transaction
+resources, they are allotted a maximum number of _compute units_ per transaction
 known as the "[_compute budget_](/docs/terminology.md#compute-budget)".
 
 The execution of each instruction within a transaction consumes a different

--- a/docs/more/exchange.md
+++ b/docs/more/exchange.md
@@ -898,7 +898,7 @@ the initial balance can be assumed to be zero.
 
 ### Withdrawing
 
-The withdrawal address a user provides must be the that of their SOL wallet.
+The withdrawal address a user provides must be that of their SOL wallet.
 
 Before executing a withdrawal [transfer](#token-transfers), the exchange should
 check the address as


### PR DESCRIPTION
This PR fixes the docs related typos from the following PRs on the solana mono repo:
- https://github.com/solana-labs/solana/pull/34385
- https://github.com/solana-labs/solana/pull/34386