### PR TITLE
rpc: add commitment constraint

### DIFF
--- a/docs/rpc/http/getTransaction.mdx
+++ b/docs/rpc/http/getTransaction.mdx
@@ -28,7 +28,11 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+>
+
+- `processed` is not supported.
+
+</Field>
 
 <Field name="maxSupportedTransactionVersion" type="number" optional={true}>
   Set the max transaction version to return in responses. If the requested


### PR DESCRIPTION
As per [this issue on the monorepo](https://github.com/solana-labs/solana/issues/34664), this constraint needed to be added to `getTransaction`!

Closes https://github.com/solana-labs/solana/issues/34664