### PR TITLE
Change lookup-tables to clarify only 64 addresses in a single transaction

### DIFF
--- a/docs/advanced/lookup-tables.md
+++ b/docs/advanced/lookup-tables.md
@@ -12,7 +12,7 @@ Since each transaction on the Solana blockchain requires a listing of every
 address that is interacted with as part of the transaction, this listing would
 effectively be capped at 32 addresses per transaction. With the help of
 [Address Lookup Tables](/docs/advanced/lookup-tables.md), a transaction would
-now be able to raise that limit to 256 addresses per transaction.
+now be able to raise that limit to 64 addresses per transaction.
 
 ## Compressing onchain addresses
 
@@ -100,7 +100,7 @@ const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
 
 Once these addresses have been inserted into the table, and stored onchain, you
 will be able to utilize the Address Lookup Table in future transactions.
-Enabling up to 256 addresses in those future transactions.
+Enabling up to 64 addresses in those future transactions.
 
 ## Fetch an Address Lookup Table
 


### PR DESCRIPTION
### Problem

Motivated by https://github.com/anza-xyz/agave/issues/2194

The Agave validator client has a cap of 64 locks (read or write) per transaction, which means that you can only have 64 unique accounts in a transaction. A transaction with >64 accounts will throw a `TooManyAccountLocks` error. 

[Example Explorer link from the above issue
](https://explorer.solana.com/tx/inspector?signatures=%255B%25221111111111111111111111111111111111111111111111111111111111111111%2522%255D&message=gAEABhTWF9K8PuztHUzAf2mtX5gzqQC5i%252BP%252FcOdB0hEyPbIQ4wIiP%252B2OepTpOyUxVepz9I5ExjZ6uZG2VM8exG3yQ%252BOTCgUkQaFYTleMcAX2p74eBXQZd1dwDyQZAPJfSv2KGc4yFBMogxxTU%252BU%252BGrhwhIBuhLAUJKe6Zau3pURqgPmu7FA%252FgvuGgmnoWJEPG2j2y0CyJx28Eq1SQH9FGXq3TGZYXfhaYt2vwu8t4GKm7%252BXhW6FzNqbD7OWi46ncjnr5bQezTPFjMwHVVIvZ0d3TADZPigtzIQldboSR4I5TlY7pUsq9SpEpF%252FRqUqyolO3yTgrLtg2C7eL2oLfQy2J4%252Bp%252Buz0uA8gNY2D%252BYM8htSK70t55vZmzsvysWdFXODuaIK9rY7DspKV%252BQHBIkCLcEO7Y6YYuIZkC%252BOmGZWozUm0c1ZuL4d%252Bg9rsaIj0Orta57MRu3jDSWCJf85ae4LBbiD%252FGX4xf4Uc7z6AGPB5Vrv5s8QKkvgyBqQ%252BBRi9RG0dPMdxPmKl%252FvFFIe%252BofB7H5T0T0QIgqh7PRsOFfsxcpWBmtsc%252F6Muh2ijt7hkMcFQsleD64W%252Bh4whqBLbDZL9QockjikAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBkZv5SEXMv%252Fsrbpyw5vnvIzlu8X3EmssQ5s6QAAAAAR51VvyMcBu7nTFbs5oFQf9sbLeo%252FSOUQKxzaJWvBOPBt324ddloZPZy%252BFGzut5rBy0he1fWzeROoz1hX7%252FAKmMlyWPTiSJ8bs9ECkUjg2DC1oTmdr%252FEIQEjnvY2%252Bn4WbQ%252F%252Bif11%252FZKdMCbHylYed5LCas238ndUUsyGqezjOXo0c0Zfzl2yoDAQ1E0t%252FzdfDr%252Bid6CVHdiuExLxD%252F8B6gFDwAFAsBcFQAPAAkDBBcBAAAAAAASBgABADAOEQEBEFsRCgAJDAIBKDAFEBMQPQoaCAwoKxERKSwqPD4jL0A7PxA0CggLGiAENSQdOAM2BzIxDi8jHzchHjIRMQ4QCgsGJScvGRw6OSYiGzIzETEQLREKGAIWBhQNFxUuNsEgmzNB1pyBAAMAAAAtBQ4AAABkAAEpk08%252FzmQBAhEAZAIDobyuGAAAAAC8BLsdAAAAAMgAZBEDAQAAAQkDURBLDgRjIEOh7I6JFFErtmx%252Fr4vmto%252B%252FJ8RjezdWMNsFUlZYVVACUVS43iwvreuR8BhYpDAeCFsoO0z9GjShsG5HPjumkohn7w8anKQeCqcpMK0rIRAkrKIMBbkSCzcCAxWgDZ%252Bptm6FW%252FKTy0eB%252B9HOI3dS6cATIW%252B8aOUfReEJbraBsf4FSBgxuwcGQ8bVdVgO)

IMO the lookup-table documentation is a bit misleading here:

> With the help of [Address Lookup Tables](https://solana.com/docs/advanced/lookup-tables), a transaction would now be able to raise that limit to 256 addresses per transaction.

An address lookup table can store 256 addresses, but this doesn't mean you can use 256 addresses per transaction.

### Summary of Changes

I've modified the sentences that refer to using a maximum number of addresses in a single transaction from 256 to 64. This should clarify the difference between these two different limits. 

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->