### PR TITLE
Update add-solana-wallet-adapter-to-nextjs.md

### DIFF
--- a/content/guides/wallets/add-solana-wallet-adapter-to-nextjs.md
+++ b/content/guides/wallets/add-solana-wallet-adapter-to-nextjs.md
@@ -89,7 +89,7 @@ npm install @solana/web3.js \
     @solana/wallet-adapter-base \
     @solana/wallet-adapter-react \
     @solana/wallet-adapter-react-ui \
-    @solana/wallet-adapter-wallets \
+    @solana/wallet-adapter-wallets
 ```
 
 ## 3. Setting up Wallet Adapter in your Next.js app


### PR DESCRIPTION
removed the trialing slash cause its not needed

### Problem

The command for adding wallet packages add a trialing slash

### Summary of Changes

Just the 1 slash at the end removed