### PR TITLE
[docs] deploying programs to point to hello world and local setup

### DIFF
--- a/docs/clients/rust.md
+++ b/docs/clients/rust.md
@@ -4,13 +4,27 @@ title: Rust Client for Solana
 sidebarSortOrder: 1
 ---
 
-Solana's Rust crates are [published to crates.io][crates.io] and can be found
-[on docs.rs with the "solana-" prefix][docs.rs].
+Solana's Rust crates are [published to
+crates.io][crates.io](https://crates.io/search?q=solana-)] and can be found
+[on docs.rs with the "solana-" prefix](https://docs.rs/releases/search?query=solana-).
 
-[crates.io]: https://crates.io/search?q=solana-
-[docs.rs]: https://docs.rs/releases/search?query=solana-
+<Callout title="Hello World: Get started with Rust development on Solana">
 
-Some important crates:
+To quickly get started with Solana development and build your first Rust
+program, take a look at these detailed quick start guides:
+
+- [Build and deploy your first Solana program](/content/guides/getstarted/hello-world-in-your-browser.md)
+  with only your browser
+- Full guide on
+  [how to setup your local environment](/content/guides/getstarted/setup-local-development.md)
+- [Setup, build, and deploy a Solana program locally in Rust](/content/guides/getstarted/local-rust-hello-world.md)
+
+</Callout>
+
+## Rust Crates
+
+The following are the most important and commonly used Rust crates for Solana
+development:
 
 - [`solana-program`] &mdash; Imported by programs running on Solana, compiled to
   SBF. This crate contains many fundamental data types and is re-exported from

--- a/docs/programs/index.md
+++ b/docs/programs/index.md
@@ -1,11 +1,24 @@
 ---
-title: Developing on-chain programs
+title: Developing On-chain Programs
 sidebarLabel: Developing Programs
 ---
 
 Developers can write and deploy their own programs to the Solana blockchain.
 While developing these "on-chain" programs can seem cumbersome, the entire
 process can be broadly summarized into a few key steps.
+
+<Callout type="success" title="Hello World: Get started with Solana development">
+
+To quickly get started with Solana development and build your first program,
+take a look at these detailed quick start guides:
+
+- [Build and deploy your first Solana program](/content/guides/getstarted/hello-world-in-your-browser.md)
+  with only your browser
+- Full guide on
+  [how to setup your local environment](/content/guides/getstarted/setup-local-development.md)
+- [Setup, build, and deploy a Solana program locally in Rust](/content/guides/getstarted/local-rust-hello-world.md)
+
+</Callout>
 
 ## On-chain program development lifecycle
 

--- a/docs/programs/lang-rust.md
+++ b/docs/programs/lang-rust.md
@@ -5,6 +5,19 @@ title: "Developing with Rust"
 Solana supports writing on-chain programs using the
 [Rust](https://www.rust-lang.org/) programming language.
 
+<Callout type="success" title="Hello World: Get started with Rust development">
+
+To quickly get started with Rust development on Solana and build your first
+program, take a look at these detailed quick start guides:
+
+- [Build and deploy your first Solana program](/content/guides/getstarted/hello-world-in-your-browser.md)
+  with only your browser
+- Full guide on
+  [how to setup your local environment](/content/guides/getstarted/setup-local-development.md)
+- [Setup, build, and deploy a Solana program locally in Rust](/content/guides/getstarted/local-rust-hello-world.md)
+
+</Callout>
+
 ## Project Layout
 
 Solana Rust programs follow the typical


### PR DESCRIPTION
### Problem

The [Deploying Programs](https://solana.com/docs/programs#1-setup-your-development-environment) doc gives no clear link to the very applicable getting started guides to help get a person started

### Summary of Changes

- added hello world callouts on the deploying programs, rust client, and rust lang docs

Fixes #206 

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->