### PR TITLE
[docs] fix: broken links

### DIFF
--- a/docs/advanced/confirmation.md
+++ b/docs/advanced/confirmation.md
@@ -5,6 +5,8 @@ seoTitle: "Transaction Confirmation & Expiration"
 description:
   "Understand how Solana transaction confirmation and when a transaction expires
   (including recent blockhash checks)."
+altRoutes:
+  - /docs/core/transactions/confirmation
 ---
 
 Problems relating to

--- a/docs/advanced/versions.md
+++ b/docs/advanced/versions.md
@@ -5,6 +5,8 @@ description:
   enabling additional functionality in the Solana runtime, address lookup
   tables, and more."
 sidebarSortOrder: 1
+altRoutes:
+  - /docs/core/transactions/versions
 ---
 
 Versioned Transactions are the new transaction format that allow for additional

--- a/docs/core/fees.md
+++ b/docs/core/fees.md
@@ -18,6 +18,7 @@ altRoutes:
   - /docs/core/runtime
   - /docs/intro/transaction_fees
   - /docs/intro/transaction-fees
+  - /docs/core/transactions/fees
 ---
 
 The small fees paid to process [instructions](/docs/terminology.md#instruction)


### PR DESCRIPTION
### Problem

With the recent PR to update many docs pages, a few were deleted or relocated. We missed a few redirects.

### Summary of Changes

added the missing redirects