### PR TITLE
Fix typo in block.rewards.rewardType literals - Capitalize

### DIFF
--- a/docs/rpc/http/getBlock.mdx
+++ b/docs/rpc/http/getBlock.mdx
@@ -190,8 +190,8 @@ The result field will be an object with the following fields:
       account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was
       applied
-    - `rewardType: <string|undefined>` - type of reward: "fee", "rent",
-      "voting", "staking"
+    - `rewardType: <string|undefined>` - type of reward: "Fee", "Rent",
+      "Voting", "Staking"
     - `commission: <u8|undefined>` - vote account commission when the reward was
       credited, only present for voting and staking rewards
   - `blockTime: <i64|null>` - estimated production time, as Unix timestamp


### PR DESCRIPTION
### Problem
The documentation page for [GetBlock](url) endpoint shows potential `rewardType` to be one of:
> "fee", "rent", "voting", "staking"

These are not capitalized.

However, querying the endpoint on block `257199412` with the following HTTP body:
```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "getBlock",
    "params": [
        257199412,
        {
            "encoding": "json",
            "maxSupportedTransactionVersion": 0,
            "transactionDetails": "none",
            "rewards": true
        }
    ]
}
```

Returns:

```json
{
    "jsonrpc": "2.0",
    "result": {
        "blockHeight": 237611155,
        "blockTime": 1711735787,
        "blockhash": "B1Y7EQCzGxR9SdWEDYBNEZ3rGNDzm474bCmNCKCHUXfq",
        "parentSlot": 257199411,
        "previousBlockhash": "8rQyMomtZUgeEtmgfXXd6HAmf6Yfw7dCyfdqdmPHeSKb",
        "rewards": [
            {
                "commission": null,
                "lamports": 31619653,
                "postBalance": 3194164089961,
                "pubkey": "q9XWcZ7T1wP4bW9SB4XgNNwjnFEJ982nE8aVbbNuwot",
                "rewardType": "Fee"
            }
        ]
    },
    "id": 1
}
```

Note the capitalization of `"Fee"` in the response. This can cause confusion for developper parsing the response with non-loose parsers.

### Summary of Changes

I simply capitalized the described `rewardType` literals in the docs.
