### PR TITLE
Fix response of getTokenAccountBalance.mdx

### DIFF
--- a/docs/rpc/http/getTokenAccountBalance.mdx
+++ b/docs/rpc/http/getTokenAccountBalance.mdx
@@ -79,10 +79,10 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
       "amount": "9864",
       "decimals": 2,
       "uiAmount": 98.64,
-      "uiAmountString": "98.64"
-    },
-    "id": 1
-  }
+      "uiAmountString": "98.64"0
+    }
+  },
+  "id": 1
 }
 ```
 

--- a/docs/rpc/http/getTokenAccountBalance.mdx
+++ b/docs/rpc/http/getTokenAccountBalance.mdx
@@ -79,7 +79,7 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
       "amount": "9864",
       "decimals": 2,
       "uiAmount": 98.64,
-      "uiAmountString": "98.64"0
+      "uiAmountString": "98.64"
     }
   },
   "id": 1


### PR DESCRIPTION
### Problem
A small mistake in the response structure of getTokenAccountBalance endpoint in Solana docs.

Fixes #
```id``` field is moved to the root object.
