### PR TITLE
refactor: do not use 'token program' for old token program

### DIFF
--- a/content/guides/token-extensions/getting-started.md
+++ b/content/guides/token-extensions/getting-started.md
@@ -18,16 +18,16 @@ tags:
   - token extensions
 ---
 
-Token extensions are the next generation of the Solana Program Library standard.
-Token extensions introduce a new set of ways to extend the normal token
-functionality. The original Token program brought the basic capabilities of
-transfer, freeze, and minting tokens. Token extensions include the same feature,
-but come with additional features such as confidential transfers, custom
-transfer logic, extended metadata, and much more.
+Token extensions are the new generation of the Solana Program Library standard, and 
+introduce new token functionality. 
 
-The Token Extensions program can be found with the programID
-`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` and is a superset of the original
-functionality provided by the [Token Program](https://spl.solana.com/token).
+The [original Token program](https://spl.solana.com/token) has the program ID 
+`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`, and brought the basic capabilities 
+of transferring, freezing, and minting tokens. 
+
+The [current Token program](https://spl.solana.com/token-2022) has the program ID `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` includes all the same features as 
+the original token program, but comes with extensions such as confidential transfers, 
+custom transfer logic, extended metadata, and much more.
 
 ## How do I create a token with token extensions?
 

--- a/content/guides/token-extensions/reallocate.md
+++ b/content/guides/token-extensions/reallocate.md
@@ -3,7 +3,7 @@ date: Dec 7, 2023
 seoTitle: "Token Extensions: Reallocate instruction"
 title: How to use the Reallocate instruction
 description:
-  "The Token Extensions program has an account extension that can be applied
+  "The current Token program has an account extension that can be applied
   after initializing a Token Account, enabling expanding support for more
   extensions after initial creation."
 keywords:
@@ -202,7 +202,7 @@ transaction details on SolanaFM.
 
 ## Conclusion
 
-The reallocate instruction on the Token Extensions program offers a flexible way
+The reallocate instruction on the current Token program offers a flexible way
 to update existing Token Accounts with additional functionalities. This
 instruction is useful for token owners who may not have foreseen the need for
 certain extensions initially, but find themselves requiring these additional

--- a/content/guides/token-extensions/transfer-hook.md
+++ b/content/guides/token-extensions/transfer-hook.md
@@ -30,7 +30,7 @@ instruction on the Transfer Hook program.
 
 <Callout type="info">
 
-When the Token Extensions program CPIs to a Transfer Hook program, all accounts
+When the current Token program CPIs to a Transfer Hook program, all accounts
 from the initial transfer are converted to read-only accounts. This means the
 signer privileges of the sender do not extend to the Transfer Hook program.
 
@@ -770,7 +770,7 @@ With the updated code below:
 <Callout type="info">
 
 Note that the order of accounts in this struct matters. This is the order in
-which the Token Extensions program provides these accounts when it CPIs to this
+which the current Token program provides these accounts when it CPIs to this
 Transfer Hook program.
 
 </Callout>
@@ -926,7 +926,7 @@ transfer amount.
 ### Fallback Instruction
 
 Lastly, we need to add a fallback instruction to the Anchor program to handle
-the CPI from the Token Extensions program.
+the CPI from the current Token program.
 
 This step is required due to the difference in the way Anchor generates
 instruction discriminators compared to the ones used in Transfer Hook interface


### PR DESCRIPTION
At some point - probably now - we should stop using 'token program' to refer to the old token program. 

This PR uses 'original Token program' to refer to the older token program, and, where needed uses 'current token program' to refer to the new program.

This is a speculative PR, free free to discuss or suggest changes. 