### PR TITLE
[i18n] remove i18n prefixes on `record._raw`

### DIFF
--- a/src/app/api/content/[...slug]/route.ts
+++ b/src/app/api/content/[...slug]/route.ts
@@ -5,7 +5,7 @@
 
 import { notFound } from "next/navigation";
 import type { BreadcrumbItem, NavItem, SupportedDocTypes } from "@/types";
-import { DEFAULT_LOCALE_EN } from "@/utils/constants";
+import { DEFAULT_LOCALE_EN, I18N_LOCALE_REGEX } from "@/utils/constants";
 import {
   generateFlatNavItemListing,
   generateNavItemListing,
@@ -144,6 +144,14 @@ export function GET(_req: Request, { params: { slug } }: RouteProps) {
     // @ts-ignore
     record.body = record.body.raw.trim();
   }
+
+  // remove the i18n prefixes
+  record._raw = {
+    ...record._raw,
+    sourceFilePath: record._raw.sourceFilePath.replace(I18N_LOCALE_REGEX, ""),
+    sourceFileDir: record._raw.sourceFileDir.replace(I18N_LOCALE_REGEX, ""),
+    flattenedPath: record._raw.flattenedPath.replace(I18N_LOCALE_REGEX, ""),
+  };
 
   // todo: preprocess the body content? (if desired in the future)
 


### PR DESCRIPTION
### Problem

the "edit on github" buttons on locale specific pages use an invalid link due to contentlayer including the i18n locale prefix in `_raw.sourceFilePath` 

### Summary of Changes

strip out the i18n prefix from the `record._raw` attributes since all github files are only in the base language of english (and therefore do not have this prefix)