### PR TITLE
Iso dates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,11 +274,9 @@ Example:
 The date this content was published
 
 - name: `date`
-- type: `date` string in the format of `MMM DD, YYYY`
+- type: `date` as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
+  formatted date (i.e. `2023-12-06T00:00:00Z`)
 - required: `false`
-
-Example:
-[this line of text](https://github.com/solana-foundation/developer-content/blob/9bf2b82d684ad487c9282c529cd998f3a6249bd9/content/guides/getstarted/local-rust-hello-world.md?plain=1#L2)
 
 #### updatedDate
 

--- a/content/guides/advanced/auto-approve.md
+++ b/content/guides/advanced/auto-approve.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: beginner
 title: How to auto approve transactions
 seoTitle: How to auto approve transactions on Solana

--- a/content/guides/advanced/how-to-optimize-compute.md
+++ b/content/guides/advanced/how-to-optimize-compute.md
@@ -1,6 +1,6 @@
 ---
 featured: true
-date: Mar 15, 2024
+date: 2024-03-15T00:00:00Z
 difficulty: intermediate
 title: "How to Optimize Compute Usage on Solana"
 description:

--- a/content/guides/advanced/how-to-request-optimal-compute.md
+++ b/content/guides/advanced/how-to-request-optimal-compute.md
@@ -1,5 +1,5 @@
 ---
-date: Mar 19, 2024
+date: 2024-03-19T00:00:00Z
 difficulty: intermediate
 title: How to Request Optimal Compute Budget
 description:

--- a/content/guides/advanced/how-to-use-priority-fees.md
+++ b/content/guides/advanced/how-to-use-priority-fees.md
@@ -1,5 +1,5 @@
 ---
-date: Mar 7, 2024
+date: 2024-04-07T00:00:00Z
 difficulty: intermediate
 title: "How to use Priority Fees on Solana"
 description:

--- a/content/guides/advanced/introduction-to-durable-nonces.md
+++ b/content/guides/advanced/introduction-to-durable-nonces.md
@@ -1,5 +1,5 @@
 ---
-date: Jun 29, 2023
+date: 2024-06-29T00:00:00Z
 difficulty: intermediate
 title: "Durable & Offline Transaction Signing using Nonces"
 description:

--- a/content/guides/advanced/stake-weighted-qos.md
+++ b/content/guides/advanced/stake-weighted-qos.md
@@ -1,6 +1,6 @@
 ---
 featured: false
-date: Mar 20, 2024
+date: 2024-03-20T00:00:00Z
 difficulty: intermediate
 seoTitle: "Stake-weighted Quality of Service on Solana"
 title: "A Guide to Stake-weighted Quality of Service on Solana"

--- a/content/guides/dapps/journal.md
+++ b/content/guides/dapps/journal.md
@@ -1,5 +1,5 @@
 ---
-date: March 18, 2024
+date: 2024-03-18T00:00:00Z
 difficulty: intro
 title: "How to create a CRUD dApp on Solana"
 description:

--- a/content/guides/games/energy-system.md
+++ b/content/guides/games/energy-system.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intermediate
 title: Build an Energy System for Casual Games on Solana
 description:

--- a/content/guides/games/game-examples.md
+++ b/content/guides/games/game-examples.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intro
 title: Solana Game Development Examples
 description:

--- a/content/guides/games/game-sdks.md
+++ b/content/guides/games/game-sdks.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intro
 title: Solana Gaming SDKs
 description:

--- a/content/guides/games/getting-started-with-game-development.md
+++ b/content/guides/games/getting-started-with-game-development.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intro
 title: Getting started with game development on Solana
 description:

--- a/content/guides/games/hello-world.md
+++ b/content/guides/games/hello-world.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: beginner
 title: Hello World for Solana Game Development
 description:

--- a/content/guides/games/interact-with-tokens.md
+++ b/content/guides/games/interact-with-tokens.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intermediate
 title: How interact with tokens in programs
 description: Learn how to use tokens in Solana games with an on-chain tutorial

--- a/content/guides/games/nfts-in-games.md
+++ b/content/guides/games/nfts-in-games.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intro
 title: Using NFTs and Digital Assets in Games
 description:

--- a/content/guides/games/porting-anchor-to-unity.md
+++ b/content/guides/games/porting-anchor-to-unity.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: beginner
 title: Port Anchor to Unity
 description:

--- a/content/guides/games/saving-game-state.md
+++ b/content/guides/games/saving-game-state.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: beginner
 title: Saving game state
 description: How to save the state of a game in a Solana program

--- a/content/guides/games/store-sol-in-pda.md
+++ b/content/guides/games/store-sol-in-pda.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intermediate
 title: Storing SOL in a PDA
 description:

--- a/content/guides/getstarted/full-stack-solana-development.md
+++ b/content/guides/getstarted/full-stack-solana-development.md
@@ -1,5 +1,5 @@
 ---
-date: Feb 29, 2024
+date: 2024-02-29T00:00:00Z
 difficulty: intermediate
 title: "Full-stack Solana development with React and Anchor"
 description: "Learn how to build a full-stack Solana dApp with React and Anchor"

--- a/content/guides/getstarted/hello-world-in-your-browser.md
+++ b/content/guides/getstarted/hello-world-in-your-browser.md
@@ -1,5 +1,5 @@
 ---
-date: Jan 18, 2023
+date: 2023-01-18T00:00:00Z
 difficulty: intro
 featured: true
 featuredPriority: 0

--- a/content/guides/getstarted/how-to-cpi-with-signer.md
+++ b/content/guides/getstarted/how-to-cpi-with-signer.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 24, 2024
+date: 2024-04-24T00:00:00Z
 difficulty: beginner
 title: "How to CPI with a PDA Signer in a Solana program"
 description:

--- a/content/guides/getstarted/how-to-cpi.md
+++ b/content/guides/getstarted/how-to-cpi.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 24, 2024
+date: 2024-04-24T00:00:00Z
 difficulty: beginner
 title: "How to CPI in a Solana program"
 description:

--- a/content/guides/getstarted/how-to-create-a-token.md
+++ b/content/guides/getstarted/how-to-create-a-token.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 30, 2024
+date: 2024-04-30T00:00:00Z
 difficulty: intro
 title: "How to create a token on Solana"
 description: "Learn how to create a SPL token on Solana with metadata."

--- a/content/guides/getstarted/intro-to-anchor.md
+++ b/content/guides/getstarted/intro-to-anchor.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 24, 2024
+date: 2024-04-24T00:00:00Z
 difficulty: beginner
 title: "Getting Started with the Anchor Framework"
 description:

--- a/content/guides/getstarted/intro-to-native-rust.md
+++ b/content/guides/getstarted/intro-to-native-rust.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 24, 2024
+date: 2024-04-24T00:00:00Z
 difficulty: beginner
 title: "How to write a Native Rust Program"
 description:

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -1,5 +1,5 @@
 ---
-date: Mar 28, 2023
+date: 2023-03-28T00:00:00Z
 difficulty: intro
 title: "Setup, build, and deploy a Solana program locally in Rust"
 description:

--- a/content/guides/getstarted/rust-to-solana.md
+++ b/content/guides/getstarted/rust-to-solana.md
@@ -1,5 +1,5 @@
 ---
-date: May 21, 2024
+date: 2024-05-21T00:00:00Z
 difficulty: Intro
 title: "Getting started with Solana with Rust Experience"
 description: "Learn how to start building on Solana as a Rust Engineer"

--- a/content/guides/getstarted/setup-local-development.md
+++ b/content/guides/getstarted/setup-local-development.md
@@ -1,6 +1,6 @@
 ---
 featured: true
-date: Feb 26, 2024
+date: 2024-02-26T00:00:00Z
 difficulty: intro
 title: "Setup local development and install the Solana CLI"
 description:

--- a/content/guides/getstarted/solana-token-airdrop-and-faucets.md
+++ b/content/guides/getstarted/solana-token-airdrop-and-faucets.md
@@ -1,5 +1,5 @@
 ---
-date: Jul 29, 2023
+date: 2023-07-29T00:00:00Z
 difficulty: intro
 title: "How to get Solana devnet SOL (including airdrops and faucets)"
 seoTitle: "Faucets: How to get Solana devnet SOL"

--- a/content/guides/intro/wallets-explained.md
+++ b/content/guides/intro/wallets-explained.md
@@ -1,5 +1,5 @@
 ---
-date: Jun 15, 2022
+date: 2022-06-15T00:00:00Z
 difficulty: intro
 title: "Wallets Explained"
 description:

--- a/content/guides/javascript/compressed-nfts.md
+++ b/content/guides/javascript/compressed-nfts.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 22, 2023
+date: 2023-04-22T00:00:00Z
 title: Creating Compressed NFTs with JavaScript
 description:
   "Compressed NFTs use the Bubblegum program from Metaplex to cheaply and

--- a/content/guides/permissioned-environments/index.md
+++ b/content/guides/permissioned-environments/index.md
@@ -1,5 +1,5 @@
 ---
-date: Mar 25, 2024
+date: 2024-03-25T00:00:00Z
 difficulty: intermediate
 title: "A Guide to Solana Permissioned Environments"
 seoTitle: "Solana Permissioned Environments"

--- a/content/guides/rpc/configure-solana-rpc-on-aws.md
+++ b/content/guides/rpc/configure-solana-rpc-on-aws.md
@@ -1,5 +1,5 @@
 ---
-date: Oct 26, 2023
+date: 2023-10-26T00:00:00Z
 difficulty: intermediate
 title: "Configure and run a Solana RPC on AWS"
 description:

--- a/content/guides/solang/getting-started.md
+++ b/content/guides/solang/getting-started.md
@@ -1,6 +1,6 @@
 ---
 featured: false
-date: Jul 17, 2023
+date: 2023-07-17T00:00:00Z
 difficulty: intro
 title: "Getting started with Solang"
 description:

--- a/content/guides/token-extensions/default-account-state.md
+++ b/content/guides/token-extensions/default-account-state.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 06, 2023
+date: 2023-12-06T00:00:00Z
 seoTitle: "Token Extensions: Default Account State"
 title: How to use the Default Account State extension
 description:

--- a/content/guides/token-extensions/dynamic-meta-data-nft.md
+++ b/content/guides/token-extensions/dynamic-meta-data-nft.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 25, 2024
+date: 2024-04-25T00:00:00Z
 difficulty: intermediate
 title: Dynamic metadata NFTs using Token Extensions
 description:

--- a/content/guides/token-extensions/getting-started.md
+++ b/content/guides/token-extensions/getting-started.md
@@ -1,7 +1,7 @@
 ---
 featured: true
 featuredPriority: 1
-date: Jan 19, 2024
+date: 2024-01-19T00:00:00Z
 difficulty: beginner
 seoTitle: "Getting Started with Token Extensions"
 title: "Getting Started with Token Extensions"

--- a/content/guides/token-extensions/immutable-owner.md
+++ b/content/guides/token-extensions/immutable-owner.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 6, 2023
+date: 2023-12-06T00:00:00Z
 difficulty: beginner
 seoTitle: "Token Extensions: Immutable Owner"
 title: "How to use the Immutable Owner extension"

--- a/content/guides/token-extensions/interest-bearing-tokens.md
+++ b/content/guides/token-extensions/interest-bearing-tokens.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 7, 2023
+date: 2023-12-07T00:00:00Z
 seoTitle: "Token Extensions: Interest-Bearing"
 title: How to use the Interest-Bearing extension
 description:

--- a/content/guides/token-extensions/metadata-pointer.md
+++ b/content/guides/token-extensions/metadata-pointer.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 21, 2023
+date: 2023-12-21T00:00:00Z
 seoTitle: "Token Extensions: Metadata Pointer and Token Metadata"
 title: How to use the Metadata Pointer extension
 description:

--- a/content/guides/token-extensions/mint-close-authority.md
+++ b/content/guides/token-extensions/mint-close-authority.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 05, 2023
+date: 2023-12-05T00:00:00Z
 seoTitle: "Token Extensions: Mint Close Authority"
 title: How to use the Mint Close Authority extension
 description:

--- a/content/guides/token-extensions/non-transferable.md
+++ b/content/guides/token-extensions/non-transferable.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 06, 2023
+date: 2023-12-06T00:00:00Z
 seoTitle: "Token Extensions: Non-transferable"
 title: How to use the Non-transferable extension
 description:

--- a/content/guides/token-extensions/permanent-delegate.md
+++ b/content/guides/token-extensions/permanent-delegate.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 06, 2023
+date: 2023-12-06T00:00:00Z
 seoTitle: "Token Extensions: Permanent Delegate"
 title: How to use the Permanent Delegate extension
 description:

--- a/content/guides/token-extensions/reallocate.md
+++ b/content/guides/token-extensions/reallocate.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 7, 2023
+date: 2023-12-07T00:00:00Z
 seoTitle: "Token Extensions: Reallocate instruction"
 title: How to use the Reallocate instruction
 description:

--- a/content/guides/token-extensions/required-memo.md
+++ b/content/guides/token-extensions/required-memo.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 7, 2023
+date: 2023-12-07T00:00:00Z
 seoTitle: "Token Extensions: Required Memo"
 title: How to use the Required Memo token extension
 description:

--- a/content/guides/token-extensions/transfer-fee.md
+++ b/content/guides/token-extensions/transfer-fee.md
@@ -1,5 +1,5 @@
 ---
-date: Dec 06, 2023
+date: 2023-12-06T00:00:00Z
 seoTitle: "Token Extensions: Transfer Fees"
 title: How to use the Transfer Fee extension
 description:

--- a/content/guides/token-extensions/transfer-hook.md
+++ b/content/guides/token-extensions/transfer-hook.md
@@ -1,5 +1,5 @@
 ---
-date: Feb 01, 2023
+date: 2023-02-01T00:00:00Z
 seoTitle: "Token Extensions: Transfer Hook"
 title: How to use the Transfer Hook extension
 description:

--- a/content/guides/wallets/add-solana-wallet-adapter-to-nextjs.md
+++ b/content/guides/wallets/add-solana-wallet-adapter-to-nextjs.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 01, 2024
+date: 2024-04-01T00:00:00Z
 difficulty: intro
 title: "Add Solana Wallet Adapter to a NextJS application"
 description:

--- a/content/workshops/ship-your-first-xnft.md
+++ b/content/workshops/ship-your-first-xnft.md
@@ -1,7 +1,7 @@
 ---
 featured: true
-date: 10 Dec 2022
-updatedDate: 10 Dec 2023
+date: 2022-12-10T00:00:00Z
+updatedDate: 2022-12-10T00:00:00Z
 title: Ship your first xNFT
 description: Ship your first xNFT with Backpack!
 repoUrl: https://github.com/Solana-Workshops/ship-an-xnft

--- a/content/workshops/solana-101.md
+++ b/content/workshops/solana-101.md
@@ -1,7 +1,7 @@
 ---
 featured: true
-date: 04 Jan 2023
-updatedDate: 04 Jan 2023
+date: 2023-01-04T00:00:00Z
+updatedDate: 2023-01-04T00:00:00Z
 title: Solana 101
 description:
   Introduction to building on & interacting with the Solana blockchain

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -1,5 +1,5 @@
 ---
-date: Apr 26, 2024
+date: 2024-04-26
 title: "Program Examples"
 description:
   "A list of Solana program examples in different languages and frameworks,

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-04-26
+date: 2024-04-26T00:00:00Z
 title: "Program Examples"
 description:
   "A list of Solana program examples in different languages and frameworks,


### PR DESCRIPTION
### Problem

The current content `date` field uses the English words for months in the dates. This can lead to some confusion among Crowdin translators. If this `date` field is set to an empty string, it will result in the content api failing to deploy.

### Summary of Changes

- update all dates in the frontmatter to be iso formatted

Fixes #229 

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->