### PR TITLE
Add example command to deploy program guide

### DIFF
--- a/docs/programs/deploying.md
+++ b/docs/programs/deploying.md
@@ -111,6 +111,22 @@ following 3 phases:
    In either case, the byte-code written to the buffer account will be copied
    into a program data account and verified.
 
+<Callout type="info">
+
+During times of congestion it is helpful to add priority fees and increase the
+max sign attempts. Using a rpc url which has
+[stake weighted quality of service](https://solana.com/de/developers/guides/advanced/stake-weighted-qos)
+enabled can also help to make program deploys more reliable. Using Solana
+version ^1.18.15 is recommended.
+
+Example command deploying a program with the Solana CLI:
+
+```shell
+program deploy target/deploy/your_program.so --with-compute-unit-price 10000 --max-sign-attempts 1000 --use-rpc
+```
+
+</Callout>
+
 ## Reclaim rent from program accounts
 
 The storage of data on the Solana blockchain requires the payment of

--- a/docs/programs/deploying.md
+++ b/docs/programs/deploying.md
@@ -115,7 +115,7 @@ following 3 phases:
 
 During times of congestion it is helpful to add priority fees and increase the
 max sign attempts. Using a rpc url which has
-[stake weighted quality of service](https://solana.com/de/developers/guides/advanced/stake-weighted-qos)
+[stake weighted quality of service](https://solana.com/developers/guides/advanced/stake-weighted-qos)
 enabled can also help to make program deploys more reliable. Using Solana
 version ^1.18.15 is recommended.
 


### PR DESCRIPTION
### Problem
Currently it is hard to deploy programs. Many people still dont know that --use-rpc makes deploys more reliable and adding priority fees is way more reliable. 


Fixes #
Added an example command which shows of these flags. 