### PR TITLE
Update javascript-reference.md

### DIFF
--- a/docs/clients/javascript-reference.md
+++ b/docs/clients/javascript-reference.md
@@ -109,10 +109,12 @@ transaction.add(
 await web3.sendAndConfirmTransaction(connection, transaction, [payer]);
 
 // Alternatively, manually construct the transaction
-let recentBlockhash = await connection.getRecentBlockhash();
+let recentBlockhash = await connection.getLatestBlockhash();
+let lastValidBlockHeight = await connection.getLatestBlockhashAndContext();
 let manualTransaction = new web3.Transaction({
-  recentBlockhash: recentBlockhash.blockhash,
+  blockhash: recentBlockhash.blockhash,
   feePayer: payer.publicKey,
+  lastValidBlockHeight,
 });
 manualTransaction.add(
   web3.SystemProgram.transfer({

--- a/docs/clients/javascript-reference.md
+++ b/docs/clients/javascript-reference.md
@@ -110,11 +110,9 @@ await web3.sendAndConfirmTransaction(connection, transaction, [payer]);
 
 // Alternatively, manually construct the transaction
 let recentBlockhash = await connection.getLatestBlockhash();
-let lastValidBlockHeight = await connection.getLatestBlockhashAndContext();
 let manualTransaction = new web3.Transaction({
-  blockhash: recentBlockhash.blockhash,
+  recentBlockhash: recentBlockhash.blockhash,
   feePayer: payer.publicKey,
-  lastValidBlockHeight,
 });
 manualTransaction.add(
   web3.SystemProgram.transfer({


### PR DESCRIPTION
Remove use of deprecated method and constructor arguments

### Problem
Remove the use of the deprecated web3.js method `getRecentBlockhash`

### Summary of Changes
Updates Transaction instantiation to 
 
```typescript
let latestBlockhash = await conn.getLatestBlockhash();
```

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->