### PR TITLE
[docs] RPC method examples should use devnet

### DIFF
--- a/docs/core/transactions/versions.md
+++ b/docs/core/transactions/versions.md
@@ -74,7 +74,7 @@ Using a standard JSON formatted POST request, you can set the
 `maxSupportedTransactionVersion` when retrieving a specific block:
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d \
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d \
 '{"jsonrpc": "2.0", "id":1, "method": "getBlock", "params": [430, {
   "encoding":"json",
   "maxSupportedTransactionVersion":0,
@@ -165,8 +165,8 @@ can send it to the cluster and `await` the response:
 
 ```js
 // send our v0 transaction to the cluster
-const txid = await connection.sendTransaction(transaction);
-console.log(`https://explorer.solana.com/tx/${txid}?cluster=devnet`);
+const txId = await connection.sendTransaction(transaction);
+console.log(`https://explorer.solana.com/tx/${txId}?cluster=devnet`);
 ```
 
 > NOTE: Unlike `legacy` transactions, sending a `VersionedTransaction` via

--- a/docs/more/exchange.md
+++ b/docs/more/exchange.md
@@ -169,11 +169,11 @@ rent-exempt balance for your deposit accounts, query the
 [`getMinimumBalanceForRentExemption` endpoint](/docs/rpc/http/getMinimumBalanceForRentExemption.mdx):
 
 ```bash
-curl localhost:8899 -X POST -H "Content-Type: application/json" -d '{
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
   "method": "getMinimumBalanceForRentExemption",
-  "params":[0]
+  "params": [0]
 }'
 ```
 
@@ -384,7 +384,7 @@ time.
   request to the api node:
 
 ```bash
-curl localhost:8899 -X POST -H "Content-Type: application/json" -d '{
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
   "method": "getSignaturesForAddress",
@@ -597,7 +597,7 @@ transaction was processed. If `confirmations: null`, it is
 [finalized](/docs/terminology.md#finality).
 
 ```bash
-curl localhost:8899 -X POST -H "Content-Type: application/json" -d '{
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc":"2.0",
   "id":1,
   "method":"getSignatureStatuses",
@@ -751,7 +751,7 @@ holding no data), currently: 0.000890880 SOL
 Similarly, every deposit account must contain at least this balance.
 
 ```bash
-curl localhost:8899 -X POST -H "Content-Type: application/json" -d '{
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
   "method": "getMinimumBalanceForRentExemption",

--- a/docs/rpc/deprecated/getConfirmedBlock.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlock.mdx
@@ -35,7 +35,7 @@ Configuration object containing the following fields:
   defaultValue="finalized"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field
   name="transactionDetails"

--- a/docs/rpc/deprecated/getConfirmedBlock.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlock.mdx
@@ -152,7 +152,7 @@ The result field will be an object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getConfirmedBlock",

--- a/docs/rpc/deprecated/getConfirmedBlocks.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlocks.mdx
@@ -33,7 +33,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/deprecated/getConfirmedBlocks.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlocks.mdx
@@ -50,7 +50,7 @@ block, inclusive. Max range allowed is 500,000 slots.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlocks","params":[5, 10]}
 '
 ```

--- a/docs/rpc/deprecated/getConfirmedBlocksWithLimit.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlocksWithLimit.mdx
@@ -37,7 +37,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/deprecated/getConfirmedBlocksWithLimit.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlocksWithLimit.mdx
@@ -53,7 +53,7 @@ starting at `start_slot` for up to `limit` blocks, inclusive.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getConfirmedBlocksWithLimit",

--- a/docs/rpc/deprecated/getConfirmedSignaturesForAddress2.mdx
+++ b/docs/rpc/deprecated/getConfirmedSignaturesForAddress2.mdx
@@ -41,7 +41,7 @@ Configuration object containing the following fields:
   defaultValue="finalized"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="limit" type="number" optional={true}>
   maximum transaction signatures to return (between 1 and 1,000, default:
@@ -83,7 +83,7 @@ fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/deprecated/getConfirmedTransaction.mdx
+++ b/docs/rpc/deprecated/getConfirmedTransaction.mdx
@@ -33,7 +33,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field 
   name="encoding"

--- a/docs/rpc/deprecated/getConfirmedTransaction.mdx
+++ b/docs/rpc/deprecated/getConfirmedTransaction.mdx
@@ -108,7 +108,7 @@ Encoding format for Account data
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/deprecated/getFeeCalculatorForBlockhash.mdx
+++ b/docs/rpc/deprecated/getFeeCalculatorForBlockhash.mdx
@@ -35,7 +35,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/deprecated/getFeeCalculatorForBlockhash.mdx
+++ b/docs/rpc/deprecated/getFeeCalculatorForBlockhash.mdx
@@ -59,7 +59,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/deprecated/getFeeRateGovernor.mdx
+++ b/docs/rpc/deprecated/getFeeRateGovernor.mdx
@@ -41,7 +41,7 @@ with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getFeeRateGovernor"}
 '
 ```

--- a/docs/rpc/deprecated/getFees.mdx
+++ b/docs/rpc/deprecated/getFees.mdx
@@ -60,7 +60,7 @@ with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   { "jsonrpc":"2.0", "id": 1, "method":"getFees"}
 '
 ```

--- a/docs/rpc/deprecated/getFees.mdx
+++ b/docs/rpc/deprecated/getFees.mdx
@@ -35,7 +35,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/deprecated/getRecentBlockhash.mdx
+++ b/docs/rpc/deprecated/getRecentBlockhash.mdx
@@ -56,7 +56,7 @@ FeeCalculator JSON object.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}
 '
 ```

--- a/docs/rpc/deprecated/getRecentBlockhash.mdx
+++ b/docs/rpc/deprecated/getRecentBlockhash.mdx
@@ -34,7 +34,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/deprecated/getSnapshotSlot.mdx
+++ b/docs/rpc/deprecated/getSnapshotSlot.mdx
@@ -33,7 +33,7 @@ Returns the highest slot that the node has a snapshot for
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getSnapshotSlot"}
 '
 ```

--- a/docs/rpc/http/getAccountInfo.mdx
+++ b/docs/rpc/http/getAccountInfo.mdx
@@ -99,7 +99,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getAccountInfo.mdx
+++ b/docs/rpc/http/getAccountInfo.mdx
@@ -27,7 +27,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field 
   name="encoding"

--- a/docs/rpc/http/getBalance.mdx
+++ b/docs/rpc/http/getBalance.mdx
@@ -28,7 +28,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getBalance.mdx
+++ b/docs/rpc/http/getBalance.mdx
@@ -48,7 +48,7 @@ balance
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getBalance",

--- a/docs/rpc/http/getBlock.mdx
+++ b/docs/rpc/http/getBlock.mdx
@@ -205,7 +205,7 @@ The result field will be an object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0","id":1,
     "method":"getBlock",

--- a/docs/rpc/http/getBlockCommitment.mdx
+++ b/docs/rpc/http/getBlockCommitment.mdx
@@ -36,7 +36,7 @@ The result field will be a JSON object containing:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getBlockCommitment",

--- a/docs/rpc/http/getBlockHeight.mdx
+++ b/docs/rpc/http/getBlockHeight.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getBlockHeight.mdx
+++ b/docs/rpc/http/getBlockHeight.mdx
@@ -42,7 +42,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0","id":1,
     "method":"getBlockHeight"

--- a/docs/rpc/http/getBlockProduction.mdx
+++ b/docs/rpc/http/getBlockProduction.mdx
@@ -62,7 +62,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getBlockProduction"}
 '
 ```

--- a/docs/rpc/http/getBlockProduction.mdx
+++ b/docs/rpc/http/getBlockProduction.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="identity" type="string" optional={true}>
   Only return results for this validator identity (base-58 encoded)

--- a/docs/rpc/http/getBlockTime.mdx
+++ b/docs/rpc/http/getBlockTime.mdx
@@ -37,7 +37,7 @@ Returns the estimated production time of a block.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,
     "method": "getBlockTime",

--- a/docs/rpc/http/getBlocks.mdx
+++ b/docs/rpc/http/getBlocks.mdx
@@ -54,7 +54,7 @@ block, inclusive. Max range allowed is 500,000 slots.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getBlocks",

--- a/docs/rpc/http/getBlocksWithLimit.mdx
+++ b/docs/rpc/http/getBlocksWithLimit.mdx
@@ -53,7 +53,7 @@ starting at `start_slot` for up to `limit` blocks, inclusive.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id":1,

--- a/docs/rpc/http/getClusterNodes.mdx
+++ b/docs/rpc/http/getClusterNodes.mdx
@@ -39,7 +39,7 @@ fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getClusterNodes"

--- a/docs/rpc/http/getEpochInfo.mdx
+++ b/docs/rpc/http/getEpochInfo.mdx
@@ -50,7 +50,7 @@ The result field will be an object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}
 '
 ```

--- a/docs/rpc/http/getEpochInfo.mdx
+++ b/docs/rpc/http/getEpochInfo.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getEpochSchedule.mdx
+++ b/docs/rpc/http/getEpochSchedule.mdx
@@ -36,7 +36,7 @@ The result field will be an object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0","id":1,
     "method":"getEpochSchedule"

--- a/docs/rpc/http/getFeeForMessage.mdx
+++ b/docs/rpc/http/getFeeForMessage.mdx
@@ -51,7 +51,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
 {
   "id":1,
   "jsonrpc":"2.0",

--- a/docs/rpc/http/getFeeForMessage.mdx
+++ b/docs/rpc/http/getFeeForMessage.mdx
@@ -32,7 +32,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getFirstAvailableBlock.mdx
+++ b/docs/rpc/http/getFirstAvailableBlock.mdx
@@ -27,7 +27,7 @@ ledger
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0","id":1,
     "method":"getFirstAvailableBlock"

--- a/docs/rpc/http/getGenesisHash.mdx
+++ b/docs/rpc/http/getGenesisHash.mdx
@@ -26,7 +26,7 @@ Returns the genesis hash
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getGenesisHash"}
 '
 ```

--- a/docs/rpc/http/getHealth.mdx
+++ b/docs/rpc/http/getHealth.mdx
@@ -31,7 +31,7 @@ of the error response are **UNSTABLE** and may change in the future
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getHealth"}
 '
 ```

--- a/docs/rpc/http/getHighestSnapshotSlot.mdx
+++ b/docs/rpc/http/getHighestSnapshotSlot.mdx
@@ -41,7 +41,7 @@ fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1,"method":"getHighestSnapshotSlot"}
 '
 ```

--- a/docs/rpc/http/getIdentity.mdx
+++ b/docs/rpc/http/getIdentity.mdx
@@ -29,7 +29,7 @@ The result field will be a JSON object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getIdentity"}
 '
 ```

--- a/docs/rpc/http/getInflationGovernor.mdx
+++ b/docs/rpc/http/getInflationGovernor.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/getInflationGovernor.mdx
+++ b/docs/rpc/http/getInflationGovernor.mdx
@@ -46,7 +46,7 @@ The result field will be a JSON object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getInflationGovernor"}
 '
 ```

--- a/docs/rpc/http/getInflationRate.mdx
+++ b/docs/rpc/http/getInflationRate.mdx
@@ -32,7 +32,7 @@ The result field will be a JSON object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getInflationRate"}
 '
 ```

--- a/docs/rpc/http/getInflationReward.mdx
+++ b/docs/rpc/http/getInflationReward.mdx
@@ -27,7 +27,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="epoch" type="u64" optional={true}>
   An epoch for which the reward occurs. If omitted, the previous epoch will be

--- a/docs/rpc/http/getInflationReward.mdx
+++ b/docs/rpc/http/getInflationReward.mdx
@@ -58,7 +58,7 @@ The result field will be a JSON array with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getLargestAccounts.mdx
+++ b/docs/rpc/http/getLargestAccounts.mdx
@@ -24,7 +24,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="filter" type="string" optional={true}>
   filter results by account type

--- a/docs/rpc/http/getLargestAccounts.mdx
+++ b/docs/rpc/http/getLargestAccounts.mdx
@@ -49,7 +49,7 @@ The result will be an RpcResponse JSON object with `value` equal to an array of
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getLargestAccounts"}
 '
 ```

--- a/docs/rpc/http/getLatestBlockhash.mdx
+++ b/docs/rpc/http/getLatestBlockhash.mdx
@@ -55,7 +55,7 @@ object including:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "id":1,
     "jsonrpc":"2.0",

--- a/docs/rpc/http/getLatestBlockhash.mdx
+++ b/docs/rpc/http/getLatestBlockhash.mdx
@@ -30,7 +30,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getLeaderSchedule.mdx
+++ b/docs/rpc/http/getLeaderSchedule.mdx
@@ -33,7 +33,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="identity" type="string" optional={true}>
   Only return results for this validator identity (base-58 encoded)

--- a/docs/rpc/http/getLeaderSchedule.mdx
+++ b/docs/rpc/http/getLeaderSchedule.mdx
@@ -57,7 +57,7 @@ Returns a result with one of the two following values:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getMaxRetransmitSlot.mdx
+++ b/docs/rpc/http/getMaxRetransmitSlot.mdx
@@ -27,7 +27,7 @@ Get the max slot seen from retransmit stage.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getMaxRetransmitSlot"}
 '
 ```

--- a/docs/rpc/http/getMaxShredInsertSlot.mdx
+++ b/docs/rpc/http/getMaxShredInsertSlot.mdx
@@ -27,7 +27,7 @@ Get the max slot seen from after shred insert.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getMaxShredInsertSlot"}
 '
 ```

--- a/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
+++ b/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
@@ -43,7 +43,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getMinimumBalanceForRentExemption",

--- a/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
+++ b/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
@@ -28,7 +28,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/getMultipleAccounts.mdx
+++ b/docs/rpc/http/getMultipleAccounts.mdx
@@ -102,7 +102,7 @@ The result will be a JSON object with `value` equal to an array of:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getMultipleAccounts.mdx
+++ b/docs/rpc/http/getMultipleAccounts.mdx
@@ -28,7 +28,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getProgramAccounts.mdx
+++ b/docs/rpc/http/getProgramAccounts.mdx
@@ -129,7 +129,7 @@ The resultant response array will contain:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getProgramAccounts.mdx
+++ b/docs/rpc/http/getProgramAccounts.mdx
@@ -28,7 +28,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getRecentPerformanceSamples.mdx
+++ b/docs/rpc/http/getRecentPerformanceSamples.mdx
@@ -48,7 +48,7 @@ An array of `RpcPerfSample<object>` with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,
     "method": "getRecentPerformanceSamples",

--- a/docs/rpc/http/getRecentPrioritizationFees.mdx
+++ b/docs/rpc/http/getRecentPrioritizationFees.mdx
@@ -47,7 +47,7 @@ An array of `RpcPrioritizationFee<object>` with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,
     "method": "getRecentPrioritizationFees",

--- a/docs/rpc/http/getSignatureStatuses.mdx
+++ b/docs/rpc/http/getSignatureStatuses.mdx
@@ -68,7 +68,7 @@ An array of `RpcResponse<object>` consisting of either:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getSignaturesForAddress.mdx
+++ b/docs/rpc/http/getSignaturesForAddress.mdx
@@ -30,7 +30,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getSignaturesForAddress.mdx
+++ b/docs/rpc/http/getSignaturesForAddress.mdx
@@ -79,7 +79,7 @@ containing transaction signature information with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getSlot.mdx
+++ b/docs/rpc/http/getSlot.mdx
@@ -24,7 +24,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getSlot.mdx
+++ b/docs/rpc/http/getSlot.mdx
@@ -43,7 +43,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getSlot"}
 '
 ```

--- a/docs/rpc/http/getSlotLeader.mdx
+++ b/docs/rpc/http/getSlotLeader.mdx
@@ -42,7 +42,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getSlotLeader"}
 '
 ```

--- a/docs/rpc/http/getSlotLeader.mdx
+++ b/docs/rpc/http/getSlotLeader.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getSlotLeaders.mdx
+++ b/docs/rpc/http/getSlotLeaders.mdx
@@ -37,7 +37,7 @@ If the current slot is `#99` - query the next `10` leaders with the following
 request:
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id": 1,
     "method": "getSlotLeaders",

--- a/docs/rpc/http/getStakeActivation.mdx
+++ b/docs/rpc/http/getStakeActivation.mdx
@@ -57,7 +57,7 @@ The result will be a JSON object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getStakeActivation.mdx
+++ b/docs/rpc/http/getStakeActivation.mdx
@@ -27,7 +27,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getStakeMinimumDelegation.mdx
+++ b/docs/rpc/http/getStakeMinimumDelegation.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/getStakeMinimumDelegation.mdx
+++ b/docs/rpc/http/getStakeMinimumDelegation.mdx
@@ -40,7 +40,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,
     "method": "getStakeMinimumDelegation"

--- a/docs/rpc/http/getSupply.mdx
+++ b/docs/rpc/http/getSupply.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="excludeNonCirculatingAccountsList" type="bool" optional={true}>
   exclude non circulating accounts list from response

--- a/docs/rpc/http/getSupply.mdx
+++ b/docs/rpc/http/getSupply.mdx
@@ -50,7 +50,7 @@ object containing:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0", "id":1, "method":"getSupply"}
 '
 ```

--- a/docs/rpc/http/getTokenAccountBalance.mdx
+++ b/docs/rpc/http/getTokenAccountBalance.mdx
@@ -55,7 +55,7 @@ from [getBlock](/docs/rpc/http/getblock) follows a similar structure.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getTokenAccountBalance",

--- a/docs/rpc/http/getTokenAccountBalance.mdx
+++ b/docs/rpc/http/getTokenAccountBalance.mdx
@@ -27,7 +27,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/getTokenAccountsByDelegate.mdx
+++ b/docs/rpc/http/getTokenAccountsByDelegate.mdx
@@ -38,7 +38,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getTokenAccountsByDelegate.mdx
+++ b/docs/rpc/http/getTokenAccountsByDelegate.mdx
@@ -115,7 +115,7 @@ can be expected inside the structure, both for the `tokenAmount` and the
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -38,7 +38,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -115,7 +115,7 @@ can be expected inside the structure, both for the `tokenAmount` and the
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getTokenLargestAccounts.mdx
+++ b/docs/rpc/http/getTokenLargestAccounts.mdx
@@ -52,7 +52,7 @@ JSON objects containing:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getTokenLargestAccounts",

--- a/docs/rpc/http/getTokenLargestAccounts.mdx
+++ b/docs/rpc/http/getTokenLargestAccounts.mdx
@@ -27,7 +27,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/getTokenSupply.mdx
+++ b/docs/rpc/http/getTokenSupply.mdx
@@ -51,7 +51,7 @@ object containing:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "getTokenSupply",

--- a/docs/rpc/http/getTokenSupply.mdx
+++ b/docs/rpc/http/getTokenSupply.mdx
@@ -27,7 +27,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/getTransaction.mdx
+++ b/docs/rpc/http/getTransaction.mdx
@@ -144,7 +144,7 @@ Encoding for the returned Transaction
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/getTransactionCount.mdx
+++ b/docs/rpc/http/getTransactionCount.mdx
@@ -42,7 +42,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}
 '
 ```

--- a/docs/rpc/http/getTransactionCount.mdx
+++ b/docs/rpc/http/getTransactionCount.mdx
@@ -23,7 +23,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/getVersion.mdx
+++ b/docs/rpc/http/getVersion.mdx
@@ -31,7 +31,7 @@ The result field will be a JSON object with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getVersion"}
 '
 ```

--- a/docs/rpc/http/getVoteAccounts.mdx
+++ b/docs/rpc/http/getVoteAccounts.mdx
@@ -24,7 +24,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="votePubkey" type="string" optional={true}>
   Only return results for this validator vote address (base-58 encoded)

--- a/docs/rpc/http/getVoteAccounts.mdx
+++ b/docs/rpc/http/getVoteAccounts.mdx
@@ -69,7 +69,7 @@ each containing an array of JSON objects with the following sub fields:
 Restrict results to a single validator vote account:
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/index.mdx
+++ b/docs/rpc/http/index.mdx
@@ -36,7 +36,7 @@ fields:
 Example using curl:
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,
@@ -64,7 +64,7 @@ The commitment parameter should be included as the last element in the `params`
 array:
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/isBlockhashValid.mdx
+++ b/docs/rpc/http/isBlockhashValid.mdx
@@ -33,7 +33,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="minContextSlot" type="number" optional={true}>
   The minimum slot that the request can be evaluated at

--- a/docs/rpc/http/isBlockhashValid.mdx
+++ b/docs/rpc/http/isBlockhashValid.mdx
@@ -52,7 +52,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "id":45,
     "jsonrpc":"2.0",

--- a/docs/rpc/http/minimumLedgerSlot.mdx
+++ b/docs/rpc/http/minimumLedgerSlot.mdx
@@ -32,7 +32,7 @@ Returns the lowest slot that the node has information about in its ledger.
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"minimumLedgerSlot"}
 '
 ```

--- a/docs/rpc/http/requestAirdrop.mdx
+++ b/docs/rpc/http/requestAirdrop.mdx
@@ -31,7 +31,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/http/requestAirdrop.mdx
+++ b/docs/rpc/http/requestAirdrop.mdx
@@ -46,7 +46,7 @@ Configuration object containing the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,
     "method": "requestAirdrop",

--- a/docs/rpc/http/sendTransaction.mdx
+++ b/docs/rpc/http/sendTransaction.mdx
@@ -100,7 +100,7 @@ encoded string ([transaction id](/docs/terminology.md#transaction-id))
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/http/simulateTransaction.mdx
+++ b/docs/rpc/http/simulateTransaction.mdx
@@ -150,7 +150,7 @@ with the following fields:
 ### Code sample
 
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/rpc/websocket/accountSubscribe.mdx
+++ b/docs/rpc/websocket/accountSubscribe.mdx
@@ -28,7 +28,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field 
   name="encoding"

--- a/docs/rpc/websocket/logsSubscribe.mdx
+++ b/docs/rpc/websocket/logsSubscribe.mdx
@@ -55,7 +55,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 </Parameter>
 

--- a/docs/rpc/websocket/programSubscribe.mdx
+++ b/docs/rpc/websocket/programSubscribe.mdx
@@ -30,7 +30,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field
   name="filters"

--- a/docs/rpc/websocket/signatureSubscribe.mdx
+++ b/docs/rpc/websocket/signatureSubscribe.mdx
@@ -41,7 +41,7 @@ Configuration object containing the following fields:
   type="string"
   optional={true}
   href="/docs/rpc/index.mdx#configuring-state-commitment"
-></Field>
+/>
 
 <Field name="enableReceivedNotification" type="bool" optional={true}>
 


### PR DESCRIPTION
### Problem

The RPC method pages use localhost within their `curl` examples to call a method. This assumes a person has the test validator installed and running, which may not be the case.

### Summary of Changes

- replaced `curl` requests to use the devnet endpoint vice localhost
- refactored closing tags of `<Field>` MDX components to please the VS code language server and remove the editor errors

Fixes #86 
