### PR TITLE
Fixes: Typo in inflation_schedule.md 

### DIFF
--- a/docs/economics/inflation/inflation_schedule.md
+++ b/docs/economics/inflation/inflation_schedule.md
@@ -60,7 +60,7 @@ inflation starting from that day).
 
 Setting aside validator uptime and commissions, the expected Staking Yield and
 Adjusted Staking Yield metrics are then primarily a function of the % of total
-SOL staked on the network. Therefore we can we can model _Staking Yield_, if we
+SOL staked on the network. Therefore we can model _Staking Yield_, if we
 introduce an additional parameter _% of Staked SOL_:
 
 <!-- $$


### PR DESCRIPTION
### Problem

Typo in inflation schedule document

### Summary of Changes

Fix typo in inflation schedule document

Fixes #
remove duplicate "we can"

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->