### PR TITLE
add hello world troubleshooting tips

### DIFF
--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -90,6 +90,19 @@ Add the `solana-program` crate to your new Rust library:
 cargo add solana-program
 ```
 
+> **PRO TIP:** It is highly recommended to keep your `solana-program` and other
+> Solana Rust dependencies in-line with your installed version of the Solana
+> CLI. For example, if you are running Solana CLI `1.17.17`, you can instead
+> run:
+>
+> ```
+> cargo add solana-program@"=1.17.17"
+> ```
+>
+> This will ensure your crate uses only `1.17.17` and nothing else. If you
+> experience compatibility issues with Solana dependencies, check out the
+> [Solana Stack Exchange](https://solana.stackexchange.com/questions/9798/error-building-program-with-solana-program-v1-18-and-cli-v1-17/9799)
+
 Open your `Cargo.toml` file and add these required Rust library configuration
 settings, updating your project name as appropriate:
 


### PR DESCRIPTION
Some issues with the Rust local "Hello world" example have been
popping up, especially with the release of `1.18.0`.

This change adds a few notes on how to handle dependency issues
when walking through this tutorial for the first time.