### PR TITLE
doc(introduction-to-durable-nonces.md): fix typo in Create Nonce Account section

### DIFF
--- a/content/guides/advanced/introduction-to-durable-nonces.md
+++ b/content/guides/advanced/introduction-to-durable-nonces.md
@@ -511,7 +511,7 @@ tx.add(
     // NONCE_ACCOUNT_LENGTH is the space a nonce account takes
     SystemProgram.createAccount({
         fromPubkey: nonceAuthKP.publicKey,
-        newAccountPubkey: nonceKeypairs[j].publicKey,
+        newAccountPubkey: nonceKeypair.publicKey,
         lamports: 0.0015 * LAMPORTS_PER_SOL,
         space: NONCE_ACCOUNT_LENGTH,
         programId: SystemProgram.programId,
@@ -519,7 +519,7 @@ tx.add(
     // initialise nonce with the created nonceKeypair's pubkey as the noncePubkey
     // also specify the authority of the nonce account
     SystemProgram.nonceInitialize({
-        noncePubkey: nonceKeypairs[j].publicKey,
+        noncePubkey: nonceKeypair.publicKey,
         authorizedPubkey: nonceAuthKP.publicKey,
     })
 );


### PR DESCRIPTION
### Problem

there is no variable named `nonceKeypairs` but there is one named `nonceKeypair` singular, and it is not an array


### Summary of Changes



Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->