### PR TITLE
code blocks to use `shell` lang

### DIFF
--- a/content/guides/advanced/introduction-to-durable-nonces.md
+++ b/content/guides/advanced/introduction-to-durable-nonces.md
@@ -314,13 +314,13 @@ replicate an IRL scenario.
 
 ```shell
 solana-keygen new -o sender.json
-// pubkey: H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51
+# pubkey: H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51
 
 solana-keygen new -o co-sender.json
-// pubkey: HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S
+# pubkey: HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S
 
 solana-keygen new -o receiver.json
-// pubkey: D3RAQxwQBhMLum2WK7eCn2MpRWgeLtDW7fqXTcqtx9uC
+# pubkey: D3RAQxwQBhMLum2WK7eCn2MpRWgeLtDW7fqXTcqtx9uC
 ```
 
 Let's add some SOL to the member wallets.
@@ -572,12 +572,12 @@ tx.sign(nonceAuthKP);
 
 // make the owner of the publicKey sign the transaction
 // this should open a wallet popup and let the user sign the tx
-const signedtx = await signTransaction(tx);
+const signedTx = await signTransaction(tx);
 
 // once you have the signed tx, you can serialize it and store it
 // in a database, or send it to another device. You can submit it
 // at a later point, without the tx having a mortality
-const serialisedTx = bs58.encode(signedtx.serialize({requireAllSignatures: false}));
+const serialisedTx = bs58.encode(signedTx.serialize({requireAllSignatures: false}));
 console.log("Signed Durable Transaction: ", serialisedTx);
 ```
 

--- a/content/guides/advanced/introduction-to-durable-nonces.md
+++ b/content/guides/advanced/introduction-to-durable-nonces.md
@@ -167,14 +167,14 @@ Let's start with creating a new keypair which we will use as our Nonce
 authority. We can use the keypair currently configured in our Solana CLI, but
 it's better to make a fresh one (make sure you're on devnet).
 
-```console
+```shell
 solana-keygen new -o nonce-authority.json
 ```
 
 Set the current Solana CLI keypair to `nonce-authority.json` and airdrop some
 SOL in it.
 
-```console
+```shell
 solana config set -k ~/<path>/nonce-authority.json
 solana airdrop 2
 ```
@@ -188,14 +188,14 @@ instruction to delegate this keypair as the Nonce Account. We will also transfer
 0.0015 SOL to the Nonce Account from the Nonce Authority, which is usually just
 above the minimum quantity needed for rent exemption.
 
-```console
+```shell
 solana-keygen new -o nonce-account.json
 solana create-nonce-account nonce-account.json 0.0015
 ```
 
 Output
 
-```console
+```shell
 Signature: skkfzUQrZF2rcmrhAQV6SuLa7Hj3jPFu7cfXAHvkVep3Lk3fNSVypwULhqMRinsa6Zj5xjj8zKZBQ1agMxwuABZ
 ```
 
@@ -208,13 +208,13 @@ on the explorer, we can see that the Nonce Account was created and the
 
 We can query the value of the stored Nonce as follows.
 
-```console
+```shell
 solana nonce nonce-account.json
 ```
 
 Output
 
-```console
+```shell
 AkrQn5QWLACSP5EMT2R1ZHyKaGWVFrDHJ6NL89HKtwjQ
 ```
 
@@ -225,13 +225,13 @@ while signing a transaction.
 
 We can inspect the details of a Nonce Account in a prettier formatted version
 
-```console
+```shell
 solana nonce-account nonce-account.json
 ```
 
 Output
 
-```console
+```shell
 Balance: 0.0015 SOL
 Minimum Balance Required: 0.00144768 SOL
 Nonce blockhash: AkrQn5QWLACSP5EMT2R1ZHyKaGWVFrDHJ6NL89HKtwjQ
@@ -245,25 +245,25 @@ As discussed before, advancing the Nonce or changing the value of the nonce is
 an important step for making subsequent transactions unique. The Nonce Authority
 needs to sign the transaction with the `nonceAdvance` instruction.
 
-```console
+```shell
 solana new-nonce nonce-account.json
 ```
 
 Output
 
-```console
+```shell
 Signature: 4nMHnedguiEtHshuMEm3NsuTQaeV8AdcDL6QSndTZLK7jcLUag6HCiLtUq6kv21yNSVQLoFj44aJ5sZrTXoYYeyS
 ```
 
 If we check the nonce again, the value of the nonce has changed or advanced.
 
-```console
+```shell
 solana nonce nonce-account.json
 ```
 
 Output
 
-```console
+```shell
 DA8ynAQTGctqQXNS2RNTGpag6s5p5RcrBm2DdHhvpRJ8
 ```
 
@@ -272,26 +272,26 @@ DA8ynAQTGctqQXNS2RNTGpag6s5p5RcrBm2DdHhvpRJ8
 We transferred 0.0015 SOL when creating the Nonce Account. The Nonce Authority
 can transfer these funds back to itself or some other account.
 
-```console
+```shell
 solana withdraw-from-nonce-account nonce-account.json nonce-authority.json 0.0000001
 ```
 
 Output
 
-```console
+```shell
 Signature: 5zuBmrUpqnubdePHVgzSNThbocruJZLJK5Dut7DM6WyoqW4Qbrc26uCw3nq6jRocR9XLMwZZ79U54HDnGhDJVNfF
 ```
 
 We can check the status of the Nonce Account after the withdrawal; the balance
 should have changed.
 
-```console
+```shell
 solana nonce-account nonce-account.json
 ```
 
 Output
 
-```console
+```shell
 Balance: 0.0014999 SOL
 Minimum Balance Required: 0.00144768 SOL
 Nonce blockhash: DA8ynAQTGctqQXNS2RNTGpag6s5p5RcrBm2DdHhvpRJ8
@@ -312,7 +312,7 @@ and the receiver. Although, for this example, we are creating the keypairs in
 the same system, we will assume that these accounts are on different systems to
 replicate an IRL scenario.
 
-```console
+```shell
 solana-keygen new -o sender.json
 // pubkey: H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51
 
@@ -325,7 +325,7 @@ solana-keygen new -o receiver.json
 
 Let's add some SOL to the member wallets.
 
-```console
+```shell
 solana airdrop -k sender.json 0.5
 solana airdrop -k co-sender.json 0.5
 ```
@@ -356,7 +356,7 @@ To sign an offline transaction, we need to use:
 - You can even turn off your internet when you sign this transaction using the
   `co-sender`'s wallet :).
 
-```console
+```shell
 solana transfer receiver.json 0.1 \
   --sign-only \
   --blockhash F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE \
@@ -367,7 +367,7 @@ solana transfer receiver.json 0.1 \
 
 Output
 
-```console
+```shell
 Blockhash: F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE
 Signers (Pubkey=Signature):
  HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S=2gUmcb4Xwm3Dy9xH3a3bePsWVKCRMtUghqDS9pnGZDmX6hqtWMfpubEbgcai5twncoAJzyr9FRn3yuXVeSvYD4Ni
@@ -384,7 +384,7 @@ with the `sender` who will need this sign and submit the transaction. This share
 may take more than a minute to happen. Once the `sender` receives this pair,
 they can initiate the transfer.
 
-```console
+```shell
 solana transfer receiver.json 0.1 \
   --allow-unfunded-recipient \
   --blockhash F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE \
@@ -395,7 +395,7 @@ solana transfer receiver.json 0.1 \
 
 Output
 
-```console
+```shell
 Error: Hash has expired F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE
 ```
 
@@ -409,14 +409,14 @@ created earlier. We already have a nonce initialized in the `nonce-account`.
 Let's advance it to get a new one first, just to be sure that the `nonce` isn't
 already used.
 
-```console
+```shell
 solana new-nonce nonce-account.json
 solana nonce-account nonce-account.json
 ```
 
 Output
 
-```console
+```shell
 Signature: 3z1sSU7fmdRoBZynVLiJEqa97Ja481nb3r1mLu8buAgwMnaKdF4ZaiBkzrLjPRzn1HV2rh4AHQTJHAQ3DsDiYVpF
 
 Balance: 0.0014999 SOL
@@ -431,7 +431,7 @@ Perfect, now let's start with offline co-signing the transaction with
 above, which is basically the `nonce` stored in the `nonce-account` as the
 blockhash for the transfer transaction.
 
-```console
+```shell
 solana transfer receiver.json 0.1 \
   --sign-only \
   --nonce nonce-account.json \
@@ -443,7 +443,7 @@ solana transfer receiver.json 0.1 \
 
 Output
 
-```console
+```shell
 Blockhash: HNUi6La2QpGJdfcAR6yFFmdgYoCvFZREkve2haMBxXVz
 Signers (Pubkey=Signature):
  HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S=5tfuPxsXchbVFU745658nsQr5Gqhb5nRnZKLnnovJ2PZBHbqUbe7oB5kDbnq7tjeJ2V8Mywa4gujUjT4BWKRcAdi
@@ -454,7 +454,7 @@ Absent Signers (Pubkey):
 This is very similar to the one we signed using the recent blockhash. Now we'll
 sign and send the transaction with the `sender`'s wallet.
 
-```console
+```shell
 solana transfer receiver.json 0.1 \
   --nonce nonce-account.json \
   --nonce-authority nonce-authority.json \
@@ -466,7 +466,7 @@ solana transfer receiver.json 0.1 \
 
 Output
 
-```console
+```shell
 Signature: anQ8VtQgeSMoKTnQCubTenq1J7WKxAa1dbFMDLsbDWgV6GGL135G1Ydv4QTNd6GptP3TxDQ2ZWi3Y5qnEtjM7yg
 ```
 

--- a/content/guides/getstarted/hello-world-in-your-browser.md
+++ b/content/guides/getstarted/hello-world-in-your-browser.md
@@ -172,7 +172,7 @@ behalf to ensure your wallet has enough SOL to cover the cost of deployment.
 > Note: If you need more SOL, you can airdrop more by typing airdrop command in
 > the playground terminal:
 
-```sh
+```shell
 solana airdrop 2
 ```
 
@@ -212,7 +212,7 @@ to aid in our client application.
 We will be using Solana Playground for the client generation. Create a client
 folder by running `run` command in the playground terminal:
 
-```bash
+```shell
 run
 ```
 
@@ -278,7 +278,7 @@ command.
 
 Once your application completes, you will see output similar to this:
 
-```sh
+```shell
 Running client...
   client.ts:
     My address: GkxZRRNPfaUfL9XdYVfKF3rWjMcj5md6b6mpRoWpURwP
@@ -292,7 +292,7 @@ Running client...
 We will be using `solana-cli` directly in playground to get the information
 about any transaction:
 
-```sh
+```shell
 solana confirm -v <TRANSACTION_HASH>
 ```
 

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -47,7 +47,7 @@ quickly get setup.
 To be able to compile Rust based Solana programs, install the Rust language and
 Cargo (the Rust package manager) using [Rustup](https://rustup.rs/):
 
-```bash
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
@@ -58,7 +58,7 @@ The Solana CLI comes with the
 This command line tool will allow you to run a full blockchain cluster on your
 machine.
 
-```bash
+```shell
 solana-test-validator
 ```
 
@@ -71,7 +71,7 @@ localhost validator to remain online and ready for action.
 Configure your Solana CLI to use your localhost validator for all your future
 terminal commands and Solana program deployment:
 
-```bash
+```shell
 solana config set --url localhost
 ```
 
@@ -83,14 +83,14 @@ and saved in the `.so` format.
 
 Initialize a new Rust library named `hello_world` via the Cargo command line:
 
-```bash
+```shell
 cargo init hello_world --lib
 cd hello_world
 ```
 
 Add the `solana-program` crate to your new Rust library:
 
-```bash
+```shell
 cargo add solana-program
 ```
 
@@ -175,7 +175,7 @@ of "_Hello, world!_" to the blockchain cluster, then gracefully exit with
 Inside a terminal window, you can build your Solana Rust program by running in
 the root of your project (i.e. the directory with your `Cargo.toml` file):
 
-```bash
+```shell
 cargo build-bpf
 ```
 
@@ -192,7 +192,7 @@ need to upgrade those tools if you encounter any version incompatibilities.
 Using the Solana CLI, you can deploy your program to your currently selected
 cluster:
 
-```bash
+```shell
 solana program deploy ./target/deploy/hello_world.so
 ```
 
@@ -200,7 +200,7 @@ Once your Solana program has been deployed (and the transaction
 [finalized](https://docs.solana.com/cluster/commitments)), the above command
 will output your program's public address (aka its "program id").
 
-```bash
+```shell
 # example output
 Program Id: EFH95fWg49vkFNbAdw9vy75tM7sWZ2hQbTTUmuACGip3
 ```

--- a/content/guides/getstarted/setup-local-development.md
+++ b/content/guides/getstarted/setup-local-development.md
@@ -78,14 +78,14 @@ First start with
 system. Be sure to restart your computer when installation is done, then
 continue this guide.
 
-```bash
+```shell
 wsl --install
 ```
 
 After installing WSL and restarting your computer, open a new Linux terminal
 session using WSL:
 
-```bash
+```shell
 wsl
 ```
 
@@ -118,7 +118,7 @@ based Solana IDE called [Solana Playground](https://beta.solpg.io).
 
 Install the following dependencies on your Linux system:
 
-```bash
+```shell
 sudo apt-get install -y \
     build-essential \
     pkg-config \
@@ -135,7 +135,7 @@ your Apple ID to download.
 
 You can check if the Xcode CLI is installed via this command:
 
-```bash
+```shell
 xcode-select -p
 ```
 
@@ -145,7 +145,7 @@ If you don't see a path returned, you need to install the CLI tools.
 
 1. Installing via your terminal using the following command:
 
-```bash
+```shell
 xcode-select --install
 ```
 
@@ -179,7 +179,7 @@ Using the following command, we can install and configure the Rust tooling on
 your local system. The following command will automatically download the correct
 binaries needed for your specific operating system:
 
-```bash
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ```
 
@@ -190,7 +190,7 @@ After the installation is complete, restart your terminal or run the following
 command to manually refresh your new `PATH` settings to make the rust tooling
 (like `cargo`) available:
 
-```bash
+```shell
 source ~/.bashrc
 ```
 
@@ -210,7 +210,7 @@ tasks, like:
 
 1.  Install the Solana CLI tool suite using the official install command:
 
-    ```bash
+    ```shell
     sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
     ```
 
@@ -220,7 +220,7 @@ tasks, like:
 3.  Depending on your specific operating system, the Solana CLI installer
     messaging may prompt you to update the `PATH` environment.
 
-    ```bash
+    ```shell
     Please update your PATH environment variable to include the Solana programs:
     ```
 
@@ -232,7 +232,7 @@ tasks, like:
 
 4.  To check if your installation was successful, check the Solana CLI version:
 
-    ```bash
+    ```shell
     solana --version
     ```
 
@@ -262,7 +262,7 @@ We can then use `avm` to install the desired version of the Anchor framework.
 
 #### Install avm
 
-```bash
+```shell
 cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
 ```
 
@@ -270,7 +270,7 @@ cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
 
 To install the `latest` version of anchor using `avm`:
 
-```bash
+```shell
 avm install latest
 avm use latest
 ```
@@ -278,7 +278,7 @@ avm use latest
 After the anchor installation is complete, you can verify anchor was installed
 by checking the installed version:
 
-```bash
+```shell
 anchor --version
 ```
 
@@ -292,7 +292,7 @@ The Solana CLI comes with the
 built-in. This command line tool will allow you to run a full blockchain cluster
 on your machine:
 
-```bash
+```shell
 solana-test-validator
 ```
 
@@ -308,13 +308,13 @@ programs).
 Configure your Solana CLI to use your localhost validator for all your future
 terminal commands:
 
-```bash
+```shell
 solana config set --url localhost
 ```
 
 At any time, you can view your current Solana CLI configuration settings:
 
-```bash
+```shell
 solana config get
 ```
 
@@ -325,7 +325,7 @@ tokens to pay for the cost of transactions and data storage on the blockchain.
 
 Let's create a simple file system wallet to use during local development:
 
-```bash
+```shell
 solana-keygen new
 ```
 
@@ -346,7 +346,7 @@ command will **NOT** override it unless you explicitly force override using the
 With your new file system wallet created, you must tell the Solana CLI to use
 this wallet to deploy and take ownership of your on-chain program:
 
-```bash
+```shell
 solana config set -k ~/.config/solana/id.json
 ```
 
@@ -355,7 +355,7 @@ solana config set -k ~/.config/solana/id.json
 Once your new wallet is set as the default, you can request a free airdrop of
 SOL tokens to it:
 
-```bash
+```shell
 solana airdrop 2
 ```
 
@@ -369,7 +369,7 @@ fails, lower your airdrop request quantity and try again.
 
 You can check your current wallet's SOL balance any time:
 
-```bash
+```shell
 solana balance
 ```
 

--- a/content/guides/getstarted/solana-token-airdrop-and-faucets.md
+++ b/content/guides/getstarted/solana-token-airdrop-and-faucets.md
@@ -31,7 +31,7 @@ Here are three different ways of requesting airdrops with it:
 
 ### Using the Solana CLI:
 
-```bash
+```shell
 solana airdrop 2
 ```
 
@@ -93,14 +93,14 @@ Currently Supported:
 Specify your [Cluster](https://docs.solana.com/clusters) to be your RPC
 provider's URL.
 
-```bash
+```shell
 solana config set --url <your RPC url>
 ```
 
 Then you can request an airdrop like you would in the first option in this
 guide.
 
-```bash
+```shell
 solana airdrop 2
 ```
 
@@ -120,13 +120,13 @@ to your computing power.
 
 **Install the Devnet POW Crate:**
 
-```bash
+```shell
 cargo install devnet-pow
 ```
 
 **Start mining devnet SOL**
 
-```bash
+```shell
 devnet-pow mine
 ```
 
@@ -147,7 +147,7 @@ Various Discord communities have setup devnet SOL Faucets as BOTs.
 The most sustainable way to save SOL is to reuse it. With the Solana CLI you can
 show and close all previous buffer accounts with the following command:
 
-```bash
+```shell
 solana program show --buffers
 ```
 
@@ -163,21 +163,21 @@ Normally, these buffer accounts are closed automatically. In the event they are
 not, you can close them manually to reclaim the SOL in them using the following
 command:
 
-```bash
+```shell
 solana program close <buffer account>
 ```
 
 You can also the `show` subcommand to show all programs you deployed have
 already deployed to your currently selected cluster:
 
-```bash
+```shell
 solana program show --programs
 ```
 
 You can then close each program with the `close` subcommand to close them and
 retrieve the SOL you used to deploy them:
 
-```bash
+```shell
 solana program close <program id>
 ```
 

--- a/content/guides/javascript/compressed-nfts.md
+++ b/content/guides/javascript/compressed-nfts.md
@@ -140,11 +140,11 @@ used to get the types and helper functions for our NFT's metadata
 Using your preferred package manager (e.g. npm, yarn, pnpm, etc), install these
 packages into your project:
 
-```sh
+```shell
 yarn add @solana/web3.js @solana/spl-token @solana/spl-account-compression
 ```
 
-```sh
+```shell
 yarn add @metaplex-foundation/mpl-bubblegum @metaplex-foundation/mpl-token-metadata
 ```
 

--- a/content/guides/token-extensions/getting-started.md
+++ b/content/guides/token-extensions/getting-started.md
@@ -64,7 +64,7 @@ also find the required flags for each below.
 Now that you know what extensions are available, you can create your new token
 with token extensions with the following command:
 
-```bash
+```shell
 spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb \
   create-token <extension flags>
 ```
@@ -73,7 +73,7 @@ With token extensions, you can mix and match based on what you need for your
 project. For example, if you wanted a token with transfer fees and a custom
 metadata, you would just use the following command to combine the extensions:
 
-```bash
+```shell
 spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb \
   create-token --interest-rate 5 --enable-metadata
 ```

--- a/content/guides/token-extensions/transfer-hook.md
+++ b/content/guides/token-extensions/transfer-hook.md
@@ -158,7 +158,7 @@ deployed you can run the test file by using the `test` command in the terminal.
 
 This will then give you the output similar to this:
 
-```bash
+```shell
   transfer-hook.test.ts:
   transfer-hook
     Transaction Signature: kB8Hkn8NEavK7xztEhQZXKSeidgEK81PZNmgSSodZFVyzM9o18GwNi4bDWD9Q3cbmh75Vn1jqyinYH3YdgJfnuJ
@@ -175,7 +175,7 @@ This will then give you the output similar to this:
 If you do not want to use javascript to create your token, you can also use the
 `spl-token` command from the Solana CLI after you deployed your program:
 
-```bash
+```shell
 spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --transfer-hook yourTransferHookProgramId
 ```
 
@@ -315,11 +315,11 @@ test file by typing `test` in the terminal.
 This will then give you the following output. In last transaction you will then
 able to see how often your token has been transferred:
 
-```bash
+```shell
 "This token has been transfered 1 times"
 ```
 
-```bash
+```shell
 Running tests...
   transfer-hook.test.ts:
   transfer-hook

--- a/docs/clients/javascript.md
+++ b/docs/clients/javascript.md
@@ -29,13 +29,13 @@ For the full list of terms, see
 
 #### yarn
 
-```bash
+```shell
 yarn add @solana/web3.js
 ```
 
 #### npm
 
-```bash
+```shell
 npm install --save @solana/web3.js
 ```
 

--- a/docs/core/accounts.md
+++ b/docs/core/accounts.md
@@ -165,8 +165,8 @@ balance of 105,290,880 lamports (=~ 0.105 SOL) to be rent-exempt:
 Rent can also be estimated via the
 [`solana rent` CLI subcommand](https://docs.solanalabs.com/cli/usage#solana-rent)
 
-```text
-$ solana rent 15000
+```shell
+solana rent 15000
 Rent per byte-year: 0.00000348 SOL
 Rent per epoch: 0.000288276 SOL
 Rent-exempt minimum: 0.10529088 SOL

--- a/docs/core/clusters.md
+++ b/docs/core/clusters.md
@@ -58,7 +58,7 @@ drive, as a user, token holder, app developer, or validator.
 
 To connect to the `devnet` Cluster using the Solana CLI:
 
-```bash
+```shell
 solana config set --url https://api.devnet.solana.com
 ```
 
@@ -91,7 +91,7 @@ stability and validator behavior.
 
 To connect to the `testnet` Cluster using the Solana CLI:
 
-```bash
+```shell
 solana config set --url https://api.testnet.solana.com
 ```
 
@@ -120,7 +120,7 @@ token holders.
 
 To connect to the `mainnet-beta` Cluster using the Solana CLI:
 
-```bash
+```shell
 solana config set --url https://api.mainnet-beta.solana.com
 ```
 

--- a/docs/core/runtime.md
+++ b/docs/core/runtime.md
@@ -166,7 +166,7 @@ feature will be activated at the next epoch.
 To determine which features are activated use the
 [Solana command-line tools](https://docs.solanalabs.com/cli/install):
 
-```bash
+```shell
 solana feature status
 ```
 

--- a/docs/core/transactions/fees.md
+++ b/docs/core/transactions/fees.md
@@ -40,7 +40,7 @@ transaction could contain as many as 12 signatures (not sure why you would do
 that). The fee per transaction signature can be fetched with the `solana` cli:
 
 ```shell
-$ solana fees
+solana fees
 Blockhash: 8eULQbYYp67o5tGF2gxACnBCKAE39TetbYYMGTx3iBFc
 Lamports per signature: 5000
 Last valid block height: 94236543
@@ -51,7 +51,7 @@ retrieve the above output information, so your application can call that method
 directly as well:
 
 ```shell
-$ curl http://api.mainnet-beta.solana.com -H "Content-Type: application/json" -d '
+curl http://api.mainnet-beta.solana.com -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getFees"}
 '
 ```

--- a/docs/core/transactions/fees.md
+++ b/docs/core/transactions/fees.md
@@ -39,7 +39,7 @@ max size of transaction itself. Each signature (64 bytes) in a transaction (max
 transaction could contain as many as 12 signatures (not sure why you would do
 that). The fee per transaction signature can be fetched with the `solana` cli:
 
-```bash
+```shell
 $ solana fees
 Blockhash: 8eULQbYYp67o5tGF2gxACnBCKAE39TetbYYMGTx3iBFc
 Lamports per signature: 5000
@@ -50,7 +50,7 @@ The `solana` cli `fees` subcommand calls the `getFees` RPC API method to
 retrieve the above output information, so your application can call that method
 directly as well:
 
-```bash
+```shell
 $ curl http://api.mainnet-beta.solana.com -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getFees"}
 '

--- a/docs/core/transactions/versions.md
+++ b/docs/core/transactions/versions.md
@@ -73,7 +73,7 @@ const getTx = await connection.getTransaction(
 Using a standard JSON formatted POST request, you can set the
 `maxSupportedTransactionVersion` when retrieving a specific block:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d \
 '{"jsonrpc": "2.0", "id":1, "method": "getBlock", "params": [430, {
   "encoding":"json",

--- a/docs/more/exchange.md
+++ b/docs/more/exchange.md
@@ -27,7 +27,7 @@ To run an api node:
 1. [Install the Solana command-line tool suite](https://docs.solanalabs.com/cli/install)
 2. Start the validator with at least the following parameters:
 
-```bash
+```shell
 solana-validator \
   --ledger <LEDGER_PATH> \
   --identity <VALIDATOR_IDENTITY_KEYPAIR> \
@@ -81,7 +81,7 @@ which can monitor your validator and detect with the `solana-validator` process
 is unhealthy. It can directly be configured to alert you via Slack, Telegram,
 Discord, or Twillio. For details, run `solana-watchtower --help`.
 
-```bash
+```shell
 solana-watchtower --validator-identity <YOUR VALIDATOR IDENTITY>
 ```
 
@@ -168,7 +168,7 @@ Solana accounts must be made rent-exempt by containing 2-years worth of
 rent-exempt balance for your deposit accounts, query the
 [`getMinimumBalanceForRentExemption` endpoint](/docs/rpc/http/getMinimumBalanceForRentExemption.mdx):
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
@@ -235,7 +235,7 @@ Solana API node.
   [`getBlocks`](/docs/rpc/http/getBlocks.mdx) request, passing the last block
   you have already processed as the start-slot parameter:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
@@ -276,7 +276,7 @@ By default, fetched blocks will return a lot of transaction info and metadata
 that isn't necessary for tracking account balances. Set the "transactionDetails"
 parameter to speed up block fetching.
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H 'Content-Type: application/json' -d '{
   "jsonrpc": "2.0",
   "id": 1,
@@ -383,7 +383,7 @@ time.
 - Send a [`getSignaturesForAddress`](/docs/rpc/http/getSignaturesForAddress.mdx)
   request to the api node:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
@@ -435,7 +435,7 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 - For each signature returned, get the transaction details by sending a
   [`getTransaction`](/docs/rpc/http/getTransaction.mdx) request:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H 'Content-Type: application/json' -d '{
   "jsonrpc":"2.0",
   "id":1,
@@ -546,7 +546,7 @@ generate, submit, and confirm transfer transactions. By default, this method
 will wait and track progress on stderr until the transaction has been finalized
 by the cluster. If the transaction fails, it will report any transaction errors.
 
-```bash
+```shell
 solana transfer <USER_ADDRESS> <AMOUNT> --allow-unfunded-recipient --keypair <KEYPAIR> --url http://localhost:8899
 ```
 
@@ -571,7 +571,7 @@ finalized by the cluster. Otherwise, you risk a double spend. See more on
 First, get a recent blockhash using the
 [`getFees`](/docs/rpc/deprecated/getFees.mdx) endpoint or the CLI command:
 
-```bash
+```shell
 solana fees --url http://localhost:8899
 ```
 
@@ -579,7 +579,7 @@ In the command-line tool, pass the `--no-wait` argument to send a transfer
 asynchronously, and include your recent blockhash with the `--blockhash`
 argument:
 
-```bash
+```shell
 solana transfer <USER_ADDRESS> <AMOUNT> --no-wait --allow-unfunded-recipient --blockhash <RECENT_BLOCKHASH> --keypair <KEYPAIR> --url http://localhost:8899
 ```
 
@@ -596,7 +596,7 @@ endpoint. The `confirmations` field reports how many
 transaction was processed. If `confirmations: null`, it is
 [finalized](/docs/terminology.md#finality).
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc":"2.0",
   "id":1,
@@ -750,7 +750,7 @@ holding no data), currently: 0.000890880 SOL
 
 Similarly, every deposit account must contain at least this balance.
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "id": 1,
@@ -953,13 +953,13 @@ line utility. The latest version of `cargo` can be installed using a handy
 one-liner for your platform at [rustup.rs](https://rustup.rs). Once `cargo` is
 installed, `spl-token` can be obtained with the following command:
 
-```bash
+```shell
 cargo install spl-token-cli
 ```
 
 You can then check the installed version to verify
 
-```bash
+```shell
 spl-token --version
 ```
 
@@ -991,13 +991,13 @@ To create an SPL Token account with the following properties:
 1. Associated with the given mint
 1. Owned by the funding account's keypair
 
-```bash
+```shell
 spl-token create-account <TOKEN_MINT_ADDRESS>
 ```
 
 #### Example
 
-```bash
+```shell
 $ spl-token create-account AkUFCWTXb3w9nY2n6SFJvBV6VwvFUCe4KBMCcgLsa2ir
 Creating account 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
 Signature: 4JsqZEPra2eDTHtHpB4FMWSfk3UgcCVmkKkP7zESZeMrKmFFkDkNd91pKP3vPVVZZPiu5XxyJwS73Vi5WsZL88D7
@@ -1005,7 +1005,7 @@ Signature: 4JsqZEPra2eDTHtHpB4FMWSfk3UgcCVmkKkP7zESZeMrKmFFkDkNd91pKP3vPVVZZPiu5
 
 Or to create an SPL Token account with a specific keypair:
 
-```bash
+```shell
 $ solana-keygen new -o token-account.json
 $ spl-token create-account AkUFCWTXb3w9nY2n6SFJvBV6VwvFUCe4KBMCcgLsa2ir token-account.json
 Creating account 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
@@ -1016,13 +1016,13 @@ Signature: 4JsqZEPra2eDTHtHpB4FMWSfk3UgcCVmkKkP7zESZeMrKmFFkDkNd91pKP3vPVVZZPiu5
 
 #### Command Line
 
-```bash
+```shell
 spl-token balance <TOKEN_ACCOUNT_ADDRESS>
 ```
 
 #### Example
 
-```bash
+```shell
 $ solana balance 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
 0
 ```
@@ -1039,13 +1039,13 @@ provided.
 
 #### Command Line
 
-```bash
+```shell
 spl-token transfer <SENDER_ACCOUNT_ADDRESS> <AMOUNT> <RECIPIENT_WALLET_ADDRESS> --fund-recipient
 ```
 
 #### Example
 
-```bash
+```shell
 $ spl-token transfer 6B199xxzw3PkAm25hGJpjj3Wj3WNYNHzDAnt1tEqg5BN 1 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
 Transfer 1 tokens
   Sender: 6B199xxzw3PkAm25hGJpjj3Wj3WNYNHzDAnt1tEqg5BN
@@ -1097,7 +1097,7 @@ SPL Token accounts, funding the withdrawal account will require 0.00203928 SOL
 
 Template `spl-token transfer` command for a withdrawal:
 
-```bash
+```shell
 $ spl-token transfer --fund-recipient <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
@@ -1151,7 +1151,7 @@ they handle tokens.
 
 It is possible to see all extensions on a mint or token account:
 
-```bash
+```shell
 $ spl-token display <account address>
 ```
 
@@ -1166,7 +1166,7 @@ the destination due to the withheld amount.
 It is possible to specify the expected fee during a transfer to avoid any
 surprises:
 
-```bash
+```shell
 $ spl-token transfer --expected-fee <fee amount> --fund-recipient <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
@@ -1180,7 +1180,7 @@ they will no longer be associated to a valid mint.
 
 It is safe to simply close these token accounts:
 
-```bash
+```shell
 $ spl-token close --address <account address>
 ```
 
@@ -1196,13 +1196,13 @@ non-confidentially.
 
 To enable confidential transfers, the account must be configured for it:
 
-```bash
+```shell
 $ spl-token configure-confidential-transfer-account --address <account address>
 ```
 
 And to transfer:
 
-```bash
+```shell
 $ spl-token transfer --confidential <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
@@ -1210,7 +1210,7 @@ During a confidential transfer, the `preTokenBalance` and `postTokenBalance`
 fields will show no change. In order to sweep deposit accounts, you must decrypt
 the new balance to withdraw the tokens:
 
-```bash
+```shell
 $ spl-token apply-pending-balance --address <account address>
 $ spl-token withdraw-confidential-tokens --address <account address> <amount or ALL>
 ```
@@ -1250,7 +1250,7 @@ The CLI and instruction creators such as
 `createTransferCheckedWithTransferHookInstruction` add the extra accounts
 automatically, but the additional accounts may also be specified explicitly:
 
-```bash
+```shell
 $ spl-token transfer --transfer-hook-account <pubkey:role> --transfer-hook-account <pubkey:role> ...
 ```
 
@@ -1262,7 +1262,7 @@ Exchanges may need to prepend a memo instruction before transferring tokens back
 to users, or they may require users to prepend a memo instruction before sending
 to the exchange:
 
-```bash
+```shell
 $ spl-token transfer --with-memo <memo text> <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 

--- a/docs/more/exchange.md
+++ b/docs/more/exchange.md
@@ -998,7 +998,12 @@ spl-token create-account <TOKEN_MINT_ADDRESS>
 #### Example
 
 ```shell
-$ spl-token create-account AkUFCWTXb3w9nY2n6SFJvBV6VwvFUCe4KBMCcgLsa2ir
+spl-token create-account AkUFCWTXb3w9nY2n6SFJvBV6VwvFUCe4KBMCcgLsa2ir
+```
+
+Giving an output similar to:
+
+```
 Creating account 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
 Signature: 4JsqZEPra2eDTHtHpB4FMWSfk3UgcCVmkKkP7zESZeMrKmFFkDkNd91pKP3vPVVZZPiu5XxyJwS73Vi5WsZL88D7
 ```
@@ -1006,8 +1011,14 @@ Signature: 4JsqZEPra2eDTHtHpB4FMWSfk3UgcCVmkKkP7zESZeMrKmFFkDkNd91pKP3vPVVZZPiu5
 Or to create an SPL Token account with a specific keypair:
 
 ```shell
-$ solana-keygen new -o token-account.json
-$ spl-token create-account AkUFCWTXb3w9nY2n6SFJvBV6VwvFUCe4KBMCcgLsa2ir token-account.json
+solana-keygen new -o token-account.json
+
+spl-token create-account AkUFCWTXb3w9nY2n6SFJvBV6VwvFUCe4KBMCcgLsa2ir token-account.json
+```
+
+Giving an output similar to:
+
+```shell
 Creating account 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
 Signature: 4JsqZEPra2eDTHtHpB4FMWSfk3UgcCVmkKkP7zESZeMrKmFFkDkNd91pKP3vPVVZZPiu5XxyJwS73Vi5WsZL88D7
 ```
@@ -1023,7 +1034,12 @@ spl-token balance <TOKEN_ACCOUNT_ADDRESS>
 #### Example
 
 ```shell
-$ solana balance 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
+solana balance 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
+```
+
+Giving an output similar to:
+
+```
 0
 ```
 
@@ -1046,7 +1062,13 @@ spl-token transfer <SENDER_ACCOUNT_ADDRESS> <AMOUNT> <RECIPIENT_WALLET_ADDRESS> 
 #### Example
 
 ```shell
-$ spl-token transfer 6B199xxzw3PkAm25hGJpjj3Wj3WNYNHzDAnt1tEqg5BN 1 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
+spl-token transfer 6B199xxzw3PkAm25hGJpjj3Wj3WNYNHzDAnt1tEqg5BN 1
+```
+
+Giving an output similar to:
+
+```shell
+6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
 Transfer 1 tokens
   Sender: 6B199xxzw3PkAm25hGJpjj3Wj3WNYNHzDAnt1tEqg5BN
   Recipient: 6VzWGL51jLebvnDifvcuEDec17sK6Wupi4gYhm5RzfkV
@@ -1098,7 +1120,7 @@ SPL Token accounts, funding the withdrawal account will require 0.00203928 SOL
 Template `spl-token transfer` command for a withdrawal:
 
 ```shell
-$ spl-token transfer --fund-recipient <exchange token account> <withdrawal amount> <withdrawal address>
+spl-token transfer --fund-recipient <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
 ### Other Considerations
@@ -1152,7 +1174,7 @@ they handle tokens.
 It is possible to see all extensions on a mint or token account:
 
 ```shell
-$ spl-token display <account address>
+spl-token display <account address>
 ```
 
 #### Transfer Fee
@@ -1167,7 +1189,7 @@ It is possible to specify the expected fee during a transfer to avoid any
 surprises:
 
 ```shell
-$ spl-token transfer --expected-fee <fee amount> --fund-recipient <exchange token account> <withdrawal amount> <withdrawal address>
+spl-token transfer --expected-fee <fee amount> --fund-recipient <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
 #### Mint Close Authority
@@ -1181,7 +1203,7 @@ they will no longer be associated to a valid mint.
 It is safe to simply close these token accounts:
 
 ```shell
-$ spl-token close --address <account address>
+spl-token close --address <account address>
 ```
 
 #### Confidential Transfer
@@ -1197,13 +1219,13 @@ non-confidentially.
 To enable confidential transfers, the account must be configured for it:
 
 ```shell
-$ spl-token configure-confidential-transfer-account --address <account address>
+spl-token configure-confidential-transfer-account --address <account address>
 ```
 
 And to transfer:
 
 ```shell
-$ spl-token transfer --confidential <exchange token account> <withdrawal amount> <withdrawal address>
+spl-token transfer --confidential <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
 During a confidential transfer, the `preTokenBalance` and `postTokenBalance`
@@ -1211,8 +1233,8 @@ fields will show no change. In order to sweep deposit accounts, you must decrypt
 the new balance to withdraw the tokens:
 
 ```shell
-$ spl-token apply-pending-balance --address <account address>
-$ spl-token withdraw-confidential-tokens --address <account address> <amount or ALL>
+spl-token apply-pending-balance --address <account address>
+spl-token withdraw-confidential-tokens --address <account address> <amount or ALL>
 ```
 
 #### Default Account State
@@ -1251,7 +1273,7 @@ The CLI and instruction creators such as
 automatically, but the additional accounts may also be specified explicitly:
 
 ```shell
-$ spl-token transfer --transfer-hook-account <pubkey:role> --transfer-hook-account <pubkey:role> ...
+spl-token transfer --transfer-hook-account <pubkey:role> --transfer-hook-account <pubkey:role> ...
 ```
 
 #### Required Memo on Transfer
@@ -1263,7 +1285,7 @@ to users, or they may require users to prepend a memo instruction before sending
 to the exchange:
 
 ```shell
-$ spl-token transfer --with-memo <memo text> <exchange token account> <withdrawal amount> <withdrawal address>
+spl-token transfer --with-memo <memo text> <exchange token account> <withdrawal amount> <withdrawal address>
 ```
 
 ## Testing the Integration

--- a/docs/programs/debugging.md
+++ b/docs/programs/debugging.md
@@ -29,7 +29,7 @@ it is helpful to focus on just the runtime and program logs and not the rest of
 the cluster logs. To focus in on program specific information the following log
 mask is recommended:
 
-```bash
+```shell
 export RUST_LOG=solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=info,solana_bpf_loader=debug,solana_rbpf=debug
 ```
 
@@ -137,7 +137,7 @@ should be three files in that directory
 - helloworld.so -- an executable file loadable into the virtual machine. The
   command line for running `solana-ledger-tool` would be something like this
 
-```bash
+```shell
 solana-ledger-tool program run -l test-ledger -e debugger target/deploy/helloworld.so
 ```
 
@@ -159,7 +159,7 @@ debugging rust programs it may be beneficial to run solana-lldb wrapper to lldb,
 i.e. at a new shell prompt (other than the one used to start
 `solana-ledger-tool`) run the command:
 
-```bash
+```shell
 solana-lldb
 ```
 

--- a/docs/programs/deploying.md
+++ b/docs/programs/deploying.md
@@ -155,7 +155,7 @@ an earlier deploy.
 Developers can check if they own any abandoned buffer accounts by using the
 Solana CLI:
 
-```bash
+```shell
 solana program show --buffers --keypair ~/.config/solana/MY_KEYPAIR.json
 
 Buffer Address                               | Authority                                    | Balance
@@ -165,7 +165,7 @@ Buffer Address                               | Authority                        
 And they can close those buffers to reclaim the SOL balance with the following
 command:
 
-```bash
+```shell
 solana program close --buffers --keypair ~/.config/solana/MY_KEYPAIR.json
 ```
 
@@ -174,7 +174,7 @@ solana program close --buffers --keypair ~/.config/solana/MY_KEYPAIR.json
 The owners of all abandoned program deploy buffer accounts can be fetched via
 the RPC API:
 
-```bash
+```shell
 curl http://api.mainnet-beta.solana.com -H "Content-Type: application/json" \
 --data-binary @- << EOF | jq --raw-output '.result | .[] | .account.data[0]'
 {
@@ -194,7 +194,7 @@ EOF
 After re-encoding the base64 encoded keys into base58 and grouping by key, we
 see some accounts have over 10 buffer accounts they could close, yikes!
 
-```bash
+```shell
 'BE3G2F5jKygsSNbPFKHHTxvKpuFXSumASeGweLcei6G3' => 10 buffer accounts
 'EsQ179Q8ESroBnnmTDmWEV4rZLkRc3yck32PqMxypE5z' => 10 buffer accounts
 '6KXtB89kAgzW7ApFzqhBg5tgnVinzP4NSXVqMAWnXcHs' => 12 buffer accounts
@@ -228,7 +228,7 @@ wrong cluster.
 
 To view the programs which are owned by your wallet address, you can run:
 
-```bash
+```shell
 solana -V # must be 1.7.11 or higher!
 solana program show --programs --keypair ~/.config/solana/MY_KEYPAIR.json
 
@@ -238,7 +238,7 @@ CN5x9WEusU6pNH66G22SnspVx4cogWLqMfmb85Z3GW7N | 53796672  | 2nr1bHFT86W9tGnyvmYW4
 
 To close those program data accounts and reclaim their SOL balance, you can run:
 
-```bash
+```shell
 solana program close --programs --keypair ~/.config/solana/MY_KEYPAIR.json
 ```
 

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -23,7 +23,7 @@ transfer the tokens.
 
 First fetch the latest version of the example code:
 
-```bash
+```shell
 $ git clone https://github.com/solana-labs/break.git
 $ cd break
 ```

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -24,8 +24,8 @@ transfer the tokens.
 First fetch the latest version of the example code:
 
 ```shell
-$ git clone https://github.com/solana-labs/break.git
-$ cd break
+git clone https://github.com/solana-labs/break.git
+cd break
 ```
 
 Next, follow the steps in the git repository's

--- a/docs/programs/faq.md
+++ b/docs/programs/faq.md
@@ -112,7 +112,7 @@ might be mangled if it is a Rust or C++ symbol.
 
 The above warning came from a Rust program, so the demangled symbol name is:
 
-```bash
+```shell
 rustfilt _ZN16curve25519_dalek7edwards21EdwardsBasepointTable6create17h178b3d2411f7f082E
 curve25519_dalek::edwards::EdwardsBasepointTable::create
 ```

--- a/docs/programs/lang-c.md
+++ b/docs/programs/lang-c.md
@@ -181,8 +181,8 @@ instruction and its context.
 To create a dump file:
 
 ```shell
-$ cd <program directory>
-$ make dump_<program name>
+cd <program directory>
+make dump_<program name>
 ```
 
 ## Examples

--- a/docs/programs/lang-c.md
+++ b/docs/programs/lang-c.md
@@ -16,7 +16,7 @@ C projects are laid out as follows:
 
 The `makefile` should contain the following:
 
-```bash
+```shell
 OUT_DIR := <path to place to resulting shared object>
 include ~/.local/share/solana/install/active_release/bin/sdk/sbf/c/sbf.mk
 ```
@@ -34,7 +34,7 @@ First setup the environment:
 
 Then build using make:
 
-```bash
+```shell
 make -C <program directory>
 ```
 
@@ -180,7 +180,7 @@ instruction and its context.
 
 To create a dump file:
 
-```bash
+```shell
 $ cd <program directory>
 $ make dump_<program name>
 ```

--- a/docs/programs/lang-rust.md
+++ b/docs/programs/lang-rust.md
@@ -62,14 +62,14 @@ First setup the environment:
 The normal cargo build is available for building programs against your host
 machine which can be used for unit testing:
 
-```bash
+```shell
 $ cargo build
 ```
 
 To build a specific program, such as SPL Token, for the Solana SBF target which
 can be deployed to the cluster:
 
-```bash
+```shell
 $ cd <the program directory>
 $ cargo build-bpf
 ```
@@ -236,7 +236,7 @@ available. Sometimes a program may depend on a crate that depends itself on
 If a program depends on `rand`, the compilation will fail because there is no
 `get-random` support for Solana. The error will typically look like this:
 
-```bash
+```shell
 error: target is not supported, for more information see: https://docs.rs/getrandom/#unsupported-targets
    --> /Users/jack/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.1.14/src/lib.rs:257:9
     |
@@ -295,7 +295,7 @@ contains a logging example.
 Rust's `panic!`, `assert!`, and internal panic results are printed to the
 [program logs](/docs/programs/debugging.md#logging) by default.
 
-```bash
+```shell
 INFO  solana_runtime::message_processor] Finalized account CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ
 INFO  solana_runtime::message_processor] Call SBF program CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ
 INFO  solana_runtime::message_processor] Program log: Panicked at: 'assertion failed: `(left == right)`
@@ -372,7 +372,7 @@ instruction and its context.
 
 To create a dump file:
 
-```bash
+```shell
 $ cd <program directory>
 $ cargo build-bpf --dump
 ```

--- a/docs/programs/lang-rust.md
+++ b/docs/programs/lang-rust.md
@@ -63,15 +63,15 @@ The normal cargo build is available for building programs against your host
 machine which can be used for unit testing:
 
 ```shell
-$ cargo build
+cargo build
 ```
 
 To build a specific program, such as SPL Token, for the Solana SBF target which
 can be deployed to the cluster:
 
 ```shell
-$ cd <the program directory>
-$ cargo build-bpf
+cd <the program directory>
+cargo build-bpf
 ```
 
 ## How to Test
@@ -373,8 +373,8 @@ instruction and its context.
 To create a dump file:
 
 ```shell
-$ cd <program directory>
-$ cargo build-bpf --dump
+cd <program directory>
+cargo build-bpf --dump
 ```
 
 ## Examples

--- a/docs/programs/limitations.md
+++ b/docs/programs/limitations.md
@@ -58,7 +58,7 @@ The
 tests will report the performance of some math operations. To run the test, sync
 the repo and run:
 
-```sh
+```shell
 cargo test-sbf -- --nocapture --test-threads=1
 ```
 

--- a/docs/rpc/deprecated/getConfirmedBlock.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlock.mdx
@@ -151,7 +151,7 @@ The result field will be an object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/deprecated/getConfirmedBlocks.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlocks.mdx
@@ -49,7 +49,7 @@ block, inclusive. Max range allowed is 500,000 slots.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlocks","params":[5, 10]}
 '

--- a/docs/rpc/deprecated/getConfirmedBlocksWithLimit.mdx
+++ b/docs/rpc/deprecated/getConfirmedBlocksWithLimit.mdx
@@ -52,7 +52,7 @@ starting at `start_slot` for up to `limit` blocks, inclusive.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/deprecated/getConfirmedSignaturesForAddress2.mdx
+++ b/docs/rpc/deprecated/getConfirmedSignaturesForAddress2.mdx
@@ -82,7 +82,7 @@ fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/deprecated/getConfirmedTransaction.mdx
+++ b/docs/rpc/deprecated/getConfirmedTransaction.mdx
@@ -107,7 +107,7 @@ Encoding format for Account data
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/deprecated/getFeeCalculatorForBlockhash.mdx
+++ b/docs/rpc/deprecated/getFeeCalculatorForBlockhash.mdx
@@ -58,7 +58,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/deprecated/getFeeRateGovernor.mdx
+++ b/docs/rpc/deprecated/getFeeRateGovernor.mdx
@@ -40,7 +40,7 @@ with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getFeeRateGovernor"}
 '

--- a/docs/rpc/deprecated/getFees.mdx
+++ b/docs/rpc/deprecated/getFees.mdx
@@ -59,7 +59,7 @@ with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   { "jsonrpc":"2.0", "id": 1, "method":"getFees"}
 '

--- a/docs/rpc/deprecated/getRecentBlockhash.mdx
+++ b/docs/rpc/deprecated/getRecentBlockhash.mdx
@@ -55,7 +55,7 @@ FeeCalculator JSON object.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}
 '

--- a/docs/rpc/deprecated/getSnapshotSlot.mdx
+++ b/docs/rpc/deprecated/getSnapshotSlot.mdx
@@ -32,7 +32,7 @@ Returns the highest slot that the node has a snapshot for
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getSnapshotSlot"}
 '

--- a/docs/rpc/http/getAccountInfo.mdx
+++ b/docs/rpc/http/getAccountInfo.mdx
@@ -98,7 +98,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getBalance.mdx
+++ b/docs/rpc/http/getBalance.mdx
@@ -47,7 +47,7 @@ balance
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getBlock.mdx
+++ b/docs/rpc/http/getBlock.mdx
@@ -204,7 +204,7 @@ The result field will be an object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0","id":1,

--- a/docs/rpc/http/getBlockCommitment.mdx
+++ b/docs/rpc/http/getBlockCommitment.mdx
@@ -35,7 +35,7 @@ The result field will be a JSON object containing:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getBlockHeight.mdx
+++ b/docs/rpc/http/getBlockHeight.mdx
@@ -41,7 +41,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0","id":1,

--- a/docs/rpc/http/getBlockProduction.mdx
+++ b/docs/rpc/http/getBlockProduction.mdx
@@ -61,7 +61,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getBlockProduction"}
 '

--- a/docs/rpc/http/getBlockTime.mdx
+++ b/docs/rpc/http/getBlockTime.mdx
@@ -36,7 +36,7 @@ Returns the estimated production time of a block.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,

--- a/docs/rpc/http/getBlocks.mdx
+++ b/docs/rpc/http/getBlocks.mdx
@@ -53,7 +53,7 @@ block, inclusive. Max range allowed is 500,000 slots.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getBlocksWithLimit.mdx
+++ b/docs/rpc/http/getBlocksWithLimit.mdx
@@ -52,7 +52,7 @@ starting at `start_slot` for up to `limit` blocks, inclusive.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getClusterNodes.mdx
+++ b/docs/rpc/http/getClusterNodes.mdx
@@ -38,7 +38,7 @@ fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getEpochInfo.mdx
+++ b/docs/rpc/http/getEpochInfo.mdx
@@ -49,7 +49,7 @@ The result field will be an object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}
 '

--- a/docs/rpc/http/getEpochSchedule.mdx
+++ b/docs/rpc/http/getEpochSchedule.mdx
@@ -35,7 +35,7 @@ The result field will be an object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0","id":1,

--- a/docs/rpc/http/getFeeForMessage.mdx
+++ b/docs/rpc/http/getFeeForMessage.mdx
@@ -50,7 +50,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
 {
   "id":1,

--- a/docs/rpc/http/getFirstAvailableBlock.mdx
+++ b/docs/rpc/http/getFirstAvailableBlock.mdx
@@ -26,7 +26,7 @@ ledger
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0","id":1,

--- a/docs/rpc/http/getGenesisHash.mdx
+++ b/docs/rpc/http/getGenesisHash.mdx
@@ -25,7 +25,7 @@ Returns the genesis hash
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getGenesisHash"}
 '

--- a/docs/rpc/http/getHealth.mdx
+++ b/docs/rpc/http/getHealth.mdx
@@ -30,7 +30,7 @@ of the error response are **UNSTABLE** and may change in the future
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getHealth"}
 '

--- a/docs/rpc/http/getHighestSnapshotSlot.mdx
+++ b/docs/rpc/http/getHighestSnapshotSlot.mdx
@@ -40,7 +40,7 @@ fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1,"method":"getHighestSnapshotSlot"}
 '

--- a/docs/rpc/http/getIdentity.mdx
+++ b/docs/rpc/http/getIdentity.mdx
@@ -28,7 +28,7 @@ The result field will be a JSON object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getIdentity"}
 '

--- a/docs/rpc/http/getInflationGovernor.mdx
+++ b/docs/rpc/http/getInflationGovernor.mdx
@@ -45,7 +45,7 @@ The result field will be a JSON object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getInflationGovernor"}
 '

--- a/docs/rpc/http/getInflationRate.mdx
+++ b/docs/rpc/http/getInflationRate.mdx
@@ -31,7 +31,7 @@ The result field will be a JSON object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getInflationRate"}
 '

--- a/docs/rpc/http/getInflationReward.mdx
+++ b/docs/rpc/http/getInflationReward.mdx
@@ -57,7 +57,7 @@ The result field will be a JSON array with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getLargestAccounts.mdx
+++ b/docs/rpc/http/getLargestAccounts.mdx
@@ -48,7 +48,7 @@ The result will be an RpcResponse JSON object with `value` equal to an array of
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getLargestAccounts"}
 '

--- a/docs/rpc/http/getLatestBlockhash.mdx
+++ b/docs/rpc/http/getLatestBlockhash.mdx
@@ -54,7 +54,7 @@ object including:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "id":1,

--- a/docs/rpc/http/getLeaderSchedule.mdx
+++ b/docs/rpc/http/getLeaderSchedule.mdx
@@ -56,7 +56,7 @@ Returns a result with one of the two following values:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getMaxRetransmitSlot.mdx
+++ b/docs/rpc/http/getMaxRetransmitSlot.mdx
@@ -26,7 +26,7 @@ Get the max slot seen from retransmit stage.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getMaxRetransmitSlot"}
 '

--- a/docs/rpc/http/getMaxShredInsertSlot.mdx
+++ b/docs/rpc/http/getMaxShredInsertSlot.mdx
@@ -26,7 +26,7 @@ Get the max slot seen from after shred insert.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getMaxShredInsertSlot"}
 '

--- a/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
+++ b/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
@@ -42,7 +42,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getMultipleAccounts.mdx
+++ b/docs/rpc/http/getMultipleAccounts.mdx
@@ -101,7 +101,7 @@ The result will be a JSON object with `value` equal to an array of:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getProgramAccounts.mdx
+++ b/docs/rpc/http/getProgramAccounts.mdx
@@ -128,7 +128,7 @@ The resultant response array will contain:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getRecentPerformanceSamples.mdx
+++ b/docs/rpc/http/getRecentPerformanceSamples.mdx
@@ -47,7 +47,7 @@ An array of `RpcPerfSample<object>` with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,

--- a/docs/rpc/http/getRecentPrioritizationFees.mdx
+++ b/docs/rpc/http/getRecentPrioritizationFees.mdx
@@ -46,7 +46,7 @@ An array of `RpcPrioritizationFee<object>` with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,

--- a/docs/rpc/http/getSignatureStatuses.mdx
+++ b/docs/rpc/http/getSignatureStatuses.mdx
@@ -67,7 +67,7 @@ An array of `RpcResponse<object>` consisting of either:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getSignaturesForAddress.mdx
+++ b/docs/rpc/http/getSignaturesForAddress.mdx
@@ -78,7 +78,7 @@ containing transaction signature information with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getSlot.mdx
+++ b/docs/rpc/http/getSlot.mdx
@@ -42,7 +42,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getSlot"}
 '

--- a/docs/rpc/http/getSlotLeader.mdx
+++ b/docs/rpc/http/getSlotLeader.mdx
@@ -41,7 +41,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getSlotLeader"}
 '

--- a/docs/rpc/http/getSlotLeaders.mdx
+++ b/docs/rpc/http/getSlotLeaders.mdx
@@ -36,7 +36,7 @@ strings
 If the current slot is `#99` - query the next `10` leaders with the following
 request:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id": 1,

--- a/docs/rpc/http/getStakeActivation.mdx
+++ b/docs/rpc/http/getStakeActivation.mdx
@@ -56,7 +56,7 @@ The result will be a JSON object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getStakeMinimumDelegation.mdx
+++ b/docs/rpc/http/getStakeMinimumDelegation.mdx
@@ -39,7 +39,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc":"2.0", "id":1,

--- a/docs/rpc/http/getSupply.mdx
+++ b/docs/rpc/http/getSupply.mdx
@@ -49,7 +49,7 @@ object containing:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0", "id":1, "method":"getSupply"}
 '

--- a/docs/rpc/http/getTokenAccountBalance.mdx
+++ b/docs/rpc/http/getTokenAccountBalance.mdx
@@ -54,7 +54,7 @@ from [getBlock](/docs/rpc/http/getblock) follows a similar structure.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getTokenAccountsByDelegate.mdx
+++ b/docs/rpc/http/getTokenAccountsByDelegate.mdx
@@ -114,7 +114,7 @@ can be expected inside the structure, both for the `tokenAmount` and the
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -114,7 +114,7 @@ can be expected inside the structure, both for the `tokenAmount` and the
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/getTokenLargestAccounts.mdx
+++ b/docs/rpc/http/getTokenLargestAccounts.mdx
@@ -51,7 +51,7 @@ JSON objects containing:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getTokenSupply.mdx
+++ b/docs/rpc/http/getTokenSupply.mdx
@@ -50,7 +50,7 @@ object containing:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/getTransaction.mdx
+++ b/docs/rpc/http/getTransaction.mdx
@@ -74,8 +74,8 @@ Encoding for the returned Transaction
 - `<object>` - if transaction is confirmed, an object with the following fields:
   - `slot: <u64>` - the slot this transaction was processed in
   - `transaction: <object|[string,encoding]>` -
-    [Transaction](/docs/rpc/json-structures.mdx#transactions) object, either in
-    JSON format or encoded binary data, depending on encoding parameter
+    [Transaction](/docs/rpc/json-structures#transactions) object, either in JSON
+    format or encoded binary data, depending on encoding parameter
   - `blockTime: <i64|null>` - estimated production time, as Unix timestamp
     (seconds since the Unix epoch) of when the transaction was processed. null
     if not available
@@ -150,11 +150,8 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
     "id": 1,
     "method": "getTransaction",
     "params": [
-      "3KBcrX7iE4qoNT5YprRQG9b5d8opEKgrZfxL5BipM3U5b1YnFQ8An5DM1Zy524YEARJUu13YVfFeEDBXSqYeVUxy",
-      {
-        "encoding": "json",
-        "maxSupportedTransactionVersion": 0
-      }
+      "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv",
+      "json"
     ]
   }
 '
@@ -164,63 +161,52 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 
 ```json
 {
-  "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "blockTime": 1711126026,
     "meta": {
-      "computeUnitsConsumed": 150,
       "err": null,
-      "fee": 10000,
+      "fee": 5000,
       "innerInstructions": [],
-      "loadedAddresses": {
-        "readonly": [],
-        "writable": []
-      },
-      "logMessages": [
-        "Program 11111111111111111111111111111111 invoke [1]",
-        "Program 11111111111111111111111111111111 success"
-      ],
-      "postBalances": [1717948251816, 890880, 1],
+      "postBalances": [499998932500, 26858640, 1, 1, 1],
       "postTokenBalances": [],
-      "preBalances": [1717949152696, 0, 1],
+      "preBalances": [499998937500, 26858640, 1, 1, 1],
       "preTokenBalances": [],
       "rewards": [],
       "status": {
         "Ok": null
       }
     },
-    "slot": 287082980,
+    "slot": 430,
     "transaction": {
       "message": {
         "accountKeys": [
-          "nick6zJc6HpW3kfBm4xS2dmbuVRyb5F3AnUvj5ymzR5",
-          "oWpo1diVUgUNaMeTug2EoicPdMUKT6KDx6gLUyQdEzm",
-          "11111111111111111111111111111111"
+          "3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe",
+          "AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc",
+          "SysvarS1otHashes111111111111111111111111111",
+          "SysvarC1ock11111111111111111111111111111111",
+          "Vote111111111111111111111111111111111111111"
         ],
-        "addressTableLookups": [],
         "header": {
           "numReadonlySignedAccounts": 0,
-          "numReadonlyUnsignedAccounts": 1,
-          "numRequiredSignatures": 2
+          "numReadonlyUnsignedAccounts": 3,
+          "numRequiredSignatures": 1
         },
         "instructions": [
           {
-            "accounts": [0, 1],
-            "data": "111112GJ1Cfr4Mnah1YBPDnXiJiZF6iLU2WSRn5rMNc3q9NWxpaodgPyGFJ8gzafyzCqqR",
-            "programIdIndex": 2,
-            "stackHeight": null
+            "accounts": [1, 2, 3, 0],
+            "data": "37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1",
+            "programIdIndex": 4
           }
         ],
-        "recentBlockhash": "4V1LHXEMBXu84rdw8ZTagSQz8qErJGW7YCquddWNvK2S"
+        "recentBlockhash": "mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"
       },
       "signatures": [
-        "3KBcrX7iE4qoNT5YprRQG9b5d8opEKgrZfxL5BipM3U5b1YnFQ8An5DM1Zy524YEARJUu13YVfFeEDBXSqYeVUxy",
-        "G1kfkcb2nhUybtsa9NHXgLvowMDDwN8zvtZCM13KWCtfhPnrEm6xcM7Dsi9vYM38bFppLzNuEbYhv7JymLxWz6F"
+        "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"
       ]
-    },
-    "version": 0
-  }
+    }
+  },
+  "blockTime": null,
+  "id": 1
 }
 ```
 

--- a/docs/rpc/http/getTransaction.mdx
+++ b/docs/rpc/http/getTransaction.mdx
@@ -74,8 +74,8 @@ Encoding for the returned Transaction
 - `<object>` - if transaction is confirmed, an object with the following fields:
   - `slot: <u64>` - the slot this transaction was processed in
   - `transaction: <object|[string,encoding]>` -
-    [Transaction](/docs/rpc/json-structures#transactions) object, either in JSON
-    format or encoded binary data, depending on encoding parameter
+    [Transaction](/docs/rpc/json-structures.mdx#transactions) object, either in
+    JSON format or encoded binary data, depending on encoding parameter
   - `blockTime: <i64|null>` - estimated production time, as Unix timestamp
     (seconds since the Unix epoch) of when the transaction was processed. null
     if not available
@@ -143,15 +143,18 @@ Encoding for the returned Transaction
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
     "id": 1,
     "method": "getTransaction",
     "params": [
-      "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv",
-      "json"
+      "3KBcrX7iE4qoNT5YprRQG9b5d8opEKgrZfxL5BipM3U5b1YnFQ8An5DM1Zy524YEARJUu13YVfFeEDBXSqYeVUxy",
+      {
+        "encoding": "json",
+        "maxSupportedTransactionVersion": 0
+      }
     ]
   }
 '
@@ -161,52 +164,63 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 
 ```json
 {
+  "id": 1,
   "jsonrpc": "2.0",
   "result": {
+    "blockTime": 1711126026,
     "meta": {
+      "computeUnitsConsumed": 150,
       "err": null,
-      "fee": 5000,
+      "fee": 10000,
       "innerInstructions": [],
-      "postBalances": [499998932500, 26858640, 1, 1, 1],
+      "loadedAddresses": {
+        "readonly": [],
+        "writable": []
+      },
+      "logMessages": [
+        "Program 11111111111111111111111111111111 invoke [1]",
+        "Program 11111111111111111111111111111111 success"
+      ],
+      "postBalances": [1717948251816, 890880, 1],
       "postTokenBalances": [],
-      "preBalances": [499998937500, 26858640, 1, 1, 1],
+      "preBalances": [1717949152696, 0, 1],
       "preTokenBalances": [],
       "rewards": [],
       "status": {
         "Ok": null
       }
     },
-    "slot": 430,
+    "slot": 287082980,
     "transaction": {
       "message": {
         "accountKeys": [
-          "3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe",
-          "AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc",
-          "SysvarS1otHashes111111111111111111111111111",
-          "SysvarC1ock11111111111111111111111111111111",
-          "Vote111111111111111111111111111111111111111"
+          "nick6zJc6HpW3kfBm4xS2dmbuVRyb5F3AnUvj5ymzR5",
+          "oWpo1diVUgUNaMeTug2EoicPdMUKT6KDx6gLUyQdEzm",
+          "11111111111111111111111111111111"
         ],
+        "addressTableLookups": [],
         "header": {
           "numReadonlySignedAccounts": 0,
-          "numReadonlyUnsignedAccounts": 3,
-          "numRequiredSignatures": 1
+          "numReadonlyUnsignedAccounts": 1,
+          "numRequiredSignatures": 2
         },
         "instructions": [
           {
-            "accounts": [1, 2, 3, 0],
-            "data": "37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1",
-            "programIdIndex": 4
+            "accounts": [0, 1],
+            "data": "111112GJ1Cfr4Mnah1YBPDnXiJiZF6iLU2WSRn5rMNc3q9NWxpaodgPyGFJ8gzafyzCqqR",
+            "programIdIndex": 2,
+            "stackHeight": null
           }
         ],
-        "recentBlockhash": "mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"
+        "recentBlockhash": "4V1LHXEMBXu84rdw8ZTagSQz8qErJGW7YCquddWNvK2S"
       },
       "signatures": [
-        "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"
+        "3KBcrX7iE4qoNT5YprRQG9b5d8opEKgrZfxL5BipM3U5b1YnFQ8An5DM1Zy524YEARJUu13YVfFeEDBXSqYeVUxy",
+        "G1kfkcb2nhUybtsa9NHXgLvowMDDwN8zvtZCM13KWCtfhPnrEm6xcM7Dsi9vYM38bFppLzNuEbYhv7JymLxWz6F"
       ]
-    }
-  },
-  "blockTime": null,
-  "id": 1
+    },
+    "version": 0
+  }
 }
 ```
 

--- a/docs/rpc/http/getTransactionCount.mdx
+++ b/docs/rpc/http/getTransactionCount.mdx
@@ -41,7 +41,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getTransactionCount"}
 '

--- a/docs/rpc/http/getVersion.mdx
+++ b/docs/rpc/http/getVersion.mdx
@@ -30,7 +30,7 @@ The result field will be a JSON object with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getVersion"}
 '

--- a/docs/rpc/http/getVoteAccounts.mdx
+++ b/docs/rpc/http/getVoteAccounts.mdx
@@ -68,7 +68,7 @@ each containing an array of JSON objects with the following sub fields:
 
 Restrict results to a single validator vote account:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/index.mdx
+++ b/docs/rpc/http/index.mdx
@@ -35,7 +35,7 @@ fields:
 
 Example using curl:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",
@@ -63,7 +63,7 @@ as the data for a single POST.
 The commitment parameter should be included as the last element in the `params`
 array:
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/isBlockhashValid.mdx
+++ b/docs/rpc/http/isBlockhashValid.mdx
@@ -51,7 +51,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "id":45,

--- a/docs/rpc/http/minimumLedgerSlot.mdx
+++ b/docs/rpc/http/minimumLedgerSlot.mdx
@@ -31,7 +31,7 @@ Returns the lowest slot that the node has information about in its ledger.
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"minimumLedgerSlot"}
 '

--- a/docs/rpc/http/requestAirdrop.mdx
+++ b/docs/rpc/http/requestAirdrop.mdx
@@ -45,7 +45,7 @@ Configuration object containing the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0", "id": 1,

--- a/docs/rpc/http/sendTransaction.mdx
+++ b/docs/rpc/http/sendTransaction.mdx
@@ -99,7 +99,7 @@ encoded string ([transaction id](/docs/terminology.md#transaction-id))
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/http/simulateTransaction.mdx
+++ b/docs/rpc/http/simulateTransaction.mdx
@@ -149,7 +149,7 @@ with the following fields:
 
 ### Code sample
 
-```bash
+```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '
   {
     "jsonrpc": "2.0",

--- a/docs/rpc/websocket/slotsUpdatesSubscribe.mdx
+++ b/docs/rpc/websocket/slotsUpdatesSubscribe.mdx
@@ -70,7 +70,7 @@ The notification will be an object with the following fields:
   - "optimisticConfirmation"
   - "root"
 
-```bash
+```shell
 {
   "jsonrpc": "2.0",
   "method": "slotsUpdatesNotification",


### PR DESCRIPTION
### Problem

some code block languages are inconsistent and may use some that do not result in correct syntax highlighting

### Summary of Changes

- be more consistent with `shell` style code blocks for better syntax highlighting
- remove code block lines that start with `$`