### PR TITLE
[docs] typos in documentation

### DIFF
--- a/content/guides/dapps/journal.md
+++ b/content/guides/dapps/journal.md
@@ -224,7 +224,7 @@ With Anchor, a PDA is initialized with the `seeds`, `bumps`, and
 much space needs to be allocated for that data.
 
 Note: By using the `InitSpace` macro in the `JournalEntryState`, we are able to
-calcualte space by using the `INIT_SPACE` constant and adding `8` to the space
+calculate space by using the `INIT_SPACE` constant and adding `8` to the space
 constraint for Anchor's internal discriminator.
 
 ### Updating a journal entry

--- a/content/guides/token-extensions/reallocate.md
+++ b/content/guides/token-extensions/reallocate.md
@@ -184,7 +184,7 @@ const transaction = new Transaction().add(
   enableRequiredMemoTransfersInstruction,
 );
 
-// Send Transactoin
+// Send Transaction
 transactionSignature = await sendAndConfirmTransaction(
   connection,
   transaction,

--- a/content/guides/token-extensions/transfer-hook.md
+++ b/content/guides/token-extensions/transfer-hook.md
@@ -316,7 +316,7 @@ This will then give you the following output. In last transaction you will then
 able to see how often your token has been transferred:
 
 ```shell
-"This token has been transfered 1 times"
+"This token has been transferred 1 times"
 ```
 
 ```shell


### PR DESCRIPTION
### Problem

I've found some typos in the documentation.


### Summary of Changes

- change `calcualte` to `calculate`
- change `Transactoin` to `Transaction`
- change `transfered` to `transferred`
