### PR TITLE
Specify slotsUpdatesSubscribe's timestamp unit

### DIFF
--- a/docs/rpc/websocket/slotsUpdatesSubscribe.mdx
+++ b/docs/rpc/websocket/slotsUpdatesSubscribe.mdx
@@ -60,7 +60,7 @@ The notification will be an object with the following fields:
   - `numFailedTransactions: <u64>`,
   - `numSuccessfulTransactions: <u64>`,
   - `numTransactionEntries: <u64>`,
-- `timestamp: <i64>` - The Unix timestamp of the update
+- `timestamp: <i64>` - The Unix timestamp of the update in milliseconds
 - `type: <string>` - The update type, one of:
   - "firstShredReceived"
   - "completed"


### PR DESCRIPTION
Unix timestamps are usually in seconds, but this one is in milliseconds.