### PR TITLE
Add prose, JS/TS & Rust guidelines used by Unboxed and prof-education

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "znck.grammarly"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    "recommendations": [
-        "znck.grammarly"
-    ]
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,42 +20,6 @@ transparent as possible, whether it's:
   a different repo)
 - content translations are supported via Crowdin
 
-## Content guidelines
-
-Since the content within this repo is meant to be publicly displayed on
-`solana.com`, we have very specific guidelines for the content that can be
-merged into this repo (and eventually displayed on solana.com). If you would
-like to submit changes to existing content or add new content, all of these
-guidelines should be observed:
-
-### Avoid official recommendations
-
-Avoid any language around making "official recommendations" such as "I recommend
-product X" or "Product Y is the best". The content within this repo will be
-publicly published on solana.com which is maintained by the
-[Solana Foundation](https://solana.org). As such, any "product recommendations"
-may appear as if coming directly from the Solana Foundation. The Solana
-Foundation does not make official recommendations for products but rather helps
-share what options are available in the broader Solana ecosystem.
-
-### Avoid "picking favorites"
-
-Avoid language similar to "service X is my favorite". When talking about or
-naming specific products within the Solana ecosystem, writers and maintainers
-should make their best attempt to list multiple options that meet similar use
-cases. As a general rule of thumb, try to share at least 3-4 options of similar
-products or services, not just a single named one. For example, when talking
-about wallet providers, a writer could list Phantom, Solflare, Backpack, and
-Ultimate. When talking about RPC providers, a writer should link to
-[solana.com/rpc](https://solana.com/rpc) instead of listing specific names.
-
-### Use up-to-date code snippets
-
-Write content that uses up-to-date code. Code bases change, functions get
-deprecated, and methods get removed. When submitting code snippets within the
-content here, use the most up-to-date code available for the given functionality
-being used. Especially net new content, like adding a new guide.
-
 ## Style guidelines
 
 To aid in keeping both consistent content and a high-quality experience, all
@@ -65,16 +29,131 @@ forth here.
 Failure to adhere to these style guidelines will slow down the review process
 and block approval/merging.
 
-### Prettier
+### Prose
 
-This repo uses prettier to help maintain the quality and consistency of the
-content within. There is a master
-[prettier configuration file](https://github.com/solana-foundation/developer-content/blob/main/.prettierrc)
-(`.prettierrc`) in the root of this repo.
+The guidelines below are consistent with Solana Foundation Style (if you work at
+Solana Foundation, see Notion), and
+[TERMINOLOGY](https://github.com/solana-foundation/developer-content/blob/main/docs/terminology.md),
+to ensure consistency with other content on solana.com. There are also a few
+additional items aimed at technical documents.
+
+In particular:
+
+- Please run a grammar check (not just a spell check) before creating a PR -
+  this will catch many of the small errors that occur from your editing process,
+  and save the person reviewing your PR some time. We recommend
+  [Grammarly](https://grammarly.com/). If you use VScode, there's also a
+  [Grammarly Extension for VScode](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
+  In [your Grammarly dictionary](https://account.grammarly.com/customize), you
+  may wish to add Solana-specific words like `lamport`, `blockhash`, etc.
+- Use US English rather than British English. Grammarly will catch this for you.
+- Use 'onchain' (not on-chain, definitely not smart contract) when referring to
+  onchain apps. This comes from the Solana Foundation style guide, and is
+  intended to be similar to 'online'.
+- Use sentence case for headlines (”Solana Foundation announces new initiative”
+  instead of “Solana Foundation Announces New Initiative”). This also comes from
+  the Solana Foundation style guide.
+- Use the terms 'blockchain' or 'web3' rather than 'crypto'.
+- Use 'SOL' rather than 'Sol' to refer to Solana's native token. Don't call the
+  native token 'Solana'!
+- Use 'secret key' rather than 'private key' to be consistent with web3.js.
+  **Note**: this will change in a future version of web3.js, but right now the
+  ecosystem uses 'secret key'.
+- Use 'wallet app' for software. 'wallet' for the address that holds value, to
+  avoid confusion between these two concepts.
+- PDAs are not public keys. It is not possible to have a public key without a
+  secret key. A public key is derived from a secret key, and it is not possible
+  to generate a public key without first generating a secret key.
+- Be careful about the term 'token account'. A
+  ['token account' is any account formatted to hold tokens](https://solana.stackexchange.com/questions/7507/what-is-the-difference-between-a-token-account-and-an-associated-token-account),
+  and being specific (rather than, for example, swapping between 'associated
+  token account' and 'token account') makes this clearer.
+  - Use the specific term 'associated token account' rather than just 'token
+    account' if you're referring to an account at an associated token address.
+  - Use 'token mint account' to refer to the address where a token is minted.
+    E.g., the
+    [USDC mainnet token mint account](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
+    Use apostrophes of possession,
+    [including for inanimate objects](https://english.stackexchange.com/questions/1031/is-using-the-possessive-s-correct-in-the-cars-antenna).
+    Eg 'the account's balance' is correct.
+- Don't use 'here' links. They make the course hard to scan and
+  ['here' links are bad for SEO](https://www.smashingmagazine.com/2012/06/links-should-never-say-click-here/).
+- JS/TS clients send `transactions` made from `instructions`. Onchain programs
+  have `instruction handlers` that process `instructions`. Do not refer to
+  [instruction handlers](https://solana.com/docs/terminology#instruction-handler)
+  as instructions! The reason is simple: an instruction cannot process an
+  instruction. The `multiple` template in Anchor also calls the functions
+  `handler`.
+
+Finally, run Grammarly over your PRs. While your spelling might be fine,
+Grammarly will often catch dangling words and consistencies over your prose. You
+don't have to change everything Grammarly asks, but checking your document will
+save other people time. For VScode users, there is a
+[VScode extension for Grammarly](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
+
+### Code
+
+You're writing code to be read, understood, and changed by others.
+
+We want the minimal amount of code necessary to solve the problem.
+
+- Use full names. Call a `thing` a `thing`. Don't call it a `thg` - this means
+  we don't have to say 'thing, spelled tee aitch gee' every time we talk about
+  it, and means students (who often don't speak English as a first language)
+  have to work out that 'thg' means 'thing'.
+- Avoid repetitive, copy-paste code. This helps others change the code easily,
+  as they can update and fix things in a single place. If there's some
+  boilerplate, Solana-specific code you always need
+  [make a PR to the 'helpers' repository](https://github.com/solana-developers/helpers).
+- Avoid magic numbers. Nobody should see a `+ 32` in your code and wonder what
+  the `32` means. See Anchor notes below for Anchor-specific advice.
+- Avoid asking students to clone a git repo. The idea is that students should be
+  able to create projects from scratch when they have finished the course.
+  Referring to the code students have made in previous chapters is fine.
+
+#### JS/TS
+
+We're trying to focus on Solana, not teaching JS/TS development and setup. This
+means reducing the JS/TS concepts needed to understand our demo code.
+
+- `.ts` files are run with `esrun`, which supports top-level `await`, doesn't
+  require a `tsconfig.json`, etc. There is no need for `async function main()`
+  wrappers or [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE).
+  `await` just works. If you see these wrappers, remove them.
+
+- Likewise, use `async`/`await` and consistently use `try` / `catch` all the
+  time, rather than sometimes using `.then()` and `.catch()`
+
+- Throw errors with `throw new Error('message')`. Don't throw strings (JS allows
+  almost any type to be thrown). TS code can assume anything thrown is of the
+  `Error` type.
+
+- Don't make custom helper functions. Instead, use the
+  `@solana-developers/helpers` package. If you need a function that doesn't
+  exist, make a PR to `@solana-developers/helpers`, and add the helper, tests,
+  and docs.
+
+- Write tests so we can run your code and ensure a new release of something
+  doesn't break your code. Ensure your tests make sense. BDD style (which Anchor
+  uses by default) uses `describe` and `it` to create the names. So
+  `describe('the plus operator', () => {}` becomes `describe the plus operation`
+  when the tests run, and `it('adds numbers', () => {...})` becomes
+  `it adds numbers` when the tests run. Ensure your test names make sense!
+
+- Use prettier to help maintain the quality and consistency of the content.
+  There is a master
+  [prettier configuration file](https://github.com/solana-foundation/developer-content/blob/main/.prettierrc)
+  (`.prettierrc`) at the root of this repo. Note that while `prettier` can
+  format Markdown,
+  [prettier doesn't yet support language-specific settings inside Markdown files](https://github.com/prettier/prettier/issues/5378)
+  so you'll need to format the code yourself for now. To do this quickly, make a
+  blank `deleteme.ts` file, paste your code in there, and then save it (allowing
+  prettier to do its work), and paste it back into the document.
 
 On all commits and PRs, there is a GitHub action that checks if your PR follows
-the master prettier formatting. If your branch/code does NOT meet the prettier
-formatting requirements, it will not be merged and it will delay its review.
+the configured prettier formatting. If your branch/code does NOT meet the
+prettier formatting requirements, it will not be merged and it will delay its
+review.
 
 If your editor is not configured to auto-format on save using prettier, then you
 can run the following command to auto-format all files in your local repo/PR:
@@ -89,6 +168,31 @@ prettier formatting guidelines.
 ```shell
 yarn prettier
 ```
+
+#### Rust & Anchor
+
+- Avoid magic numbers. People reading your code should be able to understand
+  where values come from. Use
+  [InitSpace](https://docs.rs/anchor-lang/latest/anchor_lang/derive.InitSpace.html)
+  to calculate space needed for accounts, and add a constant
+  `DISCRIMINATOR_SIZE` to `constants.rs`.
+
+  - Bad: `8 + 32 + 32 + 8 + 8`
+
+  - Good: `space = DISCRIMINATOR_SIZE + SomeAccount::INIT_SPACE`
+
+- Use `rustfmt`.
+
+- Use `UncheckedAccount` rather than `AccountInfo`. `UncheckedAccount` is a much
+  better name, and makes it explicit that the account is not being checked by
+  Anchor.
+
+- Don't manually ask people to edit `declare_id!()` and `Anchor.toml`. Instead,
+  ask them to run `anchor keys sync`.
+
+- Use the
+  [multiple files template](https://www.anchor-lang.com/docs/release-notes#multiple-files-template)
+  to organize very large Anchor projects.
 
 ### Heading styles
 
@@ -146,6 +250,43 @@ of contents.
 The exact text within the heading will be rendered as a line item in the table
 of contents. As such, thought should be put into the text within a heading,
 especially for accessibility.
+
+## Content guidelines
+
+Since the content within this repo is meant to be publicly displayed on
+`solana.com`, we have very specific guidelines for the content that can be
+merged into this repo (and eventually displayed on solana.com).
+
+If you would like to submit changes to existing content or add new content, all
+of these guidelines should be observed:
+
+### Avoid official recommendations
+
+Avoid any language around making "official recommendations" such as "I recommend
+product X" or "Product Y is the best". The content within this repo will be
+publicly published on solana.com which is maintained by the
+[Solana Foundation](https://solana.org). As such, any "product recommendations"
+may appear as if coming directly from the Solana Foundation. The Solana
+Foundation does not make official recommendations for products but rather helps
+share what options are available in the broader Solana ecosystem.
+
+### Avoid "picking favorites"
+
+Avoid language similar to "service X is my favorite". When talking about or
+naming specific products within the Solana ecosystem, writers and maintainers
+should make their best attempt to list multiple options that meet similar use
+cases. As a general rule of thumb, try to share at least 3-4 options of similar
+products or services, not just a single named one. For example, when talking
+about wallet providers, a writer could list Phantom, Solflare, Backpack, and
+Ultimate. When talking about RPC providers, a writer should link to
+[solana.com/rpc](https://solana.com/rpc) instead of listing specific names.
+
+### Use up-to-date code snippets
+
+Write content that uses up-to-date code. Code bases change, functions get
+deprecated, and methods get removed. When submitting code snippets within the
+content here, use the most up-to-date code available for the given functionality
+being used. Especially net new content, like adding a new guide.
 
 ## Content types
 
@@ -676,7 +817,7 @@ Or
 <Embed url="https://www.youtube.com/watch?v=eudSSvyZF9o" />
 ```
 
-#### Whimsical diagram
+#### Whimsical diagrams
 
 To embed a Whimsical diagram:
 
@@ -686,7 +827,16 @@ To embed a Whimsical diagram:
 
 > Note: The preferred way to display a Whimsical diagram is to export the
 > diagram as an SVG and directly [embed the image](#images) within a specific
-> piece of content.
+> piece of content. You can get an SVG export from Whimsical by appending `/svg`
+> to the end of a Whimsical URL.
+
+- If you draw Solana elliptic curves, these are
+  [Edwards curves](https://en.wikipedia.org/wiki/Edwards_curve). This is
+  [what the curve Ed25519 uses looks like](https://www.wolframalpha.com/input?i=x%5E2+%2B+y%5E2+%3D+1+-+%28121665%2F121666%29*x%5E2*y%5E2).
+  Solana public keys are the Y values on this curve (we can omit the X value
+  because the curve is symmatrical). Ed25519 is symmetrical, and looks like a
+  slightly deflated beach ball. **Do not draw a snake or some other kind or
+  curve!**
 
 ## Translations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,7 @@ and block approval/merging.
 
 ### Prose
 
-The guidelines below are consistent with Solana Foundation Style (if you work at
-Solana Foundation, see Notion), and
+The guidelines below are consistent with Solana Foundation Style Guide, and
 [TERMINOLOGY](https://github.com/solana-foundation/developer-content/blob/main/docs/terminology.md),
 to ensure consistency with other content on solana.com. There are also a few
 additional items aimed at technical documents.
@@ -44,7 +43,9 @@ In particular:
   and save the person reviewing your PR some time. We recommend
   [Grammarly](https://grammarly.com/). In
   [your Grammarly dictionary](https://account.grammarly.com/customize), you may
-  wish to add Solana-specific words like `lamport`, `blockhash`, etc.
+  wish to add Solana-specific words like `lamport`, `blockhash`, etc. For VScode
+  users, there is a
+  [VScode extension for Grammarly](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
 - Use US English rather than British English. Grammarly will catch this for you.
 - Use 'onchain' (not on-chain, definitely not smart contract) when referring to
   onchain apps. This comes from the Solana Foundation style guide, and is
@@ -84,12 +85,6 @@ In particular:
   instruction. The `multiple` template in Anchor also calls the functions
   `handler`.
 
-Finally, run Grammarly over your PRs. While your spelling might be fine,
-Grammarly will often catch dangling words and consistencies over your prose. You
-don't have to change everything Grammarly asks, but checking your document will
-save other people time. For VScode users, there is a
-[VScode extension for Grammarly](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
-
 ### Code
 
 You're writing code to be read, understood, and changed by others.
@@ -98,7 +93,7 @@ We want the minimal amount of code necessary to solve the problem.
 
 - Use full names. Call a `thing` a `thing`. Don't call it a `thg` - this means
   we don't have to say 'thing, spelled tee aitch gee' every time we talk about
-  it, and means students (who often don't speak English as a first language)
+  it, and means developers (who often don't speak English as a first language)
   have to work out that 'thg' means 'thing'.
 - Avoid repetitive, copy-paste code. This helps others change the code easily,
   as they can update and fix things in a single place. If there's some
@@ -106,9 +101,6 @@ We want the minimal amount of code necessary to solve the problem.
   [make a PR to the 'helpers' repository](https://github.com/solana-developers/helpers).
 - Avoid magic numbers. Nobody should see a `+ 32` in your code and wonder what
   the `32` means. See Anchor notes below for Anchor-specific advice.
-- Avoid asking students to clone a git repo. The idea is that students should be
-  able to create projects from scratch when they have finished the course.
-  Referring to the code students have made in previous chapters is fine.
 
 #### JS/TS
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,11 @@ We want the minimal amount of code necessary to solve the problem.
 We're trying to focus on Solana, not teaching JS/TS development and setup. This
 means reducing the JS/TS concepts needed to understand our demo code.
 
-- On the command line (not in the browser),`.ts` files are run on the command line with `esrun`, which supports top-level `await`, doesn't require a `tsconfig.json`, etc. There is no need for `async function main()` wrappers or [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE). `await` just works. If you see these wrappers, remove them.
+- On the command line (not in the browser),`.ts` files are run on the command
+  line with `esrun`, which supports top-level `await`, doesn't require a
+  `tsconfig.json`, etc. There is no need for `async function main()` wrappers or
+  [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE). `await` just
+  works. If you see these wrappers, remove them.
 
 - Likewise, use `async`/`await` and consistently use `try` / `catch` all the
   time, rather than sometimes using `.then()` and `.catch()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,9 @@ In particular:
 - Please run a grammar check (not just a spell check) before creating a PR -
   this will catch many of the small errors that occur from your editing process,
   and save the person reviewing your PR some time. We recommend
-  [Grammarly](https://grammarly.com/). If you use VScode, there's also a
-  [Grammarly Extension for VScode](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
-  In [your Grammarly dictionary](https://account.grammarly.com/customize), you
-  may wish to add Solana-specific words like `lamport`, `blockhash`, etc.
+  [Grammarly](https://grammarly.com/). In
+  [your Grammarly dictionary](https://account.grammarly.com/customize), you may
+  wish to add Solana-specific words like `lamport`, `blockhash`, etc.
 - Use US English rather than British English. Grammarly will catch this for you.
 - Use 'onchain' (not on-chain, definitely not smart contract) when referring to
   onchain apps. This comes from the Solana Foundation style guide, and is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,10 +115,7 @@ We want the minimal amount of code necessary to solve the problem.
 We're trying to focus on Solana, not teaching JS/TS development and setup. This
 means reducing the JS/TS concepts needed to understand our demo code.
 
-- `.ts` files are run with `esrun`, which supports top-level `await`, doesn't
-  require a `tsconfig.json`, etc. There is no need for `async function main()`
-  wrappers or [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE).
-  `await` just works. If you see these wrappers, remove them.
+- On the command line (not in the browser),`.ts` files are run on the command line with `esrun`, which supports top-level `await`, doesn't require a `tsconfig.json`, etc. There is no need for `async function main()` wrappers or [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE). `await` just works. If you see these wrappers, remove them.
 
 - Likewise, use `async`/`await` and consistently use `try` / `catch` all the
   time, rather than sometimes using `.then()` and `.catch()`


### PR DESCRIPTION
There's an existing [CONTRIBUTING.md](https://github.com/Unboxed-Software/solana-course/blob/main/CONTRIBUTING.md) used by the Unboxed Course, created by James and I, and used for both the Unboxed Course and Professional Education programs. Per Slack, ideally we could delete 90% of it and just refer to the one in this repo, with some added bits.