### PR TITLE
Use getSimulationComputeUnits() from helpers library

### DIFF
--- a/content/guides/advanced/how-to-request-optimal-compute.md
+++ b/content/guides/advanced/how-to-request-optimal-compute.md
@@ -26,7 +26,7 @@ For precise control over your transaction's computational resources, use the
 instruction allocates a specific number of compute units for your transaction,
 ensuring you only pay for what you need.
 
-```javascript
+```typescript
 // import { ComputeBudgetProgram } from "@solana/web3.js"
 
 const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({
@@ -39,65 +39,67 @@ transaction. How do we come up with the number to use?
 
 The
 [simulateTransaction RPC method](https://solana.com/docs/rpc/http/simulatetransaction)
-will return the estimated compute units consumed given a transaction. Using this
-RPC method, you can calculate the compute units, set the compute units in your
-new transaction, and send it for an optimal result.
+will return the estimated compute units consumed given a transaction.
 
-An example function to get the compute units from a simulation looks as follows:
+The
+[Solana helpers npm package](https://www.npmjs.com/package/@solana-developers/helpers)
+includes
+[`getSimulationComputeUnits`](https://github.com/solana-developers/helpers?tab=readme-ov-file#get-simulated-compute-units-cus-for-transaction-instructions),
+a small function that uses `simulateTransaction` to calculate the compute units.
+You can then set the compute units in your new transaction, and send the new
+transaction for an optimal result.
 
-```javascript
-// import { ... } from "@solana/web3.js"
-
-async function getSimulationUnits(
-  connection: Connection,
-  instructions: TransactionInstruction[],
-  payer: PublicKey,
-  lookupTables: AddressLookupTableAccount[]
-): Promise<number | undefined> {
-  const testInstructions = [
-    ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
-    ...instructions,
-  ];
-
-  const testVersionedTxn = new VersionedTransaction(
-    new TransactionMessage({
-      instructions: testInstructions,
-      payerKey: payer,
-      recentBlockhash: PublicKey.default.toString(),
-    }).compileToV0Message(lookupTables)
-  );
-
-  const simulation = await connection.simulateTransaction(testVersionedTxn, {
-    replaceRecentBlockhash: true,
-    sigVerify: false,
-  });
-  if (simulation.value.err) {
-    return undefined;
-  }
-  return simulation.value.unitsConsumed;
-}
+```
+npm i @solana-developers/helpers
 ```
 
-Using this `getSimulationUnits` function above, you can build an optimal
-transaction that use an appropriate amount of compute units for what the
-transaction consumes:
+The syntax is simply:
 
-```javascript
+```typescript
+getSimulationComputeUnits(
+  connection: Connection,
+  instructions: Array<TransactionInstruction>,
+  payer: PublicKey,
+  lookupTables: Array<AddressLookupTableAccount>
+);
+```
+
+For example:
+
+```typescript
+const units = await getSimulationComputeUnits(
+  connection,
+  transactions,
+  payer.publicKey,
+);
+```
+
+Using `getSimulationComputeUnits`, you can build an optimal transaction that use
+an appropriate amount of compute units for what the transaction consumes:
+
+```typescript
 // import { ... } from "@solana/web3.js"
 
 async function buildOptimalTransaction(
   connection: Connection,
-  instructions: TransactionInstruction[],
+  instructions: Array<TransactionInstruction>,
   signer: Signer,
-  lookupTables: AddressLookupTableAccount[]
+  lookupTables: Array<AddressLookupTableAccount>,
 ) {
   const [microLamports, units, recentBlockhash] = await Promise.all([
     100 /* Get optimal priority fees - https://solana.com/developers/guides/advanced/how-to-use-priority-fees*/,
-    getSimulationUnits(connection, instructions, signer.publicKey, lookupTables),
+    getSimulationComputeUnits(
+      connection,
+      instructions,
+      signer.publicKey,
+      lookupTables,
+    ),
     connection.getLatestBlockhash(),
   ]);
 
-  instructions.unshift(ComputeBudgetProgram.setComputeUnitPrice({ microLamports }));
+  instructions.unshift(
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
+  );
   if (units) {
     // probably should add some margin of error to units
     instructions.unshift(ComputeBudgetProgram.setComputeUnitLimit({ units }));
@@ -108,7 +110,7 @@ async function buildOptimalTransaction(
         instructions,
         recentBlockhash: recentBlockhash.blockhash,
         payerKey: signer.publicKey,
-      }).compileToV0Message(lookupTables)
+      }).compileToV0Message(lookupTables),
     ),
     recentBlockhash,
   };


### PR DESCRIPTION
### Summary of Changes

 - Use getSimulationComputeUnits() from helpers library. This is the same code, but has unit tests, we can publish updates if we need fixing, users don't need to maintain their own copy, etc.
 - Change language for syntax highlighting to TS - existing code was using JS for code with types.
 - Tweak wording slightly to emphasize using the function rather than the RPC method the function calls.
 - Run prettier