### PR TITLE
[docs] fix runtime docs link

### DIFF
--- a/content/guides/advanced/how-to-request-optimal-compute.md
+++ b/content/guides/advanced/how-to-request-optimal-compute.md
@@ -154,9 +154,8 @@ users.
 You can learn more about the Compute Budget and related topics with these
 resources:
 
-- documentation for the
-  [Compute Budget](https://solana.com/docs/core/runtime#compute-budget)
+- documentation for the [Compute Budget](/docs/core/fees.md#compute-budget)
 - Guide on
-  [how to use priority fees](https://solana.com/developers/guides/advanced/how-to-use-priority-fees)
+  [how to use priority fees](/content/guides/advanced/how-to-use-priority-fees.md)
 - Guide on
-  [how to optimize compute units in programs](https://solana.com/developers/guides/advanced/how-to-optimize-compute)
+  [how to optimize compute units in programs](/content/guides/advanced/how-to-optimize-compute)

--- a/content/guides/advanced/how-to-use-priority-fees.md
+++ b/content/guides/advanced/how-to-use-priority-fees.md
@@ -49,7 +49,7 @@ When adding priority fees to a transaction, keep in mind the amount of compute
 units (CU) used for your transaction. The higher the CU required for the
 transaction, the more fees you will pay when adding priority fees.
 
-Using the [Compute Budget Program](/docs/core/runtime#compute-budget), you can
+Using the [Compute Budget Program](/docs/core/fees.md#compute-budget), you can
 change the CU requested for your transaction and add any additional priority fee
 required. Do note that your CU request must be equal to or greater than the CU
 needed for the transaction; otherwise, the transaction will fail.


### PR DESCRIPTION
### Problem

there are a few lingering links to the old runtime page

### Summary of Changes

- update the old runtime doc links to point to the update fees page

Note: To not conflict with this PR https://github.com/solana-foundation/developer-content/pull/263#pullrequestreview-2177765297, the runtime link in the compression doc was not updated in this PR