### PR TITLE
Replace solana.com cli install url with anza.xyz

### DIFF
--- a/content/courses/onchain-development/local-setup.md
+++ b/content/courses/onchain-development/local-setup.md
@@ -51,7 +51,7 @@ Next
 [download the Solana CLI tools](https://docs.solana.com/cli/install-solana-cli-tools).
 
 ```
-sh -c "$(curl -sSfL https://release.solana.com/beta/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
 ```
 
 Afterwards, `solana -V` should show `solana-cli 1.18.x` (any number for `x` is

--- a/content/guides/getstarted/setup-local-development.md
+++ b/content/guides/getstarted/setup-local-development.md
@@ -207,7 +207,7 @@ tasks, like:
 1.  Install the Solana CLI tool suite using the official install command:
 
     ```shell
-    sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+    sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
     ```
 
 2.  You can replace `stable` with the release tag matching the software version

--- a/content/guides/getstarted/solana-test-validator.md
+++ b/content/guides/getstarted/solana-test-validator.md
@@ -48,7 +48,7 @@ you have Solana's command-line tools installed. You can install them using the
 following command:
 
 ```shell
-sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
 ```
 
 You can replace `stable` with the release tag matching the software version of

--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -113,7 +113,7 @@ deploy your programs. You can install the Solana CLI by running the following
 command:
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
 ```
 
 Using the Solana CLI, it is recommended to run a local validator for testing


### PR DESCRIPTION
### Problem
The old install url points to solana.com, which has 1.17.x as stable version, we want people to use the newest stable version. Since the anza docs are not yet published this is a quick fix to reach some of the developers earlier. 


### Summary of Changes
Just a search and replace 
