### PR TITLE
Removes the implication that solana has slashing

### DIFF
--- a/docs/economics/staking/index.md
+++ b/docs/economics/staking/index.md
@@ -33,14 +33,15 @@ rewards the more stake is delegated to them, they may compete with one another
 to offer the lowest commission for their services.
 
 Although this is not implemented in the Solana protocol today, in the future,
-delegators could risk losing tokens when staking through a process known as _slashing_.
-Slashing involves the removal and destruction of a portion of a validator's sol
-in response to intentional malicious behavior, such as creating
+delegators could risk losing tokens when staking through a process known as
+_slashing_. Slashing involves the removal and destruction of a portion of a
+validator's sol in response to intentional malicious behavior, such as creating
 invalid transactions or censoring certain types of transactions or network
 participants.
 
-There is no in protocol implementation of slashing currently. For more information
-on slashing see the [slashing roadmap](https://docs.solanalabs.com/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
+There is no in protocol implementation of slashing currently. For more
+information on slashing see the
+[slashing roadmap](https://docs.solanalabs.com/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
 
 ## How do I stake my SOL tokens?
 

--- a/docs/economics/staking/index.md
+++ b/docs/economics/staking/index.md
@@ -32,21 +32,15 @@ rewards earned. This fee is known as a _commission_. Since validators earn more
 rewards the more stake is delegated to them, they may compete with one another
 to offer the lowest commission for their services.
 
-You risk losing tokens when staking through a process known as _slashing_.
-Slashing involves the removal and destruction of a portion of a validator's
-delegated stake in response to intentional malicious behavior, such as creating
+Although this is not implemented in the Solana protocol today, in the future,
+delegators could risk losing tokens when staking through a process known as _slashing_.
+Slashing involves the removal and destruction of a portion of a validator's sol
+in response to intentional malicious behavior, such as creating
 invalid transactions or censoring certain types of transactions or network
 participants.
 
-When a validator is slashed, all token holders who have delegated stake to that
-validator lose a portion of their delegation. While this means an immediate loss
-for the token holder, it also is a loss of future rewards for the validator due
-to their reduced total delegation. More details on the slashing roadmap can be
-found
-[here](https://docs.solanalabs.com/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
-
-Rewards and slashing align validator and token holder interests which helps keep
-the network secure, robust and performant.
+There is no in protocol implementation of slashing currently. For more information
+on slashing see the [slashing roadmap](https://docs.solanalabs.com/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
 
 ## How do I stake my SOL tokens?
 


### PR DESCRIPTION
### Problem
The current docs seem to imply that slashing is implemented in the solana protocol. They also make assumptions about how slashing should or will be implemented (i.e. slashing takes sol from the delegator's principle).  


### Summary of Changes
Reworded the paragraph on slashing to make it clear slashing is not implemented yet.


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->