### PR TITLE
add "mut"

### DIFF
--- a/content/guides/token-extensions/transfer-hook.md
+++ b/content/guides/token-extensions/transfer-hook.md
@@ -255,6 +255,7 @@ pub struct TransferHook<'info> {
     )]
     pub extra_account_meta_list: UncheckedAccount<'info>,
     #[account(
+        mut,
         seeds = [b"counter"],
         bump
     )]


### PR DESCRIPTION
### Problem
Counter account was not updated after the transaction.

### Summary of Changes
add "mut" on `counter_account` so that the account will be updated.
Without "mut", increment is not persisted.