### PR TITLE
[guides] added evm to svm guide redirect

### DIFF
--- a/content/guides/getstarted/evm-to-svm.md
+++ b/content/guides/getstarted/evm-to-svm.md
@@ -1,0 +1,18 @@
+---
+featured: true
+title: "EVM to SVM: Understanding Solana for EVM developers"
+description:
+  "Learn about the key differences between the SVM and EVM development
+  environments and start building with Solana."
+tags:
+  - evm
+keywords:
+  - evm
+  - ethereum
+  - svm
+isExternal: false
+# this page already resides on solana.com
+href: /developers/evm-to-svm
+---
+
+Learn more https://solana.com/developers/evm-to-svm


### PR DESCRIPTION
### Problem

The [EVM to SVM](https://solana.com/developers/evm-to-svm) developer page is not displayed within the Developer guides.

### Summary of Changes

Make the page listed

