### PR TITLE
fix: default locale

### DIFF
--- a/src/utils/records.ts
+++ b/src/utils/records.ts
@@ -85,5 +85,10 @@ export function getRecordsForGroup(
     }
   }
 
+  // default the records to the base language if no records for the provided locale were found
+  if (records.findIndex(record => record.locale == options.locale) < 0) {
+    options.locale = DEFAULT_LOCALE_EN;
+  }
+
   return records.filter(record => record.locale == options.locale);
 }


### PR DESCRIPTION
### Problem

when a locale is not supported, no results will be returned. it should default to the base language of english

### Summary of Changes

- default records to the base language when a non supported locale is requested