### PR TITLE
[docs] versioned transaction example

### DIFF
--- a/docs/core/transactions/versions.md
+++ b/docs/core/transactions/versions.md
@@ -182,7 +182,7 @@ console.log(`https://explorer.solana.com/tx/${txId}?cluster=devnet`);
 - using
   [Versioned Transactions for Address Lookup Tables](/docs/advanced/lookup-tables.md#how-to-create-an-address-lookup-table)
 - view an
-  [example of a v0 transaction](https://explorer.solana.com/tx/3jpoANiFeVGisWRY5UP648xRXs3iQasCHABPWRWnoEjeA93nc79WrnGgpgazjq4K9m8g2NJoyKoWBV1Kx5VmtwHQ/?cluster=devnet)
+  [example of a v0 transaction](https://explorer.solana.com/tx/h9WQsqSUYhFvrbJWKFPaXximJpLf6Z568NW1j6PBn3f7GPzQXe9PYMYbmWSUFHwgnUmycDNbEX9cr6WjUWkUFKx/?cluster=devnet)
   on Solana Explorer
 - read the
   [accepted proposal](https://docs.solanalabs.com/proposals/versioned-transactions)


### PR DESCRIPTION
### Problem

In 'docs/core/transactions/versions.md' clicked "view an example of a v0 transaction on Solana Explorer" which under the More Resources shows Not Found

### Summary of Changes

updated link to use versioned transaction that shows on the explorer

Fixes #151 

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->