### PR TITLE
token-extensions: Add @solana/spl-memo usage to transfer memo

### DIFF
--- a/content/guides/token-extensions/required-memo.md
+++ b/content/guides/token-extensions/required-memo.md
@@ -61,8 +61,8 @@ run the starter code.
 
 ## Add Dependencies
 
-Let's start by setting up our script. We'll be using the `@solana/web3.js` and
-`@solana/spl-token` libraries.
+Let's start by setting up our script. We'll be using the `@solana/web3.js`,
+`@solana/spl-token`, and `@solana/spl-memo` libraries.
 
 Replace the starter code with the following:
 
@@ -90,6 +90,7 @@ import {
   mintTo,
   createTransferInstruction,
 } from "@solana/spl-token";
+import { createMemoInstruction } from "@solana/spl-memo";
 
 // Playground wallet
 const payer = pg.wallet.keypair;
@@ -305,6 +306,16 @@ const memoInstruction = new TransactionInstruction({
   data: Buffer.from(message, "utf-8"),
   programId: new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
 });
+```
+
+Alternatively, you can create the instruction using the `@solana/spl-memo`
+library:
+
+```javascript
+// Message for the memo
+const message = "Hello, Solana";
+// Instruction to add memo
+const memoInstruction = createMemoInstruction(message, [payer.publicKey]);
 ```
 
 ## Attempt Transfer without Memo


### PR DESCRIPTION
### Problem

As pointed out at https://github.com/solana-labs/solana-program-library/issues/6655#issuecomment-2085980581, there's no information about the `@solana/spl-memo` library in the token-extensions docs.

### Summary of Changes

Also include an example of creating the memo instruction using `@solana/spl-memo`.

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->