### PR TITLE
refactor: removed manual sort order

### DIFF
--- a/docs/rpc/http/getBalance.mdx
+++ b/docs/rpc/http/getBalance.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: getBalance
 title: getBalance RPC Method
-sidebarSortOrder: 10
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/getBalance

--- a/docs/rpc/http/getLatestBlockhash.mdx
+++ b/docs/rpc/http/getLatestBlockhash.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: getLatestBlockhash
 title: getLatestBlockhash RPC Method
-sidebarSortOrder: 0
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/getLatestBlockhash

--- a/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
+++ b/docs/rpc/http/getMinimumBalanceForRentExemption.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: getMinimumBalanceForRentExemption
 title: getMinimumBalanceForRentExemption RPC Method
-sidebarSortOrder: 0
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/getMinimumBalanceForRentExemption

--- a/docs/rpc/http/getProgramAccounts.mdx
+++ b/docs/rpc/http/getProgramAccounts.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: getProgramAccounts
 title: getProgramAccounts RPC Method
-sidebarSortOrder: 10
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/getProgramAccounts

--- a/docs/rpc/http/getSignaturesForAddress.mdx
+++ b/docs/rpc/http/getSignaturesForAddress.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: getSignaturesForAddress
 title: getSignaturesForAddress RPC Method
-sidebarSortOrder: 10
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/getSignaturesForAddress

--- a/docs/rpc/http/getTransaction.mdx
+++ b/docs/rpc/http/getTransaction.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: getTransaction
 title: getTransaction RPC Method
-sidebarSortOrder: 10
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/getTransaction

--- a/docs/rpc/http/sendTransaction.mdx
+++ b/docs/rpc/http/sendTransaction.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: sendTransaction
 title: sendTransaction RPC Method
-sidebarSortOrder: 0
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/sendTransaction

--- a/docs/rpc/http/simulateTransaction.mdx
+++ b/docs/rpc/http/simulateTransaction.mdx
@@ -1,7 +1,6 @@
 ---
 sidebarLabel: simulateTransaction
 title: simulateTransaction RPC Method
-sidebarSortOrder: 0
 hideTableOfContents: true
 altRoutes:
   - /docs/rpc/simulateTransaction


### PR DESCRIPTION
### Problem

The RPC section of the docs do not fully sort alphabetically since they are assigned a manual sort order

### Summary of Changes

removed the sort order to have them sort alphabetically
