### PR TITLE
docs: add 'instruction handler' and separate from 'instruction'

### DIFF
--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -195,11 +195,18 @@ See [cross-program invocation](#cross-program-invocation-cpi).
 
 ## instruction
 
-The smallest contiguous unit of execution logic in a [program](#program). An
-instruction specifies which program it is calling, which accounts it wants to
+A call to invoke a specific [instruction-handler](#instruction-handler) in a
+[program](#program). An instruction also specifies which accounts it wants to
 read or modify, and additional data that serves as auxiliary input to the
-program. A [client](#client) can include one or multiple instructions in a
-[transaction](#transaction). An instruction may contain one or more
+[instruction-handler](#instruction-handler). A [client](#client) must include at
+least one instruction in a [transaction](#transaction), and all instructions
+must complete for the transaction to be considered successful.
+
+## instruction handler
+
+Instruction handlers are [program](#program) functions that process
+[instructions](#instruction) from [transactions](#transaction). An instruction
+handler may contain one or more
 [cross-program invocations](#cross-program-invocation-cpi).
 
 ## keypair

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -198,7 +198,7 @@ See [cross-program invocation](#cross-program-invocation-cpi).
 A call to invoke a specific [instruction-handler](#instruction-handler) in a
 [program](#program). An instruction also specifies which accounts it wants to
 read or modify, and additional data that serves as auxiliary input to the
-[instruction-handler](#instruction-handler). A [client](#client) must include at
+[instruction handler](#instruction-handler). A [client](#client) must include at
 least one instruction in a [transaction](#transaction), and all instructions
 must complete for the transaction to be considered successful.
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -195,7 +195,7 @@ See [cross-program invocation](#cross-program-invocation-cpi).
 
 ## instruction
 
-A call to invoke a specific [instruction-handler](#instruction-handler) in a
+A call to invoke a specific [instruction handler](#instruction-handler) in a
 [program](#program). An instruction also specifies which accounts it wants to
 read or modify, and additional data that serves as auxiliary input to the
 [instruction handler](#instruction-handler). A [client](#client) must include at


### PR DESCRIPTION
Current terminology uses the same term for the function and the thing being processed, which does not make logical sense and causes difficulty when explaining Solana development ("the instructions process the instructions"). 

Anchor 0.29 uses 'handler' to describe instruction handlers (see the function names when you start a project with `--template=multiple`) and this seems like a fine way of distinguishing between instructions and (what we now call) instruction handlers. 