### PR TITLE
fix: removed nested quote block

### DIFF
--- a/docs/core/clusters.md
+++ b/docs/core/clusters.md
@@ -17,8 +17,8 @@ The Solana Labs organization operates a public RPC endpoint for each Cluster.
 Each of these public endpoints are subject to rate limits, but are available for
 users and developers to interact with the Solana blockchain.
 
-> > Note: Public endpoint rate limits are subject to change. The specific rate
-> > limits listed on this document are not guaranteed to be the most up-to-date.
+> Note: Public endpoint rate limits are subject to change. The specific rate
+> limits listed on this document are not guaranteed to be the most up-to-date.
 
 ### Using explorers with different Clusters
 


### PR DESCRIPTION
### Problem

With the new markdown processor on solana.com, nested quote blocks result in nested Callouts.

### Summary of Changes

removed the nesting
