### PR TITLE
fix: clarify quic tpu port for peering

### DIFF
--- a/content/guides/advanced/stake-weighted-qos.md
+++ b/content/guides/advanced/stake-weighted-qos.md
@@ -138,10 +138,11 @@ split proportionally based on the lamport amounts specified in the
 
 On the RPC you will have to use `--rpc-send-transaction-tpu-peer` to forward
 transactions to a specific leader. The exact usage would be
-`--rpc-send-transaction-tpu-peer HOST:PORT`.   The Host is the ip address of the
+`--rpc-send-transaction-tpu-peer HOST:PORT`. The Host is the ip address of the
 leader you have the `staked-nodes-overrides` enabled on and the Port is the QUIC
-TPU port of that host.  The QUIC TPU port number is the lowest value of your `--dynamic-port-range`
-plus 9. For example, if the flag is `--dynamic-port-range 8000-8100`, the QUIC TPU port is `8009`.
+TPU port of that host. The QUIC TPU port number is the lowest value of your
+`--dynamic-port-range` plus 9. For example, if the flag is
+`--dynamic-port-range 8000-8100`, the QUIC TPU port is `8009`.
 
 The peering would looking like the following:
 

--- a/content/guides/advanced/stake-weighted-qos.md
+++ b/content/guides/advanced/stake-weighted-qos.md
@@ -138,9 +138,12 @@ split proportionally based on the lamport amounts specified in the
 
 On the RPC you will have to use `--rpc-send-transaction-tpu-peer` to forward
 transactions to a specific leader. The exact usage would be
-`--rpc-send-transaction-tpu-peer HOST:PORT`, with the Host being of the leader
-you have the `staked-nodes-overrides` enabled on. The peering would looking like
-the following:
+`--rpc-send-transaction-tpu-peer HOST:PORT`.   The Host is the ip address of the
+leader you have the `staked-nodes-overrides` enabled on and the Port is the QUIC
+TPU port of that host.  The QUIC TPU port number is the lowest value of your `--dynamic-port-range`
+plus 9. For example, if the flag is `--dynamic-port-range 8000-8100`, the QUIC TPU port is `8009`.
+
+The peering would looking like the following:
 
 ![Diagram of RPCs peering with Validator for Stake-weighted Qos](/assets/guides/stake-weighted-qos-guide/peered-RPCs-guide.png)
 


### PR DESCRIPTION
### Problem
The stake weighted QoS guide is not clear on the PORT number that should be used by the RPC node when specifying `--rpc-send-transaction-tpu-peer`


### Summary of Changes
Adds a few sentences to clarify how to identify the quic tpu port number based on the dynamic port range.

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->