### PR TITLE
fix typo in signatureSubscribe

### DIFF
--- a/docs/rpc/websocket/signatureSubscribe.mdx
+++ b/docs/rpc/websocket/signatureSubscribe.mdx
@@ -130,7 +130,7 @@ The following is an example response of a notification from a successfully
 ```
 
 The following is an example response of a notification from a successfully
-**recieved** transaction signature:
+**received** transaction signature:
 
 ```json
 {


### PR DESCRIPTION
### Problem
just fixed a typo in `docs/rpc/websocket/signatureSubscribe.mdx`


### Summary of Changes
s/recieved/received