### PR TITLE
Fix link's relative path

### DIFF
--- a/content/guides/getstarted/full-stack-solana-development.md
+++ b/content/guides/getstarted/full-stack-solana-development.md
@@ -963,7 +963,7 @@ Let's give them a front-end to do that.
 #### Program deploy failed?
 
 Program code is temporarily stored in
-[buffer accounts](docs/programs/deploying#state-accounts) while programs are
+[buffer accounts](/docs/programs/deploying#state-accounts) while programs are
 being deployed. You can view and close these accounts with:
 
 ```shell


### PR DESCRIPTION
### Problem
The buffer accounts link on [this page](https://solana.com/developers/guides/getstarted/full-stack-solana-development) points to `docs/programs/deploying#state-accounts` instead of `/docs/programs/deploying#state-accounts` which results in a [404 page](https://solana.com/developers/guides/getstarted/docs/programs/deploying#state-accounts) on the solana.com website.


### Summary of Changes
Fix this specific link to be relative to root.