### PR TITLE
Skip rpc and terminology pages when setting next/previous page routes

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -134,6 +134,20 @@ const basicContentFields: FieldDefs = {
     description: "Force hide the table of contents displayed on page",
     required: false,
   },
+  isSkippedInNav: {
+    type: "boolean",
+    description:
+      "Whether or not to skip this page when generating previous/next page routes on docs",
+    required: false,
+    default: false,
+  },
+  isHiddenInNavSidebar: {
+    type: "boolean",
+    description:
+      "Whether or not to hide this section in the DocNavSidebar (left-hand side) on docs",
+    required: false,
+    default: false,
+  },
 
   /**
    * Custom SEO specific details

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ seoTitle: Learn how the Solana blockchain works
 description: "Solana is a high performance network that is utilized for a range
   of use cases, \
   including finance, NFTs, payments, and gaming."
+isHiddenInNavSidebar: true
 ---
 
 Solana is a blockchain built for mass adoption. It's a high performance network

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -1,6 +1,7 @@
 ---
 title: JSON RPC Methods
 sidebarSortOrder: 1
+isSkippedInNav: true
 ---
 
 This file should not be edited since it is not intended to be displayed. This

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -9,6 +9,7 @@ keywords:
   - definitions
   - define
   - programming models
+isSkippedInNav: true
 ---
 
 The following terms are used throughout the Solana documentation and development

--- a/src/app/api/content/[...slug]/route.ts
+++ b/src/app/api/content/[...slug]/route.ts
@@ -79,10 +79,15 @@ export function GET(req: Request, { params: { slug } }: RouteProps) {
     }
 
     // get the "next" record link to display (that is an actual link)
+    // skip "/docs/rpc" and "/docs/terminology" when setting next page
     if (flatNavItems.length >= i + 1) {
-      for (let j = i; j < flatNavItems.length; j++) {
-        if (!!flatNavItems[j + 1]?.href) {
-          next = flatNavItems[j + 1];
+      for (let j = i + 1; j < flatNavItems.length; j++) {
+        if (
+          !!flatNavItems[j]?.href &&
+          flatNavItems[j].href !== "/docs/rpc" &&
+          flatNavItems[j].href !== "/docs/terminology"
+        ) {
+          next = flatNavItems[j];
           break;
         }
       }

--- a/src/app/api/content/[...slug]/route.ts
+++ b/src/app/api/content/[...slug]/route.ts
@@ -69,15 +69,19 @@ export function GET(req: Request, { params: { slug } }: RouteProps) {
     current = flatNavItems[i];
 
     // get the "previous" record link to display (that is an actual link)
+    // skip "/docs/rpc" and "/docs/terminology" when setting previous page
     if (flatNavItems.length >= i - 1) {
       for (let j = i; j > 0; j--) {
-        if (!!flatNavItems[j - 1]?.href) {
+        if (
+          !!flatNavItems[j - 1]?.href &&
+          flatNavItems[j - 1].href !== "/docs/rpc" &&
+          flatNavItems[j - 1].href !== "/docs/terminology"
+        ) {
           prev = flatNavItems[j - 1];
           break;
         }
       }
     }
-
     // get the "next" record link to display (that is an actual link)
     // skip "/docs/rpc" and "/docs/terminology" when setting next page
     if (flatNavItems.length >= i + 1) {

--- a/src/app/api/content/[...slug]/route.ts
+++ b/src/app/api/content/[...slug]/route.ts
@@ -69,28 +69,18 @@ export function GET(req: Request, { params: { slug } }: RouteProps) {
     current = flatNavItems[i];
 
     // get the "previous" record link to display (that is an actual link)
-    // skip "/docs/rpc" and "/docs/terminology" when setting previous page
-    if (flatNavItems.length >= i - 1) {
-      for (let j = i; j > 0; j--) {
-        if (
-          !!flatNavItems[j - 1]?.href &&
-          flatNavItems[j - 1].href !== "/docs/rpc" &&
-          flatNavItems[j - 1].href !== "/docs/terminology"
-        ) {
-          prev = flatNavItems[j - 1];
+    if (i > 0) {
+      for (let j = i - 1; j >= 0; j--) {
+        if (!!flatNavItems[j]?.href && !flatNavItems[j].isSkippedInNav) {
+          prev = flatNavItems[j];
           break;
         }
       }
     }
     // get the "next" record link to display (that is an actual link)
-    // skip "/docs/rpc" and "/docs/terminology" when setting next page
     if (flatNavItems.length >= i + 1) {
       for (let j = i + 1; j < flatNavItems.length; j++) {
-        if (
-          !!flatNavItems[j]?.href &&
-          flatNavItems[j].href !== "/docs/rpc" &&
-          flatNavItems[j].href !== "/docs/terminology"
-        ) {
+        if (!!flatNavItems[j]?.href && !flatNavItems[j].isSkippedInNav) {
           next = flatNavItems[j];
           break;
         }

--- a/src/app/api/content/[...slug]/route.ts
+++ b/src/app/api/content/[...slug]/route.ts
@@ -71,7 +71,7 @@ export function GET(req: Request, { params: { slug } }: RouteProps) {
     // get the "previous" record link to display (that is an actual link)
     if (i > 0) {
       for (let j = i - 1; j >= 0; j--) {
-        if (!!flatNavItems[j]?.href && !flatNavItems[j].isSkippedInNav) {
+        if (Boolean(flatNavItems[j]?.href) && !flatNavItems[j].isSkippedInNav) {
           prev = flatNavItems[j];
           break;
         }
@@ -80,7 +80,7 @@ export function GET(req: Request, { params: { slug } }: RouteProps) {
     // get the "next" record link to display (that is an actual link)
     if (flatNavItems.length >= i + 1) {
       for (let j = i + 1; j < flatNavItems.length; j++) {
-        if (!!flatNavItems[j]?.href && !flatNavItems[j].isSkippedInNav) {
+        if (Boolean(flatNavItems[j]?.href) && !flatNavItems[j].isSkippedInNav) {
           next = flatNavItems[j];
           break;
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,8 @@ type NavItemBase = {
    */
   items?: Array<any>;
   altRoutes?: string[] | undefined;
+  isSkippedInNav?: boolean;
+  isHiddenInNavSidebar?: boolean;
 };
 
 export type NavItem = NavItemBase & {

--- a/src/utils/navItem.ts
+++ b/src/utils/navItem.ts
@@ -240,6 +240,8 @@ export function computeNavItem(
     sidebarSortOrder: doc?.sidebarSortOrder,
     metaOnly: doc?.metaOnly,
     altRoutes: doc.altRoutes,
+    isSkippedInNav: doc?.isSkippedInNav,
+    isHiddenInNavSidebar: doc?.isHiddenInNavSidebar,
   };
 
   // compute a label based on the doc's file name


### PR DESCRIPTION
Skip rpc and terminology pages when setting next/previous page routes

- `/doc` now skips over rpc and terminology page on next navigation
- `/docs/terminology` now skips rpc page on previous navigation

![CleanShot 2024-07-22 at 16 08 46](https://github.com/user-attachments/assets/8ccea07d-a198-4dc1-b719-44de1508ecda)
