### PR TITLE
docs: Correct spelling mistake from 'were' to 'where' in docs/intro/dev

### DIFF
--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -161,7 +161,7 @@ mature testing and CI/CD practices:
 
 - **Mainnet Beta**: The production network where all the action happens.
   Transactions cost real money here.
-- **Devnet**: The quality assurance network were you deploy your programs to
+- **Devnet**: The quality assurance network where you deploy your programs to
   test before deploying to production. Think "staging environment".
 - **Local**: The local network that you run on your machine using
   `solana-test-validator` to test your programs. This should be your first


### PR DESCRIPTION
### Problem
Typo error 


### Summary of Changes
- Corrected a spelling mistake in the documentation.
- Changed 'were' to 'where' in the file located at docs/intro/dev.


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->