### PR TITLE
migrate local development refs from cookbook

### DIFF
--- a/content/cookbook/development/connect-environment.md
+++ b/content/cookbook/development/connect-environment.md
@@ -1,0 +1,32 @@
+---
+title: Connecting to a Solana Environment
+sidebarSortOrder: 2
+description: "Learn how to connect to a Solana environment."
+---
+
+When you are working on Solana development, you will need to connect to a
+specific RPC API endpoint. Solana has 3 public development environments:
+
+- mainnet-beta https://api.mainnet-beta.solana.com
+- devnet https://api.devnet.solana.com
+- testnet https://api.testnet.solana.com
+
+```typescript filename="connect-to-environment.ts"
+import { clusterApiUrl, Connection } from "@solana/web3.js";
+
+(async () => {
+  const connection = new Connection(clusterApiUrl("mainnet-beta"), "confirmed");
+})();
+```
+
+Finally, you can also connect to a private cluster, either one local or running
+remotely with the following:
+
+```ts
+import { Connection } from "@solana/web3.js";
+
+(async () => {
+  // This will connect you to your local validator
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+})();
+```

--- a/content/cookbook/development/index.md
+++ b/content/cookbook/development/index.md
@@ -1,0 +1,6 @@
+---
+metaOnly: true
+sidebarLabel: Development
+title: Local Development
+sidebarSortOrder: 1
+---

--- a/content/cookbook/development/start-local-validator.md
+++ b/content/cookbook/development/start-local-validator.md
@@ -18,7 +18,7 @@ Benefits of using local-test-validator include:
 
 - No RPC rate-limits
 - No airdrop limits
-- Direct on-chain program deployment (`--bpf-program ...`)
+- Direct onchain program deployment (`--bpf-program ...`)
 - Clone accounts from a public cluster, including programs (`--clone ...`)
 - Configurable transaction history retention (`--limit-ledger-size ...`)
 - Configurable epoch length (`--slots-per-epoch ...`)

--- a/content/cookbook/development/start-local-validator.md
+++ b/content/cookbook/development/start-local-validator.md
@@ -1,0 +1,25 @@
+---
+title: How to Start a Local Validator
+sidebarSortOrder: 1
+description: "Learn how to start a local solana validator."
+---
+
+Testing your program code locally can be a lot more reliable than testing on
+devnet, and can help you test before trying it out on devnet.
+
+You can setup your local-test-validator by installing the
+[solana tool suite](/getting-started/installation.md#install-cli) and running
+
+```shell
+solana-test-validator
+```
+
+Benefits of using local-test-validator include:
+
+- No RPC rate-limits
+- No airdrop limits
+- Direct on-chain program deployment (`--bpf-program ...`)
+- Clone accounts from a public cluster, including programs (`--clone ...`)
+- Configurable transaction history retention (`--limit-ledger-size ...`)
+- Configurable epoch length (`--slots-per-epoch ...`)
+- Jump to an arbitrary slot (`--warp-slot ...`)

--- a/content/cookbook/development/subscribing-events.md
+++ b/content/cookbook/development/subscribing-events.md
@@ -1,0 +1,44 @@
+---
+title: Subscribing to Events
+sidebarSortOrder: 4
+description: Learn how to subscribe to events in the Solana network.
+---
+
+Websockets provide a pub/sub interface where you can listen for certain events.
+Instead of pinging a typical HTTP endpoint at an interval to get frequent
+updates, you can instead receive those updates only when they happen.
+
+Solana's web3
+[`Connection`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html)
+under the hood generates a websocket endpoint and registers a websocket client
+when you create a new `Connection` instance (see source code
+[here](https://github.com/solana-labs/solana-web3.js/blob/45923ca00e4cc1ed079d8e55ecbee83e5b4dc174/src/connection.ts#L2100)).
+
+The `Connection` class exposes pub/sub methods - they all start with `on`, like
+event emitters. When you call these listener methods, it registers a new
+subscription to the websocket client of that `Connection` instance. The example
+pub/sub method we use below is
+[`onAccountChange`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#onAccountChange).
+The callback will provide the updated state data through arguments (see
+[`AccountChangeCallback`](https://solana-labs.github.io/solana-web3.js/modules.html#AccountChangeCallback)
+as an example).
+
+```typescript filename="subscribe-to-events.ts"
+import { clusterApiUrl, Connection, Keypair } from "@solana/web3.js";
+
+(async () => {
+  // Establish new connect to devnet - websocket client connected to devnet will also be registered here
+  const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+
+  // Create a test wallet to listen to
+  const wallet = Keypair.generate();
+
+  // Register a callback to listen to the wallet (ws subscription)
+  connection.onAccountChange(
+    wallet.publicKey(),
+    (updatedAccountInfo, context) =>
+      console.log("Updated account info: ", updatedAccountInfo),
+    "confirmed",
+  );
+})();
+```

--- a/content/cookbook/development/test-sol.md
+++ b/content/cookbook/development/test-sol.md
@@ -19,8 +19,7 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
     keypair.publicKey,
     LAMPORTS_PER_SOL,
   );
-  const { blockhash, lastValidBlockHeight } =
-    await connection.getLatestBlockhash();
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
   await connection.confirmTransaction({
     blockhash,
     lastValidBlockHeight,

--- a/content/cookbook/development/test-sol.md
+++ b/content/cookbook/development/test-sol.md
@@ -19,7 +19,8 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
     keypair.publicKey,
     LAMPORTS_PER_SOL,
   );
-  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash();
   await connection.confirmTransaction({
     blockhash,
     lastValidBlockHeight,

--- a/content/cookbook/development/test-sol.md
+++ b/content/cookbook/development/test-sol.md
@@ -1,0 +1,30 @@
+---
+title: Getting Test SOL
+sidebarSortOrder: 3
+description: Learn how to get test SOL for development purposes.
+---
+
+When you're working locally, you need some SOL in order to send transactions. In
+non-mainnet environments you can receive SOL by airdropping it to your address
+
+```typescript filename="get-test-sol.ts"
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+
+(async () => {
+  const keypair = Keypair.generate();
+
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+
+  const signature = await connection.requestAirdrop(
+    keypair.publicKey,
+    LAMPORTS_PER_SOL,
+  );
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash();
+  await connection.confirmTransaction({
+    blockhash,
+    lastValidBlockHeight,
+    signature,
+  });
+})();
+```

--- a/content/cookbook/development/using-mainnet-accounts-programs.md
+++ b/content/cookbook/development/using-mainnet-accounts-programs.md
@@ -6,7 +6,7 @@ description:
   environment.
 ---
 
-Oftentimes, local tests rely on programs and accounts available only on mainnet.
+Oftentimes, local tests rely on programs and accounts that are not available on the local validator by default.  
 The Solana CLI allows to both:
 
 - Download Programs and Accounts
@@ -14,7 +14,7 @@ The Solana CLI allows to both:
 
 ### How to load accounts from mainnet
 
-It is possible to download the SRM token mint account to file:
+It is possible to download the JUP token mint account to file:
 
 ```shell
 # solana account -u <source cluster> --output <output format> --output-file <destination file name/path> <address of account to fetch>

--- a/content/cookbook/development/using-mainnet-accounts-programs.md
+++ b/content/cookbook/development/using-mainnet-accounts-programs.md
@@ -1,0 +1,45 @@
+---
+title: Using Mainnet Accounts and Programs
+sidebarSortOrder: 5
+description:
+  Learn how to use the Mainnet accounts and programs in your local development
+  environment.
+---
+
+Oftentimes, local tests rely on programs and accounts available only on mainnet.
+The Solana CLI allows to both:
+
+- Download Programs and Accounts
+- Load Programs and Accounts to a local validator
+
+### How to load accounts from mainnet
+
+It is possible to download the SRM token mint account to file:
+
+```shell
+# solana account -u <source cluster> --output <output format> --output-file <destination file name/path> <address of account to fetch>
+solana account -u m --output json-compact --output-file jup.json JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN
+```
+
+Loading it to your localnet is then done by passing the account's file and
+destination address (on the local cluster) when starting the validator:
+
+```shell
+# solana-test-validator --account <address to load the account to> <path to account file> --reset
+solana-test-validator --account JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN jup.json --reset
+```
+
+Similarly, it is possible to download the Openbook program:
+
+```shell
+# solana program dump -u <source cluster> <address of account to fetch> <destination file name/path>
+solana program dump -u m srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX openbook.so
+```
+
+Loading it to your localnet is then done by passing the program's file and
+destination address (on the local cluster) when starting the validator:
+
+```shell
+# solana-test-validator --bpf-program <address to load the program to> <path to program file> --reset
+solana-test-validator --bpf-program srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX openbook.so --reset
+```

--- a/content/cookbook/development/using-mainnet-accounts-programs.md
+++ b/content/cookbook/development/using-mainnet-accounts-programs.md
@@ -6,7 +6,8 @@ description:
   environment.
 ---
 
-Oftentimes, local tests rely on programs and accounts that are not available on the local validator by default.  
+Oftentimes, local tests rely on programs and accounts that are not available on
+the local validator by default.  
 The Solana CLI allows to both:
 
 - Download Programs and Accounts


### PR DESCRIPTION
from: https://solanacookbook.com/references/local-development.html#starting-a-local-validator

to: https://solana.com/developers/cookbook/development/start-local-validator