### PR TITLE
Update compressed-nfts docs link

### DIFF
--- a/content/guides/javascript/compressed-nfts.md
+++ b/content/guides/javascript/compressed-nfts.md
@@ -281,7 +281,7 @@ two related instructions:
 2. actually create the tree, owned by the Bubblegum program
 
 Using the
-[`createAllocTreeIx`](https://solana-labs.github.io/solana-program-library/account-compression/sdk/docs/modules/index.html#createAllocTreeIx)
+[`createAllocTreeIx`](https://solana-labs.github.io/solana-program-library/account-compression/sdk/modules/index.html#createAllocTreeIx)
 helper function, we allocate enough space on-chain for our tree.
 
 ```ts


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/34184 contains a fix for a link in the compressed NFTs page, but with the move of the repo the change must be made here instead.

#### Solution

Update to the correct link.

cc @metasal1