### PR TITLE
Add links to a few more testnet faucets

### DIFF
--- a/content/guides/getstarted/solana-token-airdrop-and-faucets.md
+++ b/content/guides/getstarted/solana-token-airdrop-and-faucets.md
@@ -48,9 +48,15 @@ documentation inside web3.js.
 
 _Available for Devnet_
 
-A web faucet hosted by Solana Foundation that has lower rate limits.
+1. [faucet.solana.com](https://faucet.solana.com) - A web faucet hosted by Solana Foundation that has lower rate limits.
+1. [solfaucet](https://solfaucet.com/)
+1. [quicknode](https://faucet.quicknode.com/solana/devnet)
 
-[faucet.solana.com](https://faucet.solana.com)
+_Available for Testnet_
+
+1. [solfaucet](https://solfaucet.com/)
+1. [quicknode](https://faucet.quicknode.com/solana/testnet)
+1. [testnetfaucet](https://testnetfaucet.org)
 
 ## 3. RPC Provider Faucets
 

--- a/content/guides/getstarted/solana-token-airdrop-and-faucets.md
+++ b/content/guides/getstarted/solana-token-airdrop-and-faucets.md
@@ -48,15 +48,24 @@ documentation inside web3.js.
 
 _Available for Devnet_
 
-1. [faucet.solana.com](https://faucet.solana.com) - A web faucet hosted by Solana Foundation that has lower rate limits.
-1. [solfaucet](https://solfaucet.com/)
-1. [quicknode](https://faucet.quicknode.com/solana/devnet)
+1. [faucet.solana.com](https://faucet.solana.com) - A public web faucet hosted
+   by the Solana Foundation
+2. [SolFaucet.com](https://solfaucet.com/) - Web UI for airdrops from the public
+   RPC endpoints
+3. [QuickNode](https://faucet.quicknode.com/solana/devnet) - A web faucet
+   operated by QuickNode
 
 _Available for Testnet_
 
-1. [solfaucet](https://solfaucet.com/)
-1. [quicknode](https://faucet.quicknode.com/solana/testnet)
-1. [testnetfaucet](https://testnetfaucet.org)
+1. [faucet.solana.com](https://faucet.solana.com) - A public web faucet hosted
+   by the Solana Foundation
+2. [SolFaucet.com](https://solfaucet.com/) - Web UI for airdrops from the public
+   RPC endpoints
+3. [QuickNode](https://faucet.quicknode.com/solana/testnet) - A web faucet
+   operated by QuickNode
+4. [TestnetFaucet.org](https://testnetfaucet.org) - A web faucet with a rate
+   limit separate than the public RPC endpoints, operated by
+   [@Ferric](https://twitter.com/ferric)
 
 ## 3. RPC Provider Faucets
 


### PR DESCRIPTION
In order to spin up a testnet validator, validators need testnet SOL. The faucet is often overloaded, so adding a few web faucets to this list for others to find.

Full disclosure: I wrote testnetfaucet.org (the code is in a public github repo here: https://github.com/ferric-sol/testnetfaucet) to help folks on the Solana Tech discord