### PR TITLE
[api] href parser for content records

### DIFF
--- a/src/utils/navItem.ts
+++ b/src/utils/navItem.ts
@@ -286,7 +286,7 @@ export function computeDetailsFromSlug(slug: string[]) {
   let href = slug
     .join("/")
     .toLowerCase()
-    .replaceAll(/\/index(.mdx?)?/gi, "")
+    .replaceAll(/(\/?index)?(.mdx?)?$/gi, "")
     .trim();
 
   if (group == "docs") {


### PR DESCRIPTION
### Problem

when getting for content records from the api, it does not correctly parse the route for href finding

### Summary of Changes

fixed it
