### PR TITLE
fix: last valid block height value

### DIFF
--- a/docs/advanced/retry.md
+++ b/docs/advanced/retry.md
@@ -246,12 +246,12 @@ const sleep = async (ms: number) => {
 
   await connection.confirmTransaction({ signature: airdropSignature });
 
-  const blockhashResponse = await connection.getLatestBlockhashAndContext();
-  const lastValidBlockHeight = blockhashResponse.context.slot + 150;
+  const blockhashResponse = await connection.getLatestBlockhash();
+  const lastValidBlockHeight = blockhashResponse.lastValidBlockHeight - 150;
 
   const transaction = new Transaction({
     feePayer: payer.publicKey,
-    blockhash: blockhashResponse.value.blockhash,
+    blockhash: blockhashResponse.blockhash,
     lastValidBlockHeight: lastValidBlockHeight,
   }).add(
     SystemProgram.transfer({


### PR DESCRIPTION
### Problem
A mistake sneaked in about the last valid block height (for tx validity). Slots are way ahead of blockHeights, as the blockHeight count doesn't increase when no block is produced during a slot.


### Summary of Changes
- `lastValidBlockHeight` should be used instead. Yet this one is confusing because it's current block height + 300, so [we have to subtract 150 from it](https://github.com/anza-xyz/agave/blob/e42e7fd692a9777f0b3f25b460c2038fabbe4a2c/sdk/program/src/clock.rs#L129-L131)
- alternatively we can get the current blockHeight (via `getBlockHeight`) then add 150 to it. But that's 2 rpc calls instead of 1.

PS: it'd be great to update the `lastValidBlockHeight` number returned from `getLatestBlockhash` such that it's just 150 ahead of `getBlockHeight`. I'm sure it's confusing more devs writing the tx retry logic of their apps.
