### PR TITLE
Add new token extensions lessons from Unboxed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,7 @@ corresponding path within this repo and webpage for viewing on solana.com:
 | ------------ | ------------------------------------------- | --------------------------------------------------------- |
 | `docs`       | [`/docs`](/docs/)                           | [View Docs](https://solana.com/docs)                      |
 | `rpc`        | [`/docs/rpc`](/docs/rpc/)                   | [View Docs](https://solana.com/docs/rpc)                  |
+| `courses`    | [`/content/courses`](/content/courses/)     | [View Courses](https://solana.com/developers/courses)     |
 | `guides`     | [`/content/guides`](/content/guides/)       | [View Guides](https://solana.com/developers/guides)       |
 | `resources`  | [`/content/resources`](/content/resources/) | [View Resources](https://solana.com/developers/resources) |
 | `cookbook`   | [`/content/cookbook`](/content/cookbook)    | [View Cookbook](https://solana.com/developers/cookbook)   |

--- a/content/courses/token-extensions/cpi-guard.md
+++ b/content/courses/token-extensions/cpi-guard.md
@@ -1,0 +1,1403 @@
+---
+title: CPI Guard
+objectives:
+  - Explain what the CPI Guard protects against
+  - Write code to test the CPI Guard
+---
+
+# Summary
+
+- `CPI Guard` is a token account extension from the Token Extensions Program
+- The `CPI Guard` extension prohibits certain actions inside cross-program
+  invocations. When enabled, the guard provides protections against various
+  potentially malicious actions on a token account
+- `CPI Guard` can be enabled or disabled at will
+- These protections are enforced within the `Token Extensions Program` itself
+
+# Overview
+
+CPI Guard is an extension that prohibits certain actions inside cross-program
+invocations, protecting users from implicitly signing for actions they can't
+see, such as those hidden in programs that aren't the System or Token programs.
+
+A specific example of this is when the CPI gaurd is enabled, no CPI can approve
+a delegate over a token account. This is handy, because if a malicious CPI calls
+`set_delegate` no immediate balance change will be apparent, however the
+attacker now has transfer and burn authority over the token account. CPI gaurd
+makes this impossible.
+
+Users may choose to enable or disable the CPI Guard extension on their token
+account at will. When enabled, it has the following effects during a CPI:
+
+- Transfer: the signing authority must be the owner or previously established
+  account delegate
+- Burn: the signing authority must be the owner or previously established
+  account delegate
+- Approve: prohibited - no delegates can be approved within the CPI
+- Close Account: the lamport destination must be the account owner
+- Set Close Authority: prohibited unless unsetting
+- Set Owner: always prohibited, including outside CPI
+
+The CPI Guard is a token account extension, meaning each individual Token
+Extensions Program token account has to enable it.
+
+## How the CPI Guard Works
+
+The CPI Guard can be enabled and disabled on a token account that was created
+with enough space for the extension. The `Token Extensions Program` runs a few
+checks in the logic related to the above actions to determine if it should allow
+an instruction to continue or not related to CPI Guards. Generally, what it does
+is the following:
+
+- Check if the account has the CPI Guard extension
+- Check if CPI Guard is enabled on the token account
+- Check if the function is being executed within a CPI
+
+A good way to think about the CPI Guard token extension is simply as a lock that
+is either enabled or disabled. The guard uses a
+[data struct called `CpiGuard`](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/extension/cpi_guard/mod.rs#L24)
+that stores a boolean value. That value indicates whether the guard is enabled
+or disabled. The CPI Guard extension only has two instructions, `Enable` and
+`Disable`. They each toggle this boolean value.
+
+```rust
+pub struct CpiGuard {
+    /// Lock privileged token operations from happening via CPI
+    pub lock_cpi: PodBool,
+}
+```
+
+The CPI Guard has two additional helper functions that the
+`Token Extensions Program` is able to use to help determine when the CPI Guard
+is enabled and when the instruction is being executed as part of a CPI. The
+first, `cpi_guard_enabled()`, simply returns the current value of the
+`CpiGuard.lock_cpi` field if the extension exists on the account, otherwise, it
+returns false. The rest of the program can use this function to determine if the
+guard is enabled or not.
+
+```rust
+/// Determine if CPI Guard is enabled for this account
+pub fn cpi_guard_enabled(account_state: &StateWithExtensionsMut<Account>) -> bool {
+    if let Ok(extension) = account_state.get_extension::<CpiGuard>() {
+        return extension.lock_cpi.into();
+    }
+    false
+}
+```
+
+The second helper function is called `in_cpi()` and determines whether or not
+the current instruction is within a CPI. The function is able to determine if
+it's currently in a CPI by calling
+[`get_stack_height()` from the `solana_program` rust crate](https://docs.rs/solana-program/latest/solana_program/instruction/fn.get_stack_height.html).
+This function returns the current stack height of instructions. Instructions
+created at the initial transaction level will have a height of
+[`TRANSACTION_LEVEL_STACK_HEIGHT`](https://docs.rs/solana-program/latest/solana_program/instruction/constant.TRANSACTION_LEVEL_STACK_HEIGHT.html)
+or 1. The first inner invoked transaction, or CPI, will have a height of
+`TRANSACTION_LEVEL_STACK_HEIGHT` + 1 and so on. With this information, we know
+that if `get_stack_height()` returns a value greater than
+`TRANSACTION_LEVEL_STACK_HEIGHT`, we're currently in a CPI! This is exactly what
+the `in_cpi()` function checks. If
+`get_stack_height() > TRANSACTION_LEVEL_STACK_HEIGHT`, it returns `True`.
+Otherwise, it returns `False`.
+
+```rust
+/// Determine if we are in CPI
+pub fn in_cpi() -> bool {
+    get_stack_height() > TRANSACTION_LEVEL_STACK_HEIGHT
+}
+```
+
+Using these two helper functions, the `Token Extensions Program` can easily
+determine if it should reject an instruction or not.
+
+## Toggle CPI Guard
+
+To toggle the CPI Guard on/off, a Token Account must have been initialized for
+this specific extension. Then, an instruction can be sent to enable the CPI
+Guard. This can only be done from a client. _You cannot toggle the CPI Guard via
+CPI_. The `Enable` instruction
+[checks if it was invoked via CPI and will return an error if so](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/extension/cpi_guard/processor.rs#L44).
+This means only the end user can toggle the CPI Guard.
+
+```rust
+// inside process_toggle_cpi_guard()
+if in_cpi() {
+    return Err(TokenError::CpiGuardSettingsLocked.into());
+}
+```
+
+You can enable the CPI using the
+[`@solana/spl-token` Typescript package](https://solana-labs.github.io/solana-program-library/token/js/modules.html).
+Here is an example.
+
+```typescript
+// create token account with the CPI Guard extension
+const tokenAccount = tokenAccountKeypair.publicKey;
+const extensions = [ExtensionType.CpiGuard];
+const tokenAccountLen = getAccountLen(extensions);
+const lamports =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountLen);
+
+const createTokenAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: tokenAccount,
+  space: tokenAccountLen,
+  lamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+
+// create 'enable CPI Guard' instruction
+const enableCpiGuardInstruction = createEnableCpiGuardInstruction(
+  tokenAccount,
+  owner.publicKey,
+  [],
+  TOKEN_2022_PROGRAM_ID,
+);
+
+const initializeAccountInstruction = createInitializeAccountInstruction(
+  tokenAccount,
+  mint,
+  owner.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+// construct transaction with these instructions
+const transaction = new Transaction().add(
+  createTokenAccountInstruction,
+  initializeAccountInstruction,
+  enableCpiGuardInstruction,
+);
+
+transaction.feePayer = payer.publicKey;
+// Send transaction
+await sendAndConfirmTransaction(connection, transaction, [
+  payer,
+  owner,
+  tokenAccountKeypair,
+]);
+```
+
+You can also use the
+[`enableCpiGuard`](https://solana-labs.github.io/solana-program-library/token/js/functions/enableCpiGuard.html)
+and
+[`disableCpiGuard`](https://solana-labs.github.io/solana-program-library/token/js/functions/disableCpiGuard.html)
+helper functions from the `@solana/spl-token` API after the account as been
+initialized.
+
+```typescript
+// enable CPI Guard
+await enableCpiGuard(
+  connection, // connection
+  payer, // payer
+  userTokenAccount.publicKey, // account
+  payer, // owner
+  [], // multiSigners
+);
+
+// disable CPI Guard
+await disableCpiGuard(
+  connection, // connection
+  payer, // payer
+  userTokenAccount.publicKey, // account
+  payer, // owner
+  [], // multiSigners
+);
+```
+
+## CPI Guard Protections
+
+### Transfer
+
+The transfer feature of the CPI Guard prevents anyone but the account delegate
+from authorizing a transfer instruction. This is enforced in the various
+transfer functions in the `Token Extensions Program`. For example,
+[looking at the `transfer` instruction](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/processor.rs#L428)
+we can see a check that will return an error if the required circumstances are
+met.
+
+Using the helper functions we discussed above, the program is able to determine
+if it should throw an error or not.
+
+```rust
+// inside process_transfer in the token extensions program
+if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
+    if cpi_guard.lock_cpi.into() && in_cpi() {
+        return Err(TokenError::CpiGuardTransferBlocked.into());
+    }
+}
+```
+
+This guard means that not even the owner of a token account can transfer tokens
+out of the account while another account is an authorized delegate.
+
+### Burn
+
+This CPI Guard also ensures only the account delegate can burn tokens from a
+token account, just like the transfer protection.
+
+The `process_burn` function in the `Token Extension Program` functions in the
+same way as the transfer instructions. It will
+[return an error under the same circumstances](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/processor.rs#L1076).
+
+```rust
+// inside process_burn in the token extensions program
+if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
+    if cpi_guard.lock_cpi.into() && in_cpi() {
+        return Err(TokenError::CpiGuardBurnBlocked.into());
+    }
+}
+```
+
+This guard means that not even the owner of a token account can burn tokens out
+of the account while another account is an authorized delegate.
+
+### Approve
+
+The CPI Guard prevents from approving a delegate of a token account via CPI. You
+can approve a delegate via a client instruction, but not CPI. The
+`process_approve` function of the `Token Extension Program` runs the
+[same checks to determine if the guard is enabled and its currently in a CPI](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/processor.rs#L583).
+
+This means an end user is not at risk of signing a transaction that indirectly
+approves a delegate over their token account without the knowledge of the user.
+Before, the user was at the mercy of their wallet to notify them of transactions
+like this ahead of time.
+
+### Close
+
+To close a token account via CPI, having the guard enabled means that the
+`Token Extensions Program` will check that the
+[destination account receiving the token account's lamports is the account owner](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/processor.rs#L1128).
+
+Here is the exact code block from the `process_close_account` function.
+
+```rust
+if !source_account
+    .base
+    .is_owned_by_system_program_or_incinerator()
+{
+    if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
+        if cpi_guard.lock_cpi.into()
+            && in_cpi()
+            && !cmp_pubkeys(destination_account_info.key, &source_account.base.owner)
+        {
+            return Err(TokenError::CpiGuardCloseAccountBlocked.into());
+        }
+    }
+...
+}
+```
+
+This guard protects the user from signing a transaction that closes a token
+account they own and transferring that account's lamports to another account via
+CPI. This would be hard to detect from an end user's perspective without
+inspecting the instructions themselves. This guard ensures those lamports are
+transferred only to their owner when closing a token account via CPI.
+
+### Set Close Authority
+
+The CPI Guard prevents from setting the `CloseAccount` authority via CPI, you
+can unset a previously set `CloseAccount` authority however. The
+`Token Extension Program` enforces this by
+[checking if a value has been passed in the `new_authority` parameter](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/processor.rs#L697)
+to the `process_set_authority` function.
+
+```rust
+AuthorityType::CloseAccount => {
+    let authority = account.base.close_authority.unwrap_or(account.base.owner);
+    Self::validate_owner(
+        program_id,
+        &authority,
+        authority_info,
+        authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    if let Ok(cpi_guard) = account.get_extension::<CpiGuard>() {
+        if cpi_guard.lock_cpi.into() && in_cpi() && new_authority.is_some() {
+            return Err(TokenError::CpiGuardSetAuthorityBlocked.into());
+        }
+    }
+
+    account.base.close_authority = new_authority;
+}
+```
+
+This guard prevents the user from signing a transaction that gives another
+account the ability to close their Token account behind the scenes.
+
+### Set Owner
+
+The CPI Guard prevents from changing the account owner in all circumstances,
+whether via CPI or not. The account authority is updated in the same
+`process_set_authority` function as the `CloseAccount` authority in the previous
+section. If the instruction is attempting to update the authority of an account
+with the CPI Guard enabled, the
+[function will return one of two possible errors](https://github.com/solana-labs/solana-program-library/blob/ce8e4d565edcbd26e75d00d0e34e9d5f9786a646/token/program-2022/src/processor.rs#L662).
+
+If the instruction is being executed in a CPI, the function will return a
+`CpiGuardSetAuthorityBlocked` error. Otherwise it will return a
+`CpiGuardOwnerChangeBlocked` error.
+
+```rust
+if let Ok(cpi_guard) = account.get_extension::<CpiGuard>() {
+    if cpi_guard.lock_cpi.into() && in_cpi() {
+        return Err(TokenError::CpiGuardSetAuthorityBlocked.into());
+    } else if cpi_guard.lock_cpi.into() {
+        return Err(TokenError::CpiGuardOwnerChangeBlocked.into());
+    }
+}
+```
+
+This guard prevents from changing the ownership of a Token account at all times
+when enabled.
+
+# Lab
+
+This lab will primarily focus on writing tests in TypeScript, but we'll need to
+run a program locally against these tests. For this reason, we'll need to go
+through a few steps to ensure a proper environment on your machine for the
+program to run. The onchain program has already been written for you and is
+included in the lab starter code.
+
+The onchain program contains a few instructions that showcase what the CPI Guard
+can protect against. We'll write tests invoking these instructions both with a
+CPI Guard enabled and disabled.
+
+The tests have been broken up into individual files in the `/tests` directory.
+Each file serves as its own unit test that will invoke a specific instruction on
+our program and illustrate a specific CPI Guard.
+
+The program has five instructions: `malicious_close_account`,
+`prohibited_approve_account`, `prohibited_set_authority`, `unauthorized_burn`,
+`set_owner`.
+
+Each of these instructions makes a CPI to the `Token Extensions Program` and
+attempts to take an action on the given token account that is potentially
+malicious unknowingly to the signer of the original transaction. We won't test
+the `Transfer` guard as it is same as the `Burn` guard.
+
+### 1. Verify Solana/Anchor/Rust Versions
+
+We'll be interacting with the `Token Extensions Program` in this lab and that
+requires you to have Solana CLI version ≥ 1.18.0.
+
+To check your version run:
+
+```bash
+solana --version
+```
+
+If the version printed out after running `solana --version` is less than
+`1.18.0` then you can update the CLI version manually. Note, at the time of
+writing this, you cannot simply run the `solana-install update` command. This
+command will not update the CLI to the correct version for us, so we have to
+explicitly download version `1.18.0`. You can do so with the following command:
+
+```bash
+solana-install init 1.18.0
+```
+
+If you run into this error at any point attempting to build the program, that
+likely means you do not have the correct version of the Solana CLI installed.
+
+```bash
+anchor build
+error: package `solana-program v1.18.0` cannot be built because it requires rustc 1.72.0 or newer, while the currently active rustc version is 1.68.0-dev
+Either upgrade to rustc 1.72.0 or newer, or use
+cargo update -p solana-program@1.18.0 --precise ver
+where `ver` is the latest version of `solana-program` supporting rustc 1.68.0-dev
+```
+
+You will also want the `0.29.0` version of the Anchor CLI installed. You can
+follow the steps listed here to update via avm
+https://www.anchor-lang.com/docs/avm
+
+or simply run
+
+```bash
+avm install 0.29.0
+avm use 0.29.0
+```
+
+At the time of writing, the latest version of the Anchor CLI is `0.29.0`
+
+Now, we can check our rust version.
+
+```bash
+rustc --version
+```
+
+At the time of writing, version `1.26.0` was used for the Rust compiler. If you
+would like to update, you can do so via `rustup`
+https://doc.rust-lang.org/book/ch01-01-installation.html
+
+```bash
+rustup update
+```
+
+Now, we should have all the correct versions installed.
+
+### 2. Get starter code and add dependencies
+
+Let's grab the starter branch.
+
+```bash
+git clone https://github.com/Unboxed-Software/solana-lab-cpi-guard
+cd solana-lab-cpi-guard
+git checkout starter
+```
+
+### 3. Update Program ID and Anchor Keypair
+
+Once in the starter branch, run
+
+`anchor keys sync`
+
+This will replace the program ID in various locations with your new program
+keypair.
+
+Then set your developer keypair path in `Anchor.toml`.
+
+```toml
+[provider]
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+```
+
+"~/.config/solana/id.json" is the most common keypair path, but if you're
+unsure, just run:
+
+```bash
+solana config get
+```
+
+### 4. Confirm the program builds
+
+Let's build the starter code to confirm we have everything configured correctly.
+If it does not build, please revisit the steps above.
+
+```bash
+anchor build
+```
+
+You can safely ignore the warnings of the build script, these will go away as we
+add in the necessary code.
+
+Feel free to run the provided tests to make sure the rest of the dev environment
+is setup correctly. You'll have to install the node dependencies using `npm` or
+`yarn`. The tests should run, but they do not do anything currently.
+
+```bash
+yarn install
+anchor test
+```
+
+### 5. Create token with CPI Guard
+
+Before we write any tests, let's create a helper function that will create a
+Token account with the CPI Guard extension. Let's do this in a new file
+`tests/token-helper.ts` and a new function called
+`createTokenAccountWithCPIGuard`.
+
+Internally, this function will call:
+
+- `SystemProgram.createAccount`: Allocates space for the token account
+- `createInitializeAccountInstruction`: Initializes the token account
+- `createEnableCpiGuardInstruction`: Enables the CPI Guard
+
+```ts
+import {
+  ExtensionType,
+  TOKEN_2022_PROGRAM_ID,
+  createEnableCpiGuardInstruction,
+  createInitializeAccountInstruction,
+  getAccountLen,
+} from "@solana/spl-token";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+
+export async function createTokenAccountWithCPIGuard(
+  connection: Connection,
+  payer: Keypair,
+  owner: Keypair,
+  tokenAccountKeypair: Keypair,
+  mint: PublicKey,
+): Promise<string> {
+  const tokenAccount = tokenAccountKeypair.publicKey;
+
+  const extensions = [ExtensionType.CpiGuard];
+
+  const tokenAccountLen = getAccountLen(extensions);
+  const lamports =
+    await connection.getMinimumBalanceForRentExemption(tokenAccountLen);
+
+  const createTokenAccountInstruction = SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: tokenAccount,
+    space: tokenAccountLen,
+    lamports,
+    programId: TOKEN_2022_PROGRAM_ID,
+  });
+
+  const initializeAccountInstruction = createInitializeAccountInstruction(
+    tokenAccount,
+    mint,
+    owner.publicKey,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  const enableCpiGuardInstruction = createEnableCpiGuardInstruction(
+    tokenAccount,
+    owner.publicKey,
+    [],
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  const transaction = new Transaction().add(
+    createTokenAccountInstruction,
+    initializeAccountInstruction,
+    enableCpiGuardInstruction,
+  );
+
+  transaction.feePayer = payer.publicKey;
+
+  // Send transaction
+  return await sendAndConfirmTransaction(connection, transaction, [
+    payer,
+    owner,
+    tokenAccountKeypair,
+  ]);
+}
+```
+
+### 5. Approve delegate
+
+The first CPI Guard we'll test is the approve delegate functionality. The CPI
+Guard prevents approving a delegate of a token account with the CPI Guard
+enabled via CPI completely. It's important to note that you can approve a
+delegate on a CPI Guarded account, just not with a CPI. To do so, you must send
+an instruction directly to the `Token Extensions Program` from a client rather
+than via another program.
+
+Before we write our test, we need to take a look at the program code we are
+testing. The `prohibited_approve_account` instruction is what we'll be targeting
+here.
+
+```rust
+// inside src/lib.rs
+pub fn prohibited_approve_account(ctx: Context<ApproveAccount>, amount: u64) -> Result<()> {
+    msg!("Invoked ProhibitedApproveAccount");
+
+    msg!(
+        "Approving delegate: {} to transfer up to {} tokens.",
+        ctx.accounts.delegate.key(),
+        amount
+    );
+
+    approve(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Approve {
+                to: ctx.accounts.token_account.to_account_info(),
+                delegate: ctx.accounts.delegate.to_account_info(),
+                authority: ctx.accounts.authority.to_account_info(),
+            },
+        ),
+        amount,
+    )
+}
+...
+
+#[derive(Accounts)]
+pub struct ApproveAccount<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        mut,
+        token::token_program = token_program,
+        token::authority = authority
+    )]
+    pub token_account: InterfaceAccount<'info, token_interface::TokenAccount>,
+    /// CHECK: delegat to approve
+    #[account(mut)]
+    pub delegate: AccountInfo<'info>,
+    pub token_program: Interface<'info, token_interface::TokenInterface>,
+}
+```
+
+If you are familiar with Solana programs, then this should look like a pretty
+simple instruction. The instruction expects an `authority` account as a `Signer`
+and a `token_account` that `authority` is the authority of.
+
+The instruction then invokes the `Approve` instruction on the
+`Token Extensions Program` and attempts to assign `delegate` as the delegate
+over the given `token_account`.
+
+Let's open the `/tests/approve-delegate-example.ts` file to begin testing this
+instruction. Take a look at the starting code. We have a payer, some test
+keypairs and an `airdropIfRequired` function that will run before the tests.
+
+Once you feel comfortable with the starting code, we can move on to the 'Approve
+Delegate' tests. We will make tests that invoke the same exact instruction in
+our target program, with and without CPI guard.
+
+To test our instruction, we first need to create our token mint and a token
+account with extensions.
+
+```typescript
+it("stops 'Approve Delegate' when CPI guard is enabled", async () => {
+  await createMint(
+    provider.connection,
+    payer,
+    provider.wallet.publicKey,
+    undefined,
+    6,
+    testTokenMint,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+  await createTokenAccountWithCPIGuard(
+    provider.connection,
+    payer,
+    payer,
+    userTokenAccount,
+    testTokenMint.publicKey,
+  );
+});
+```
+
+Now let's send a transaction to our program that will attempt to invoke the
+'Approve delegate' instruction on the `Token Extensions Program`.
+
+```typescript
+// inside "allows 'Approve Delegate' when CPI guard is disabled" test block
+try {
+  const tx = await program.methods
+    .prohibitedApproveAccount(new anchor.BN(1000))
+    .accounts({
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      delegate: maliciousAccount.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+
+  console.log("Your transaction signature", tx);
+} catch (e) {
+  assert(
+    e.message ==
+      "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2d",
+  );
+  console.log(
+    "CPI Guard is enabled, and a program attempted to approve a delegate",
+  );
+}
+```
+
+Notice we wrap this in a try/catch block. This is because this instruction
+should fail if the CPI Guard works correctly. We catch the error and assert that
+the error message is what we expect.
+
+Now, we essentially do the same thing for the
+`"allows 'Approve Delegate' when CPI guard is disabled"` test, except we want to
+pass in a token account without a CPI Guard. To do this, we can simply disable
+the CPI Guard on the `userTokenAccount` and resend the transaction.
+
+```typescript
+it("allows 'Approve Delegate' when CPI guard is disabled", async () => {
+  await disableCpiGuard(
+    provider.connection,
+    payer,
+    userTokenAccount.publicKey,
+    payer,
+    [],
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await program.methods
+    .prohibitedApproveAccount(new anchor.BN(1000))
+    .accounts({
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      delegate: maliciousAccount.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+});
+```
+
+This transaction will succeed and the `delegate` account will now have the
+authority to transfer the given amount of tokens from the `userTokenAccount`.
+
+Feel free to save your work and run `anchor test`. All of the tests will run,
+but these two are the only ones that are doing anything yet. They should both
+pass at this point.
+
+### 6. Close Account
+
+The close account instruction invokes the `close_account` instruction on the
+`Token Extensions Program`. This closes the given token account. However, you
+have the ability to define which account the returned rent lamports should be
+transferred to. The CPI Guard ensures that this account is always the account
+owner.
+
+```rust
+pub fn malicious_close_account(ctx: Context<MaliciousCloseAccount>) -> Result<()> {
+    msg!("Invoked MaliciousCloseAccount");
+
+    msg!(
+        "Token account to close : {}",
+        ctx.accounts.token_account.key()
+    );
+
+    close_account(CpiContext::new(
+        ctx.accounts.token_program.to_account_info(),
+        CloseAccount {
+            account: ctx.accounts.token_account.to_account_info(),
+            destination: ctx.accounts.destination.to_account_info(),
+            authority: ctx.accounts.authority.to_account_info(),
+        },
+    ))
+}
+
+...
+
+#[derive(Accounts)]
+pub struct MaliciousCloseAccount<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        mut,
+        token::token_program = token_program,
+        token::authority = authority
+    )]
+    pub token_account: InterfaceAccount<'info, token_interface::TokenAccount>,
+    /// CHECK: malicious account
+    #[account(mut)]
+    pub destination: AccountInfo<'info>,
+    pub token_program: Interface<'info, token_interface::TokenInterface>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+Our program just invokes the `close_account` instruction, but a potentially
+malicious client could pass in a different account than the token account owner
+as the `destination` account. This would be hard to see from a user's
+perspective unless the wallet notified them. With CPI Guards enabled, the
+`Token Extension Program` will simply reject the instruction if that is the
+case.
+
+To test this, we'll open up the `/tests/close-account-example.ts` file. The
+starting code here is the same as our previous test.
+
+First, let's create our mint and CPI guarded token account:
+
+```typescript
+it("stops 'Close Account' when CPI guard in enabled", async () => {
+  await createMint(
+    provider.connection,
+    payer,
+    provider.wallet.publicKey,
+    undefined,
+    6,
+    testTokenMint,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+  await createTokenAccountWithCPIGuard(
+    provider.connection,
+    payer,
+    payer,
+    userTokenAccount,
+    testTokenMint.publicKey,
+  );
+});
+```
+
+Now let's send a transaction to our `malicious_close_account` instruction. Since
+we have the CPI Guard enabled on this token account, the transaction should
+fail. Our test verifies it fails for the expected reason.
+
+```typescript
+// inside "stops 'Close Account' when CPI guard in enabled" test block
+try {
+  const tx = await program.methods
+    .maliciousCloseAccount()
+    .accounts({
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      destination: maliciousAccount.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+
+  console.log("Your transaction signature", tx);
+} catch (e) {
+  assert(
+    e.message ==
+      "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2c",
+  );
+  console.log(
+    "CPI Guard is enabled, and a program attempted to close an account without returning lamports to owner",
+  );
+}
+```
+
+Now, we can disable the CPI Guard and send the same exact transaction in the
+`"Close Account without CPI Guard"` test. This transaction should succeed this
+time.
+
+```typescript
+it("Close Account without CPI Guard", async () => {
+  await disableCpiGuard(
+    provider.connection,
+    payer,
+    userTokenAccount.publicKey,
+    payer,
+    [],
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await program.methods
+    .maliciousCloseAccount()
+    .accounts({
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      destination: maliciousAccount.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+});
+```
+
+### 7. Set Authority
+
+Moving on to the `prohibited_set_authority` instruction, the CPI Guard protects
+against a CPI setting the `CloseAccount` authority.
+
+```rust
+pub fn prohibted_set_authority(ctx: Context<SetAuthorityAccount>) -> Result<()> {
+    msg!("Invoked ProhibitedSetAuthority");
+
+    msg!(
+        "Setting authority of token account: {} to address: {}",
+        ctx.accounts.token_account.key(),
+        ctx.accounts.new_authority.key()
+    );
+
+    set_authority(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            SetAuthority {
+                current_authority: ctx.accounts.authority.to_account_info(),
+                account_or_mint: ctx.accounts.token_account.to_account_info(),
+            },
+        ),
+        spl_token_2022::instruction::AuthorityType::CloseAccount,
+        Some(ctx.accounts.new_authority.key()),
+    )
+}
+
+#[derive(Accounts)]
+pub struct SetAuthorityAccount<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        mut,
+        token::token_program = token_program,
+        token::authority = authority
+    )]
+    pub token_account: InterfaceAccount<'info, token_interface::TokenAccount>,
+    /// CHECK: delegat to approve
+    #[account(mut)]
+    pub new_authority: AccountInfo<'info>,
+    pub token_program: Interface<'info, token_interface::TokenInterface>,
+}
+```
+
+Our program instruction simply invokes the `SetAuthority` instruction and
+indicates we want to set the
+`spl_token_2022::instruction::AuthorityType::CloseAccount` authority of the
+given token account.
+
+Open the `/tests/set-authority-example.ts` file. The starter code is the same as
+the previous tests.
+
+Let's create our mint and CPI-guarded token account. Then, we can send a
+transaction to our `prohibited_set_authority` instruction.
+
+```typescript
+it("sets authority when CPI guard in enabled", async () => {
+  await createMint(
+    provider.connection,
+    payer,
+    provider.wallet.publicKey,
+    undefined,
+    6,
+    testTokenMint,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+  await createTokenAccountWithCPIGuard(
+    provider.connection,
+    payer,
+    payer,
+    userTokenAccount,
+    testTokenMint.publicKey,
+  );
+
+  try {
+    const tx = await program.methods
+      .prohibtedSetAuthority()
+      .accounts({
+        authority: payer.publicKey,
+        tokenAccount: userTokenAccount.publicKey,
+        newAuthority: maliciousAccount.publicKey,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      })
+      .signers([payer])
+      .rpc();
+
+    console.log("Your transaction signature", tx);
+  } catch (e) {
+    assert(
+      e.message ==
+        "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2e",
+    );
+    console.log(
+      "CPI Guard is enabled, and a program attempted to add or change an authority",
+    );
+  }
+});
+```
+
+For the `"Set Authority Example"` test, we can disable the CPI Guard and re-send
+the transaction.
+
+```typescript
+it("Set Authority Example", async () => {
+  await disableCpiGuard(
+    provider.connection,
+    payer,
+    userTokenAccount.publicKey,
+    payer,
+    [],
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await program.methods
+    .prohibtedSetAuthority()
+    .accounts({
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      newAuthority: maliciousAccount.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+});
+```
+
+### 8. Burn
+
+The next instruction we'll test is the `unauthorized_burn` instruction from our
+test program. This instruction invokes the `burn` instruction from the
+`Token Extensions Program` and attempts to burn a given amount of tokens from
+the given token account.
+
+The CPI Guard ensures that this is only possible if the signing authority is the
+token account delegate.
+
+```rust
+pub fn unauthorized_burn(ctx: Context<BurnAccounts>, amount: u64) -> Result<()> {
+    msg!("Invoked Burn");
+
+    msg!(
+        "Burning {} tokens from address: {}",
+        amount,
+        ctx.accounts.token_account.key()
+    );
+
+    burn(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Burn {
+                mint: ctx.accounts.token_mint.to_account_info(),
+                from: ctx.accounts.token_account.to_account_info(),
+                authority: ctx.accounts.authority.to_account_info(),
+            },
+        ),
+        amount,
+    )
+}
+
+...
+
+#[derive(Accounts)]
+pub struct BurnAccounts<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        mut,
+        token::token_program = token_program,
+        token::authority = authority
+    )]
+    pub token_account: InterfaceAccount<'info, token_interface::TokenAccount>,
+    #[account(
+        mut,
+        mint::token_program = token_program
+    )]
+    pub token_mint: InterfaceAccount<'info, token_interface::Mint>,
+    pub token_program: Interface<'info, token_interface::TokenInterface>,
+}
+```
+
+To test this, open up the `tests/burn-example.ts` file. The starter code is the
+same as the previous, except we swapped `maliciousAccount` to `delegate`.
+
+Then, we can create our mint and CPI-guarded token account.
+
+```typescript
+it("stops 'Burn' without a delegate signature", async () => {
+  await createMint(
+    provider.connection,
+    payer,
+    provider.wallet.publicKey,
+    undefined,
+    6,
+    testTokenMint,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await createTokenAccountWithCPIGuard(
+    provider.connection,
+    payer,
+    payer,
+    userTokenAccount,
+    testTokenMint.publicKey,
+  );
+});
+```
+
+Now, let's mint some tokens to our test account.
+
+```typescript
+// inside "stops 'Burn' without a delegate signature" test block
+const mintToTx = await mintTo(
+  provider.connection,
+  payer,
+  testTokenMint.publicKey,
+  userTokenAccount.publicKey,
+  payer,
+  1000,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+Now let's approve a delegate over our token account. This token account has a
+CPI Guard enabled currently, but we are still able to approve a delegate. This
+is because we are doing so by invoking the `Token Extensions Program` directly
+and not via a CPI like our earlier example.
+
+```typescript
+// inside "stops 'Burn' without a delegate signature" test block
+const approveTx = await approve(
+  provider.connection,
+  payer,
+  userTokenAccount.publicKey,
+  delegate.publicKey,
+  payer,
+  500,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+Now that we have a delegate over our token account, we can send a transaction to
+our program to attempt to burn some tokens. We'll be passing in the `payer`
+account as the authority. This account is the owner over the `userTokenAccount`,
+but since we have approved the `delegate` account as the delegate, the CPI Guard
+will prevent this transaction from going through.
+
+```typescript
+// inside "stops 'Burn' without a delegate signature" test block
+try {
+  const tx = await program.methods
+    .unauthorizedBurn(new anchor.BN(500))
+    .accounts({
+      // payer is not the delegate
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      tokenMint: testTokenMint.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+
+  console.log("Your transaction signature", tx);
+} catch (e) {
+  assert(
+    e.message ==
+      "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2b",
+  );
+  console.log(
+    "CPI Guard is enabled, and a program attempted to burn user funds without using a delegate.",
+  );
+}
+```
+
+For the `"Burn without Delegate Signature Example"` test, we'll simply disable
+the CPI Guard and re-send the transaction.
+
+```typescript
+it("Burn without Delegate Signature Example", async () => {
+  await disableCpiGuard(
+    provider.connection,
+    payer,
+    userTokenAccount.publicKey,
+    payer,
+    [],
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  const tx = await program.methods
+    .unauthorizedBurn(new anchor.BN(500))
+    .accounts({
+      // payer is not the delegate
+      authority: payer.publicKey,
+      tokenAccount: userTokenAccount.publicKey,
+      tokenMint: testTokenMint.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+});
+```
+
+### 9. Set Owner
+
+The last CPI Guard we'll test is the `SetOwner` protection. With the CPI Guard
+enabled, this action is always prohibited even outside of a CPI. To test this,
+we'll attempt to set the owner of a token account from the client side, as well
+as CPI via our test program.
+
+Here is the program instruction.
+
+```rust
+pub fn set_owner(ctx: Context<SetOwnerAccounts>) -> Result<()> {
+    msg!("Invoked SetOwner");
+
+    msg!(
+        "Setting owner of token account: {} to address: {}",
+        ctx.accounts.token_account.key(),
+        ctx.accounts.new_owner.key()
+    );
+
+    set_authority(
+        CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            SetAuthority {
+                current_authority: ctx.accounts.authority.to_account_info(),
+                account_or_mint: ctx.accounts.token_account.to_account_info(),
+            },
+        ),
+        spl_token_2022::instruction::AuthorityType::AccountOwner,
+        Some(ctx.accounts.new_owner.key()),
+    )
+}
+
+#[derive(Accounts)]
+pub struct SetOwnerAccounts<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        mut,
+        token::token_program = token_program,
+        token::authority = authority
+    )]
+    pub token_account: InterfaceAccount<'info, token_interface::TokenAccount>,
+    /// CHECK: delegat to approve
+    #[account(mut)]
+    pub new_owner: AccountInfo<'info>,
+    pub token_program: Interface<'info, token_interface::TokenInterface>,
+}
+```
+
+Open up the `/tests/set-owner-example.ts` file. There are four tests we'll write
+for this one. Two for setting the Owner without a CPI and two for setting the
+owner via CPI.
+
+Notice we've taken out `delegate` and added `firstNonCPIGuardAccount`,
+`secondNonCPIGuardAccount`, and `newOwner`.
+
+Starting with the first
+`"stops 'Set Authority' without CPI on a CPI-guarded account"` test, we'll
+create the mint and CPI-guarded token account.
+
+```typescript
+it("stops 'Set Authority' without CPI on a CPI-guarded account", async () => {
+  await createMint(
+    provider.connection,
+    payer,
+    provider.wallet.publicKey,
+    undefined,
+    6,
+    testTokenMint,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await createTokenAccountWithCPIGuard(
+    provider.connection,
+    payer,
+    payer,
+    userTokenAccount,
+    testTokenMint.publicKey,
+  );
+});
+```
+
+Then, we'll try to send a transaction to the `set_authority` instruction of the
+`Token Extensions Program` with the `setAuthority` function from the
+`@solana/spl-token` library.
+
+```typescript
+// inside the "stops 'Set Authority' without CPI on a CPI-guarded account" test block
+try {
+  await setAuthority(
+    provider.connection,
+    payer,
+    userTokenAccount.publicKey,
+    payer,
+    AuthorityType.AccountOwner,
+    newOwner.publicKey,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+} catch (e) {
+  assert(
+    e.message ==
+      "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2f",
+  );
+  console.log(
+    "Account ownership cannot be changed while CPI Guard is enabled.",
+  );
+}
+```
+
+This transaction should fail, so we wrap the call in a try/catch block and
+ensure the error is the expected error.
+
+Next, we'll create another token account without the CPI Guard enabled and
+attempt the same thing.
+
+```typescript
+it("Set Authority without CPI on Non-CPI Guarded Account", async () => {
+  await createAccount(
+    provider.connection,
+    payer,
+    testTokenMint.publicKey,
+    payer.publicKey,
+    firstNonCPIGuardAccount,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await setAuthority(
+    provider.connection,
+    payer,
+    firstNonCPIGuardAccount.publicKey,
+    payer,
+    AuthorityType.AccountOwner,
+    newOwner.publicKey,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+});
+```
+
+This test should succeed.
+
+Now, let's test this out using a CPI. To do that, we just have to send a
+transaction to the `set_owner` instruction of our program.
+
+```typescript
+it("[CPI Guard] Set Authority via CPI on CPI Guarded Account", async () => {
+  try {
+    await program.methods
+      .setOwner()
+      .accounts({
+        authority: payer.publicKey,
+        tokenAccount: userTokenAccount.publicKey,
+        newOwner: newOwner.publicKey,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      })
+      .signers([payer])
+      .rpc();
+  } catch (e) {
+    assert(
+      e.message ==
+        "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2e",
+    );
+    console.log(
+      "CPI Guard is enabled, and a program attempted to add or change an authority.",
+    );
+  }
+});
+```
+
+Lastly, we can create another token account without the CPI Guard enabled and
+pass this to the program instruction. This time, the CPI should go through.
+
+```typescript
+it("Set Authority via CPI on Non-CPI Guarded Account", async () => {
+  await createAccount(
+    provider.connection,
+    payer,
+    testTokenMint.publicKey,
+    payer.publicKey,
+    secondNonCPIGuardAccount,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await program.methods
+    .setOwner()
+    .accounts({
+      authority: payer.publicKey,
+      tokenAccount: secondNonCPIGuardAccount.publicKey,
+      newOwner: newOwner.publicKey,
+      tokenProgram: TOKEN_2022_PROGRAM_ID,
+    })
+    .signers([payer])
+    .rpc();
+});
+```
+
+And that is it! You should be able to save your work and run `anchor test`. All
+of the tests we have written should pass.
+
+# Challenge
+
+Write some tests for the Transfer functionality.

--- a/content/courses/token-extensions/cpi-guard.md
+++ b/content/courses/token-extensions/cpi-guard.md
@@ -3,6 +3,9 @@ title: CPI Guard
 objectives:
   - Explain what the CPI Guard protects against
   - Write code to test the CPI Guard
+description:
+  "Create tokens that don't allow certain accounts to be invoked from toher
+  programs."
 ---
 
 # Summary

--- a/content/courses/token-extensions/cpi-guard.md
+++ b/content/courses/token-extensions/cpi-guard.md
@@ -8,7 +8,7 @@ description:
   programs."
 ---
 
-# Summary
+## Summary
 
 - `CPI Guard` is a token account extension from the Token Extensions Program
 - The `CPI Guard` extension prohibits certain actions inside cross-program
@@ -17,7 +17,7 @@ description:
 - `CPI Guard` can be enabled or disabled at will
 - These protections are enforced within the `Token Extensions Program` itself
 
-# Overview
+## Overview
 
 CPI Guard is an extension that prohibits certain actions inside cross-program
 invocations, protecting users from implicitly signing for actions they can't
@@ -44,7 +44,7 @@ account at will. When enabled, it has the following effects during a CPI:
 The CPI Guard is a token account extension, meaning each individual Token
 Extensions Program token account has to enable it.
 
-## How the CPI Guard Works
+### How the CPI Guard Works
 
 The CPI Guard can be enabled and disabled on a token account that was created
 with enough space for the extension. The `Token Extensions Program` runs a few
@@ -113,7 +113,7 @@ pub fn in_cpi() -> bool {
 Using these two helper functions, the `Token Extensions Program` can easily
 determine if it should reject an instruction or not.
 
-## Toggle CPI Guard
+### Toggle CPI Guard
 
 To toggle the CPI Guard on/off, a Token Account must have been initialized for
 this specific extension. Then, an instruction can be sent to enable the CPI
@@ -207,9 +207,9 @@ await disableCpiGuard(
 );
 ```
 
-## CPI Guard Protections
+### CPI Guard Protections
 
-### Transfer
+#### Transfer
 
 The transfer feature of the CPI Guard prevents anyone but the account delegate
 from authorizing a transfer instruction. This is enforced in the various
@@ -233,7 +233,7 @@ if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
 This guard means that not even the owner of a token account can transfer tokens
 out of the account while another account is an authorized delegate.
 
-### Burn
+#### Burn
 
 This CPI Guard also ensures only the account delegate can burn tokens from a
 token account, just like the transfer protection.
@@ -254,7 +254,7 @@ if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
 This guard means that not even the owner of a token account can burn tokens out
 of the account while another account is an authorized delegate.
 
-### Approve
+#### Approve
 
 The CPI Guard prevents from approving a delegate of a token account via CPI. You
 can approve a delegate via a client instruction, but not CPI. The
@@ -266,7 +266,7 @@ approves a delegate over their token account without the knowledge of the user.
 Before, the user was at the mercy of their wallet to notify them of transactions
 like this ahead of time.
 
-### Close
+#### Close
 
 To close a token account via CPI, having the guard enabled means that the
 `Token Extensions Program` will check that the
@@ -297,7 +297,7 @@ CPI. This would be hard to detect from an end user's perspective without
 inspecting the instructions themselves. This guard ensures those lamports are
 transferred only to their owner when closing a token account via CPI.
 
-### Set Close Authority
+#### Set Close Authority
 
 The CPI Guard prevents from setting the `CloseAccount` authority via CPI, you
 can unset a previously set `CloseAccount` authority however. The
@@ -329,7 +329,7 @@ AuthorityType::CloseAccount => {
 This guard prevents the user from signing a transaction that gives another
 account the ability to close their Token account behind the scenes.
 
-### Set Owner
+#### Set Owner
 
 The CPI Guard prevents from changing the account owner in all circumstances,
 whether via CPI or not. The account authority is updated in the same
@@ -355,7 +355,7 @@ if let Ok(cpi_guard) = account.get_extension::<CpiGuard>() {
 This guard prevents from changing the ownership of a Token account at all times
 when enabled.
 
-# Lab
+## Lab
 
 This lab will primarily focus on writing tests in TypeScript, but we'll need to
 run a program locally against these tests. For this reason, we'll need to go
@@ -380,7 +380,7 @@ attempts to take an action on the given token account that is potentially
 malicious unknowingly to the signer of the original transaction. We won't test
 the `Transfer` guard as it is same as the `Burn` guard.
 
-### 1. Verify Solana/Anchor/Rust Versions
+#### 1. Verify Solana/Anchor/Rust Versions
 
 We'll be interacting with the `Token Extensions Program` in this lab and that
 requires you to have Solana CLI version ≥ 1.18.0.
@@ -441,7 +441,7 @@ rustup update
 
 Now, we should have all the correct versions installed.
 
-### 2. Get starter code and add dependencies
+#### 2. Get starter code and add dependencies
 
 Let's grab the starter branch.
 
@@ -451,7 +451,7 @@ cd solana-lab-cpi-guard
 git checkout starter
 ```
 
-### 3. Update Program ID and Anchor Keypair
+#### 3. Update Program ID and Anchor Keypair
 
 Once in the starter branch, run
 
@@ -475,7 +475,7 @@ unsure, just run:
 solana config get
 ```
 
-### 4. Confirm the program builds
+#### 4. Confirm the program builds
 
 Let's build the starter code to confirm we have everything configured correctly.
 If it does not build, please revisit the steps above.
@@ -496,7 +496,7 @@ yarn install
 anchor test
 ```
 
-### 5. Create token with CPI Guard
+#### 5. Create token with CPI Guard
 
 Before we write any tests, let's create a helper function that will create a
 Token account with the CPI Guard extension. Let's do this in a new file
@@ -580,7 +580,7 @@ export async function createTokenAccountWithCPIGuard(
 }
 ```
 
-### 5. Approve delegate
+#### 5. Approve delegate
 
 The first CPI Guard we'll test is the approve delegate functionality. The CPI
 Guard prevents approving a delegate of a token account with the CPI Guard
@@ -746,7 +746,7 @@ Feel free to save your work and run `anchor test`. All of the tests will run,
 but these two are the only ones that are doing anything yet. They should both
 pass at this point.
 
-### 6. Close Account
+#### 6. Close Account
 
 The close account instruction invokes the `close_account` instruction on the
 `Token Extensions Program`. This closes the given token account. However, you
@@ -886,7 +886,7 @@ it("Close Account without CPI Guard", async () => {
 });
 ```
 
-### 7. Set Authority
+#### 7. Set Authority
 
 Moving on to the `prohibited_set_authority` instruction, the CPI Guard protects
 against a CPI setting the `CloseAccount` authority.
@@ -1015,7 +1015,7 @@ it("Set Authority Example", async () => {
 });
 ```
 
-### 8. Burn
+#### 8. Burn
 
 The next instruction we'll test is the `unauthorized_burn` instruction from our
 test program. This instruction invokes the `burn` instruction from the
@@ -1196,7 +1196,7 @@ it("Burn without Delegate Signature Example", async () => {
 });
 ```
 
-### 9. Set Owner
+#### 9. Set Owner
 
 The last CPI Guard we'll test is the `SetOwner` protection. With the CPI Guard
 enabled, this action is always prohibited even outside of a CPI. To test this,
@@ -1401,6 +1401,6 @@ it("Set Authority via CPI on Non-CPI Guarded Account", async () => {
 And that is it! You should be able to save your work and run `anchor test`. All
 of the tests we have written should pass.
 
-# Challenge
+## Challenge
 
 Write some tests for the Transfer functionality.

--- a/content/courses/token-extensions/group-member.md
+++ b/content/courses/token-extensions/group-member.md
@@ -4,6 +4,7 @@ objectives:
   - Create an NFT collection using the group, group pointer, member, and member
     pointer extensions.
   - Update the authority and max size of a group.
+description: "Make an NFT collection using token extensions."
 ---
 
 # Summary

--- a/content/courses/token-extensions/group-member.md
+++ b/content/courses/token-extensions/group-member.md
@@ -1,0 +1,1075 @@
+---
+title: Group, Group Pointer, Member, Member Pointer
+objectives:
+  - Create an NFT collection using the group, group pointer, member, and member
+    pointer extensions.
+  - Update the authority and max size of a group.
+---
+
+# Summary
+
+- 'token groups' are commonly used to implement NFT collections.
+- The `group pointer` extension sets a group account on the token mint, to hold
+  token group information.
+- The `group` extension allows us to save group data within the mint itself.
+- The `member pointer` extension sets an individual member account on the token
+  mint, to hold information about the token's membership within a group.
+- The `member` extension allows us to save member data within the mint itself.
+
+# Overview
+
+SPL tokens are valuable alone but can be combined for extra functionality. We
+can do this in the Token Extensions Program by combining the `group`,
+`group pointer`, `member`, and `member pointer` extensions. The most common use
+case for these extensions is to create a collection of NFTs.
+
+To create a collection of NFTs we need two parts: the "collection" NFT and all
+of the NFTs within the collection. We can do this entirely using token
+extensions. The "collection" NFT can be a single mint combining the `metadata`,
+`metadata pointer`, `group`, and `group pointer` extensions. And then each
+individual NFT within the collection can be an array of mints combining the
+`metadata`, `metadata pointer`, `member`, and `member pointer` extensions.
+
+Although NFT collections are a common use-case, groups and members can be
+applied to any token type.
+
+A quick note on `group pointer` vs `group`. The `group pointer` extension saves
+the address of any onchain account that follows to the
+[Token-Group Interface](https://github.com/solana-labs/solana-program-library/tree/master/token-group/interface).
+While the `group` extension saves the Token-Group Interface data directly within
+the mint account. Generally, these are used together where the `group pointer`
+points to the mint itself. The same is true for `member pointer` vs `member`,
+but with the member data.
+
+NOTE: A group can have many members, but a member can only belong to one group.
+
+## Group and Group Pointer
+
+The `group` and `group pointer` extensions define a token group. The onchain
+data is as follows:
+
+- `update_authority`: The authority that can sign to update the group.
+- `mint`: The mint of the group token.
+- `size`: The current number of group members.
+- `max_size`: The maximum number of group members.
+
+```rust
+type OptionalNonZeroPubkey = Pubkey; // if all zeroes, interpreted as `None`
+type PodU32 = [u8; 4];
+type Pubkey = [u8; 32];
+
+/// Type discriminant: [214, 15, 63, 132, 49, 119, 209, 40]
+/// First 8 bytes of `hash("spl_token_group_interface:group")`
+pub struct TokenGroup {
+    /// The authority that can sign to update the group
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The associated mint, used to counter spoofing to be sure that group
+    /// belongs to a particular mint
+    pub mint: Pubkey,
+    /// The current number of group members
+    pub size: PodU32,
+    /// The maximum number of group members
+    pub max_size: PodU32,
+}
+```
+
+### Creating a mint with group and group pointer
+
+Creating a mint with the `group` and `group pointer` involves four instructions:
+
+- `SystemProgram.createAccount`
+- `createInitializeGroupPointerInstruction`
+- `createInitializeMintInstruction`
+- `createInitializeGroupInstruction`
+
+The first instruction `SystemProgram.createAccount` allocates space on the
+blockchain for the mint account. However like all Token Extensions Program
+mints, we need to calculate the size and cost of the mint. This can be
+accomplished by using `getMintLen` and `getMinimumBalanceForRentExemption`. In
+this case, we'll call `getMintLen` with only the `ExtensionType.GroupPointer`.
+Then we add `TOKEN_GROUP_SIZE` to the mint length to account for the group data.
+
+To get the mint length and create account instruction, do the following:
+
+```ts
+// get mint length
+const extensions = [ExtensionType.GroupPointer];
+const mintLength = getMintLen(extensions) + TOKEN_GROUP_SIZE;
+
+const mintLamports =
+  await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const createAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: mintKeypair.publicKey,
+  space: mintLength,
+  lamports: mintLamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+The second instruction `createInitializeGroupPointerInstruction` initializes the
+group pointer. It takes the mint, optional authority that can set the group
+address, address that holds the group and the owning program as it's arguments.
+
+```ts
+const initializeGroupPointerInstruction =
+  createInitializeGroupPointerInstruction(
+    mintKeypair.publicKey,
+    payer.publicKey,
+    mintKeypair.publicKey,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+The third instruction `createInitializeMintInstruction` initializes the mint.
+
+```ts
+const initializeMintInstruction = createInitializeMintInstruction(
+  mintKeypair.publicKey,
+  decimals,
+  payer.publicKey,
+  payer.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+The fourth instruction `createInitializeGroupInstruction` actually initializes
+the group and stores the configuration on the group account.
+
+```ts
+const initializeGroupInstruction = createInitializeGroupInstruction({
+  group: mintKeypair.publicKey,
+  maxSize: maxMembers,
+  mint: mintKeypair.publicKey,
+  mintAuthority: payer.publicKey,
+  programId: TOKEN_2022_PROGRAM_ID,
+  updateAuthority: payer.publicKey,
+});
+```
+
+Finally, we add the instructions to the transaction and submit it to the Solana
+network.
+
+```ts
+const mintTransaction = new Transaction().add(
+  createAccountInstruction,
+  initializeGroupPointerInstruction,
+  initializeMintInstruction,
+  initializeGroupInstruction,
+);
+
+const signature = await sendAndConfirmTransaction(
+  connection,
+  mintTransaction,
+  [payer, mintKeypair],
+  { commitment: "finalized" },
+);
+```
+
+## Update group authority
+
+To update the authority of a group, we just need the
+`tokenGroupUpdateGroupAuthority` function.
+
+```ts
+import { tokenGroupUpdateGroupAuthority } from "@solana/spl-token";
+
+const signature = await tokenGroupUpdateGroupAuthority(
+  connection, //connection - Connection to use
+  payer, // payer - Payer for the transaction fees
+  mint.publicKey, // mint - Group mint
+  oldAuthority, // account - Public key of the old update authority
+  newAuthority, // account - Public key of the new update authority
+  undefined, // multiSigners - Signing accounts if `authority` is a multisig
+  { commitment: "finalized" }, // confirmOptions - Options for confirming thr transaction
+  TOKEN_2022_PROGRAM_ID, // programId - SPL Token program account
+);
+```
+
+## Update max size of a group
+
+To update the max size of a group we just need the
+`tokenGroupUpdateGroupMaxSize` function.
+
+```ts
+import { tokenGroupUpdateGroupMaxSize } from "@solana/spl-token";
+
+const signature = tokenGroupUpdateGroupMaxSize(
+  connection, //connection - Connection to use
+  payer, // payer - Payer for the transaction fees
+  mint.publicKey, // mint - Group mint
+  updpateAuthority, // account - Update authority of the group
+  4, // maxSize - new max size of the group
+  undefined, // multiSigners — Signing accounts if `authority` is a multisig
+  { commitment: "finalized" }, // confirmOptions - Options for confirming thr transaction
+  TOKEN_2022_PROGRAM_ID, // programId - SPL Token program account
+);
+```
+
+## Member and Member Pointer
+
+The `member` and `member pointer` extensions define a token member. The onchain
+data is as follows:
+
+- `mint`: The mint of the member token.
+- `group`: The address of the group account.
+- `member_number`: The member number (index within the group).
+
+```rust
+/// Type discriminant: [254, 50, 168, 134, 88, 126, 100, 186]
+/// First 8 bytes of `hash("spl_token_group_interface:member")`
+pub struct TokenGroupMember {
+    /// The associated mint, used to counter spoofing to be sure that member
+    /// belongs to a particular mint
+    pub mint: Pubkey,
+    /// The pubkey of the `TokenGroup`
+    pub group: Pubkey,
+    /// The member number
+    pub member_number: PodU32,
+}
+```
+
+### Creating a mint with member pointer
+
+Creating a mint with the `member pointer` and `member` extensions involves four
+instructions:
+
+- `SystemProgram.createAccount`
+- `createInitializeGroupMemberPointerInstruction`
+- `createInitializeMintInstruction`
+- `createInitializeMemberInstruction`
+
+The first instruction `SystemProgram.createAccount` allocates space on the
+blockchain for the mint account. However, like all Token Extensions Program
+mints, we need to calculate the size and cost of the mint. This can be
+accomplished by using `getMintLen` and `getMinimumBalanceForRentExemption`. In
+this case, we'll call `getMintLen` with the `ExtensionType.GroupMemberPointer`.
+Then we have to add `TOKEN_GROUP_MEMBER_SIZE` to the mint length to account for
+the member data.
+
+To get the mint length and create account instruction, do the following:
+
+```ts
+// get mint length
+const extensions = [ExtensionType.GroupMemberPointer];
+const mintLength = getMintLen(extensions) + TOKEN_GROUP_MEMBER_SIZE;
+
+const mintLamports =
+  await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const createAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: mintKeypair.publicKey,
+  space: mintLength,
+  lamports: mintLamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+The second instruction `createInitializeGroupMemberPointerInstruction`
+initializes the group member pointer. It takes the mint, optional authority that
+can set the group address, address that holds the group, and the owning program
+as its arguments.
+
+```ts
+const initializeGroupMemberPointerInstruction =
+  createInitializeGroupMemberPointerInstruction(
+    mintKeypair.publicKey,
+    payer.publicKey,
+    mintKeypair.publicKey,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+The third instruction `createInitializeMintInstruction` initializes the mint.
+
+```ts
+const initializeMintInstruction = createInitializeMintInstruction(
+  mintKeypair.publicKey,
+  decimals,
+  payer.publicKey,
+  payer.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+The fourth instruction `createInitializeMemberInstruction` actually initializes
+the member and stores the configuration on the member account. This function
+takes the group address as an argument and associates the member with that
+group.
+
+```ts
+const initializeMemberInstruction = createInitializeMemberInstruction({
+  group: groupAddress,
+  groupUpdateAuthority: payer.publicKey,
+  member: mintKeypair.publicKey,
+  memberMint: mintKeypair.publicKey,
+  memberMintAuthority: payer.publicKey,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+Finally, we add the instructions to the transaction and submit it to the Solana
+network.
+
+```ts
+const mintTransaction = new Transaction().add(
+  createAccountInstruction,
+  initializeGroupMemberPointerInstruction,
+  initializeMintInstruction,
+  initializeMemberInstruction,
+);
+
+const signature = await sendAndConfirmTransaction(
+  connection,
+  mintTransaction,
+  [payer, mintKeypair],
+  { commitment: "finalized" },
+);
+```
+
+## Fetch group and member data
+
+### Get group pointer state
+
+To retrieve the state of the `group pointer` for a mint, we need to fetch the
+account using `getMint` and then parse this data using the
+`getGroupPointerState` function. This returns us the `GroupPointer` struct.
+
+```ts
+/** GroupPointer as stored by the program */
+export interface GroupPointer {
+  /** Optional authority that can set the group address */
+  authority: PublicKey | null;
+  /** Optional account address that holds the group */
+  groupAddress: PublicKey | null;
+}
+```
+
+To get the `GroupPointer` data, call the following:
+
+```ts
+const groupMint = await getMint(
+  connection,
+  mint,
+  "confirmed",
+  TOKEN_2022_PROGRAM_ID,
+);
+
+const groupPointerData: GroupPointer = getGroupPointerState(groupMint);
+```
+
+### Get group state
+
+To retrieve the group state for a mint, we need to fetch the account using
+`getMint` and then parse this data using the `getTokenGroupState` function. This
+returns the `TokenGroup` struct.
+
+```ts
+export interface TokenGroup {
+  /** The authority that can sign to update the group */
+  updateAuthority?: PublicKey;
+  /** The associated mint, used to counter spoofing to be sure that group belongs to a particular mint */
+  mint: PublicKey;
+  /** The current number of group members */
+  size: number;
+  /** The maximum number of group members */
+  maxSize: number;
+}
+```
+
+To get the `TokenGroup` data, call the following:
+
+```ts
+const groupMint = await getMint(
+  connection,
+  mint,
+  "confirmed",
+  TOKEN_2022_PROGRAM_ID,
+);
+
+const groupData: TokenGroup = getTokenGroupState(groupMint);
+```
+
+### Get group member pointer state
+
+To retrieve the `member pointer` state for a mint, we fetch the mint with
+`getMint` and then parse with `getGroupMemberPointerState`. This returns us the
+`GroupMemberPointer` struct.
+
+```ts
+/** GroupMemberPointer as stored by the program */
+export interface GroupMemberPointer {
+  /** Optional authority that can set the member address */
+  authority: PublicKey | null;
+  /** Optional account address that holds the member */
+  memberAddress: PublicKey | null;
+}
+```
+
+To get the `GroupMemberPointer` data, call the following:
+
+```ts
+const memberMint = await getMint(
+  connection,
+  mint,
+  "confirmed",
+  TOKEN_2022_PROGRAM_ID,
+);
+
+const memberPointerData = getGroupMemberPointerState(memberMint);
+```
+
+### Get group member state
+
+To retrieve a mint's `member` state, we fetch the mint with `getMint` and then
+parse with `getTokenGroupMemberState`. This returns the `TokenGroupMember`
+struct.
+
+```ts
+export interface TokenGroupMember {
+  /** The associated mint, used to counter spoofing to be sure that member belongs to a particular mint */
+  mint: PublicKey;
+  /** The pubkey of the `TokenGroup` */
+  group: PublicKey;
+  /** The member number */
+  memberNumber: number;
+}
+```
+
+To get the `TokenGroupMember` data, call the following:
+
+```ts
+const memberMint = await getMint(
+  connection,
+  mint,
+  "confirmed",
+  TOKEN_2022_PROGRAM_ID,
+);
+const memberData = getTokenGroupMemberState(memberMint);
+```
+
+# Lab
+
+In this lab we'll create a Cool Cats NFT collection using the `group`,
+`group pointer`, `member` and `member pointer` extensions in conjunction with
+the `metadata` and `metadata pointer` extensions.
+
+The Cool Cats NFT collection will have a group NFT with three member NFTs within
+it.
+
+### 1. Getting started
+
+To get started, clone
+[this](https://github.com/Unboxed-Software/solana-lab-group-member) repository's
+`starter` branch.
+
+```bash
+git clone https://github.com/Unboxed-Software/solana-lab-group-member.git
+cd solana-lab-group-member
+git checkout starter
+npm install
+```
+
+The `starter` code comes with:
+
+- `index.ts`: creates a connection object and calls `initializeKeypair`. This is
+  where we will write our script.
+- `assets`: folder which contains the image for our NFT collection.
+- `helper.ts`: helper functions for uploading metadata.
+
+### 2. Run validator node
+
+For the sake of this guide, we'll be running our own validator node.
+
+In a separate terminal, run the following command: `solana-test-validator`. This
+will run the node and also log out some keys and values. The value we need to
+retrieve and use in our connection is the JSON RPC URL, which in this case is
+`http://127.0.0.1:8899`. We then use that in the connection to specify to use
+the local RPC URL.
+
+`const connection = new Connection("http://127.0.0.1:8899", "confirmed");`
+
+With the validator setup correctly, you may run `index.ts` and confirm
+everything is working.
+
+```bash
+npx esrun src/index.ts
+```
+
+### 3. Setup group metadata
+
+Before creating our group NFT, we must prepare and upload the group metadata. We
+are using devnet Irys (Arweave) to upload the image and metadata. This
+functionality is provided for you in the `helpers.ts`.
+
+For ease of this lesson, we've provided assets for the NFTs in the `assets`
+directory.
+
+If you'd like to use your own files and metadata feel free!
+
+To get our group metadata ready we have to do the following:
+
+1. We need to format our metadata for upload using the `LabNFTMetadata`
+   interface from `helper.ts`
+2. Call the `uploadOffChainMetadata` from `helpers.ts`
+3. Format everything including the resulting uri from the previous step into the
+
+We need to format our metadata for upload (`LabNFTMetadata`), upload the image
+and metadata (`uploadOffChainMetadata`), and finally format everything into the
+`TokenMetadata` interface from the `@solana/spl-token-metadata` library.
+
+Note: We are using devnet Irys, which is free to upload to under 100kb.
+
+```ts
+// Create group metadata
+
+const groupMetadata: LabNFTMetadata = {
+  mint: groupMintKeypair,
+  imagePath: "assets/collection.png",
+  tokenName: "cool-cats-collection",
+  tokenDescription: "Collection of Cool Cat NFTs",
+  tokenSymbol: "MEOW",
+  tokenExternalUrl: "https://solana.com/",
+  tokenAdditionalMetadata: {},
+  tokenUri: "",
+};
+
+// Upload off-chain metadata
+groupMetadata.tokenUri = await uploadOffChainMetadata(payer, groupMetadata);
+
+// Format group token metadata
+const collectionTokenMetadata: TokenMetadata = {
+  name: groupMetadata.tokenName,
+  mint: groupMintKeypair.publicKey,
+  symbol: groupMetadata.tokenSymbol,
+  uri: groupMetadata.tokenUri,
+  updateAuthority: payer.publicKey,
+  additionalMetadata: Object.entries(
+    groupMetadata.tokenAdditionalMetadata || [],
+  ).map(([trait_type, value]) => [trait_type, value]),
+};
+```
+
+Feel free to run the script and make sure everything uploads.
+
+```bash
+npx esrun src/index.ts
+```
+
+### 3. Create a mint with group and group pointer
+
+Let's create the group NFT by creating a mint with the `metadata`,
+`metadata pointer`, `group` and `group pointer` extensions.
+
+This NFT is the visual representation of our collection.
+
+Let's first define the inputs to our new function `createTokenGroup`:
+
+- `connection`: Connection to the blockchain
+- `payer`: The keypair paying for the transaction
+- `mintKeypair`: The mint keypair
+- `decimals`: The mint decimals ( 0 for NFTs )
+- `maxMembers`: The maximum number of members allowed in the group
+- `metadata`: The metadata for the group mint
+
+```ts
+export async function createTokenGroup(
+  connection: Connection,
+  payer: Keypair,
+  mintKeypair: Keypair,
+  decimals: number,
+  maxMembers: number,
+  metadata: TokenMetadata,
+): Promise<TransactionSignature>;
+```
+
+To make our NFT, we will store the metadata directly on the mint account using
+the `metadata` and `metadata pointer` extensions. We'll also save some info
+about the group with the `group` and `group pointer` extensions.
+
+To create our group NFT, we need the following instructions:
+
+- `SystemProgram.createAccount`: Allocates space on Solana for the mint account.
+  We can get the `mintLength` and `mintLamports` using `getMintLen` and
+  `getMinimumBalanceForRentExemption` respectively.
+- `createInitializeGroupPointerInstruction`: Initializes the group pointer
+- `createInitializeMetadataPointerInstruction`: Initializes the metadata pointer
+- `createInitializeMintInstruction`: Initializes the mint
+- `createInitializeGroupInstruction`: Initializes the group
+- `createInitializeInstruction`: Initializes the metadata
+
+Finally, we need to add all of these instructions to a transaction and send it
+to the Solana network, and return the signature. We can do this by calling
+`sendAndConfirmTransaction`.
+
+```ts
+import {
+  sendAndConfirmTransaction,
+  Connection,
+  Keypair,
+  SystemProgram,
+  Transaction,
+  TransactionSignature,
+} from "@solana/web3.js";
+
+import {
+  ExtensionType,
+  createInitializeMintInstruction,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+  createInitializeGroupInstruction,
+  createInitializeGroupPointerInstruction,
+  TYPE_SIZE,
+  LENGTH_SIZE,
+  createInitializeMetadataPointerInstruction,
+  TOKEN_GROUP_SIZE,
+} from "@solana/spl-token";
+import {
+  TokenMetadata,
+  createInitializeInstruction,
+  pack,
+} from "@solana/spl-token-metadata";
+
+export async function createTokenGroup(
+  connection: Connection,
+  payer: Keypair,
+  mintKeypair: Keypair,
+  decimals: number,
+  maxMembers: number,
+  metadata: TokenMetadata,
+): Promise<TransactionSignature> {
+  const extensions: ExtensionType[] = [
+    ExtensionType.GroupPointer,
+    ExtensionType.MetadataPointer,
+  ];
+
+  const metadataLen = TYPE_SIZE + LENGTH_SIZE + pack(metadata).length + 500;
+  const mintLength = getMintLen(extensions);
+  const totalLen = mintLength + metadataLen + TOKEN_GROUP_SIZE;
+
+  const mintLamports =
+    await connection.getMinimumBalanceForRentExemption(totalLen);
+
+  const mintTransaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mintKeypair.publicKey,
+      space: mintLength,
+      lamports: mintLamports,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeGroupPointerInstruction(
+      mintKeypair.publicKey,
+      payer.publicKey,
+      mintKeypair.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeMetadataPointerInstruction(
+      mintKeypair.publicKey,
+      payer.publicKey,
+      mintKeypair.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeMintInstruction(
+      mintKeypair.publicKey,
+      decimals,
+      payer.publicKey,
+      payer.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeGroupInstruction({
+      group: mintKeypair.publicKey,
+      maxSize: maxMembers,
+      mint: mintKeypair.publicKey,
+      mintAuthority: payer.publicKey,
+      programId: TOKEN_2022_PROGRAM_ID,
+      updateAuthority: payer.publicKey,
+    }),
+    createInitializeInstruction({
+      metadata: mintKeypair.publicKey,
+      mint: mintKeypair.publicKey,
+      mintAuthority: payer.publicKey,
+      name: metadata.name,
+      programId: TOKEN_2022_PROGRAM_ID,
+      symbol: metadata.symbol,
+      updateAuthority: payer.publicKey,
+      uri: metadata.uri,
+    }),
+  );
+
+  const signature = await sendAndConfirmTransaction(
+    connection,
+    mintTransaction,
+    [payer, mintKeypair],
+  );
+
+  return signature;
+}
+```
+
+Now that we have our function, let's call it in our `index.ts` file.
+
+```ts
+// Create group
+const signature = await createTokenGroup(
+  connection,
+  payer,
+  groupMintKeypair,
+  decimals,
+  maxMembers,
+  collectionTokenMetadata,
+);
+
+console.log(
+  `Created collection mint with metadata:\n${getExplorerLink("tx", signature, "localnet")}\n`,
+);
+```
+
+Before we run the script, lets fetch the newly created group NFT and print it's
+contents. Let's do this in `index.ts`:
+
+```ts
+// Fetch the group
+const groupMint = await getMint(
+  connection,
+  groupMintKeypair.publicKey,
+  "confirmed",
+  TOKEN_2022_PROGRAM_ID,
+);
+const fetchedGroupMetadata = await getTokenMetadata(
+  connection,
+  groupMintKeypair.publicKey,
+);
+const metadataPointerState = getMetadataPointerState(groupMint);
+const groupData = getGroupPointerState(groupMint);
+
+console.log("\n---------- GROUP DATA -------------\n");
+console.log("Group Mint: ", groupMint.address.toBase58());
+console.log(
+  "Metadata Pointer Account: ",
+  metadataPointerState?.metadataAddress?.toBase58(),
+);
+console.log("Group Pointer Account: ", groupData?.groupAddress?.toBase58());
+console.log("\n--- METADATA ---\n");
+console.log("Name: ", fetchedGroupMetadata?.name);
+console.log("Symbol: ", fetchedGroupMetadata?.symbol);
+console.log("Uri: ", fetchedGroupMetadata?.uri);
+console.log("\n------------------------------------\n");
+```
+
+Now we can run the script and see the group NFT we created.
+
+```bash
+npx esrun src/index.ts
+```
+
+### 4. Setup member NFT Metadata
+
+Now that we've created our group NFT, we can create the member NFTs. But before
+we actually create them, we need to prepare their metadata.
+
+The flow is the exact same to what we did with the group NFT.
+
+1. We need to format our metadata for upload using the `LabNFTMetadata`
+   interface from `helper.ts`
+2. Call the `uploadOffChainMetadata` from `helpers.ts`
+3. Format everything including the resulting uri from the previous step into the
+   `TokenMetadata` interface from the `@solana/spl-token-metadata` library.
+
+However, since we have three members, we'll loop through each step for each
+member.
+
+First, let's define the metadata for each member:
+
+```ts
+// Define member metadata
+const membersMetadata: LabNFTMetadata[] = [
+  {
+    mint: cat0Mint,
+    imagePath: "assets/cat_0.png",
+    tokenName: "Cat 1",
+    tokenDescription: "Adorable cat",
+    tokenSymbol: "MEOW",
+    tokenExternalUrl: "https://solana.com/",
+    tokenAdditionalMetadata: {},
+    tokenUri: "",
+  },
+  {
+    mint: cat1Mint,
+    imagePath: "assets/cat_1.png",
+    tokenName: "Cat 2",
+    tokenDescription: "Sassy cat",
+    tokenSymbol: "MEOW",
+    tokenExternalUrl: "https://solana.com/",
+    tokenAdditionalMetadata: {},
+    tokenUri: "",
+  },
+  {
+    mint: cat2Mint,
+    imagePath: "assets/cat_2.png",
+    tokenName: "Cat 3",
+    tokenDescription: "Silly cat",
+    tokenSymbol: "MEOW",
+    tokenExternalUrl: "https://solana.com/",
+    tokenAdditionalMetadata: {},
+    tokenUri: "",
+  },
+];
+```
+
+Now let's loop through each member and upload their metadata.
+
+```ts
+// Upload member metadata
+for (const member of membersMetadata) {
+  member.tokenUri = await uploadOffChainMetadata(payer, member);
+}
+```
+
+Finally, let's format the metadata for each member into the `TokenMetadata`
+interface:
+
+Note: We'll want to carry over the keypair since we'll need it to create the
+member NFTs.
+
+```ts
+// Format token metadata
+const memberTokenMetadata: { mintKeypair: Keypair; metadata: TokenMetadata }[] =
+  membersMetadata.map(member => ({
+    mintKeypair: member.mint,
+    metadata: {
+      name: member.tokenName,
+      mint: member.mint.publicKey,
+      symbol: member.tokenSymbol,
+      uri: member.tokenUri,
+      updateAuthority: payer.publicKey,
+      additionalMetadata: Object.entries(
+        member.tokenAdditionalMetadata || [],
+      ).map(([trait_type, value]) => [trait_type, value]),
+    } as TokenMetadata,
+  }));
+```
+
+### 5. Create member NFTs
+
+Just like the group NFT, we need to create the member NFTs. Let's do this in a
+new file called `create-member.ts`. It will look very similar to the
+`create-group.ts` file, except we'll use the `member` and `member pointer`
+extensions instead of the `group` and `group pointer` extensions.
+
+First, let's define the inputs to our new function `createTokenMember`:
+
+- `connection`: Connection to the blockchain
+- `payer`: The keypair paying for the transaction
+- `mintKeypair`: The mint keypair
+- `decimals`: The mint decimals ( 0 for NFTs )
+- `metadata`: The metadata for the group mint
+- `groupAddress`: The address of the group account - in this case it's the group
+  mint itself
+
+```ts
+export async function createTokenMember(
+  connection: Connection,
+  payer: Keypair,
+  mintKeypair: Keypair,
+  decimals: number,
+  metadata: TokenMetadata,
+  groupAddress: PublicKey,
+): Promise<TransactionSignature>;
+```
+
+Just like the group NFT, we need the following instructions:
+
+- `SystemProgram.createAccount`: Allocates space on Solana for the mint account.
+  We can get the `mintLength` and `mintLamports` using `getMintLen` and
+  `getMinimumBalanceForRentExemption` respectively.
+- `createInitializeGroupMemberPointerInstruction`: Initializes the member
+  pointer
+- `createInitializeMetadataPointerInstruction`: Initializes the metadata pointer
+- `createInitializeMintInstruction`: Initializes the mint
+- `createInitializeMemberInstruction`: Initializes the member
+- `createInitializeInstruction`: Initializes the metadata
+
+Finally, we need to add these instructions to a transaction, send it to the
+Solana network, and return the signature. We can do this by calling
+`sendAndConfirmTransaction`.
+
+```ts
+import {
+  sendAndConfirmTransaction,
+  Connection,
+  Keypair,
+  SystemProgram,
+  Transaction,
+  TransactionSignature,
+  PublicKey,
+} from "@solana/web3.js";
+
+import {
+  ExtensionType,
+  createInitializeMintInstruction,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+  TYPE_SIZE,
+  LENGTH_SIZE,
+  createInitializeMetadataPointerInstruction,
+  TOKEN_GROUP_MEMBER_SIZE,
+  createInitializeGroupMemberPointerInstruction,
+  createInitializeMemberInstruction,
+} from "@solana/spl-token";
+import {
+  TokenMetadata,
+  createInitializeInstruction,
+  pack,
+} from "@solana/spl-token-metadata";
+
+export async function createTokenMember(
+  connection: Connection,
+  payer: Keypair,
+  mintKeypair: Keypair,
+  decimals: number,
+  metadata: TokenMetadata,
+  groupAddress: PublicKey,
+): Promise<TransactionSignature> {
+  const extensions: ExtensionType[] = [
+    ExtensionType.GroupMemberPointer,
+    ExtensionType.MetadataPointer,
+  ];
+
+  const metadataLen = TYPE_SIZE + LENGTH_SIZE + pack(metadata).length;
+  const mintLength = getMintLen(extensions);
+  const totalLen = mintLength + metadataLen + TOKEN_GROUP_MEMBER_SIZE;
+
+  const mintLamports =
+    await connection.getMinimumBalanceForRentExemption(totalLen);
+
+  const mintTransaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mintKeypair.publicKey,
+      space: mintLength,
+      lamports: mintLamports,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeGroupMemberPointerInstruction(
+      mintKeypair.publicKey,
+      payer.publicKey,
+      mintKeypair.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeMetadataPointerInstruction(
+      mintKeypair.publicKey,
+      payer.publicKey,
+      mintKeypair.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeMintInstruction(
+      mintKeypair.publicKey,
+      decimals,
+      payer.publicKey,
+      payer.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeMemberInstruction({
+      group: groupAddress,
+      groupUpdateAuthority: payer.publicKey,
+      member: mintKeypair.publicKey,
+      memberMint: mintKeypair.publicKey,
+      memberMintAuthority: payer.publicKey,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeInstruction({
+      metadata: mintKeypair.publicKey,
+      mint: mintKeypair.publicKey,
+      mintAuthority: payer.publicKey,
+      name: metadata.name,
+      programId: TOKEN_2022_PROGRAM_ID,
+      symbol: metadata.symbol,
+      updateAuthority: payer.publicKey,
+      uri: metadata.uri,
+    }),
+  );
+
+  const signature = await sendAndConfirmTransaction(
+    connection,
+    mintTransaction,
+    [payer, mintKeypair],
+  );
+
+  return signature;
+}
+```
+
+Let's add our new function to `index.ts` and call it for each member:
+
+```ts
+// Create member mints
+for (const memberMetadata of memberTokenMetadata) {
+  const signature = await createTokenMember(
+    connection,
+    payer,
+    memberMetadata.mintKeypair,
+    decimals,
+    memberMetadata.metadata,
+    groupMintKeypair.publicKey,
+  );
+
+  console.log(
+    `Created ${memberMetadata.metadata.name} NFT:\n${getExplorerLink("tx", signature, "localnet")}\n`,
+  );
+}
+```
+
+Let's fetch our newly created member NFTs and display their contents.
+
+```ts
+for (const member of membersMetadata) {
+  const memberMint = await getMint(
+    connection,
+    member.mint.publicKey,
+    "confirmed",
+    TOKEN_2022_PROGRAM_ID,
+  );
+  const memberMetadata = await getTokenMetadata(
+    connection,
+    member.mint.publicKey,
+  );
+  const metadataPointerState = getMetadataPointerState(memberMint);
+  const memberPointerData = getGroupMemberPointerState(memberMint);
+  const memberData = getTokenGroupMemberState(memberMint);
+
+  console.log("\n---------- MEMBER DATA -------------\n");
+  console.log("Member Mint: ", memberMint.address.toBase58());
+  console.log(
+    "Metadata Pointer Account: ",
+    metadataPointerState?.metadataAddress?.toBase58(),
+  );
+  console.log("Group Account: ", memberData?.group?.toBase58());
+  console.log(
+    "Member Pointer Account: ",
+    memberPointerData?.memberAddress?.toBase58(),
+  );
+  console.log("Member Number: ", memberData?.memberNumber);
+  console.log("\n--- METADATA ---\n");
+  console.log("Name: ", memberMetadata?.name);
+  console.log("Symbol: ", memberMetadata?.symbol);
+  console.log("Uri: ", memberMetadata?.uri);
+  console.log("\n------------------------------------\n");
+}
+```
+
+Lastly, let's run the script and see our full collection of NFTs!
+
+```bash
+npx esrun src/index.ts
+```
+
+That's it! If you're having troubles feel free to check out the `solution`
+[branch in the repository](https://github.com/Unboxed-Software/solana-lab-group-member/tree/solution).
+
+# Challenge
+
+Go create a NFT collection of your own using the the `group`, `group pointer`,
+`member` and `member pointer` extensions.

--- a/content/courses/token-extensions/group-member.md
+++ b/content/courses/token-extensions/group-member.md
@@ -7,7 +7,7 @@ objectives:
 description: "Make an NFT collection using token extensions."
 ---
 
-# Summary
+## Summary
 
 - 'token groups' are commonly used to implement NFT collections.
 - The `group pointer` extension sets a group account on the token mint, to hold
@@ -17,7 +17,7 @@ description: "Make an NFT collection using token extensions."
   mint, to hold information about the token's membership within a group.
 - The `member` extension allows us to save member data within the mint itself.
 
-# Overview
+## Overview
 
 SPL tokens are valuable alone but can be combined for extra functionality. We
 can do this in the Token Extensions Program by combining the `group`,
@@ -44,7 +44,7 @@ but with the member data.
 
 NOTE: A group can have many members, but a member can only belong to one group.
 
-## Group and Group Pointer
+### Group and Group Pointer
 
 The `group` and `group pointer` extensions define a token group. The onchain
 data is as follows:
@@ -74,7 +74,7 @@ pub struct TokenGroup {
 }
 ```
 
-### Creating a mint with group and group pointer
+#### Creating a mint with group and group pointer
 
 Creating a mint with the `group` and `group pointer` involves four instructions:
 
@@ -168,7 +168,7 @@ const signature = await sendAndConfirmTransaction(
 );
 ```
 
-## Update group authority
+### Update group authority
 
 To update the authority of a group, we just need the
 `tokenGroupUpdateGroupAuthority` function.
@@ -188,7 +188,7 @@ const signature = await tokenGroupUpdateGroupAuthority(
 );
 ```
 
-## Update max size of a group
+### Update max size of a group
 
 To update the max size of a group we just need the
 `tokenGroupUpdateGroupMaxSize` function.
@@ -208,7 +208,7 @@ const signature = tokenGroupUpdateGroupMaxSize(
 );
 ```
 
-## Member and Member Pointer
+### Member and Member Pointer
 
 The `member` and `member pointer` extensions define a token member. The onchain
 data is as follows:
@@ -231,7 +231,7 @@ pub struct TokenGroupMember {
 }
 ```
 
-### Creating a mint with member pointer
+#### Creating a mint with member pointer
 
 Creating a mint with the `member pointer` and `member` extensions involves four
 instructions:
@@ -330,9 +330,9 @@ const signature = await sendAndConfirmTransaction(
 );
 ```
 
-## Fetch group and member data
+### Fetch group and member data
 
-### Get group pointer state
+#### Get group pointer state
 
 To retrieve the state of the `group pointer` for a mint, we need to fetch the
 account using `getMint` and then parse this data using the
@@ -361,7 +361,7 @@ const groupMint = await getMint(
 const groupPointerData: GroupPointer = getGroupPointerState(groupMint);
 ```
 
-### Get group state
+#### Get group state
 
 To retrieve the group state for a mint, we need to fetch the account using
 `getMint` and then parse this data using the `getTokenGroupState` function. This
@@ -393,7 +393,7 @@ const groupMint = await getMint(
 const groupData: TokenGroup = getTokenGroupState(groupMint);
 ```
 
-### Get group member pointer state
+#### Get group member pointer state
 
 To retrieve the `member pointer` state for a mint, we fetch the mint with
 `getMint` and then parse with `getGroupMemberPointerState`. This returns us the
@@ -422,7 +422,7 @@ const memberMint = await getMint(
 const memberPointerData = getGroupMemberPointerState(memberMint);
 ```
 
-### Get group member state
+#### Get group member state
 
 To retrieve a mint's `member` state, we fetch the mint with `getMint` and then
 parse with `getTokenGroupMemberState`. This returns the `TokenGroupMember`
@@ -451,7 +451,7 @@ const memberMint = await getMint(
 const memberData = getTokenGroupMemberState(memberMint);
 ```
 
-# Lab
+## Lab
 
 In this lab we'll create a Cool Cats NFT collection using the `group`,
 `group pointer`, `member` and `member pointer` extensions in conjunction with
@@ -460,7 +460,7 @@ the `metadata` and `metadata pointer` extensions.
 The Cool Cats NFT collection will have a group NFT with three member NFTs within
 it.
 
-### 1. Getting started
+#### 1. Getting started
 
 To get started, clone
 [this](https://github.com/Unboxed-Software/solana-lab-group-member) repository's
@@ -480,7 +480,7 @@ The `starter` code comes with:
 - `assets`: folder which contains the image for our NFT collection.
 - `helper.ts`: helper functions for uploading metadata.
 
-### 2. Run validator node
+#### 2. Run validator node
 
 For the sake of this guide, we'll be running our own validator node.
 
@@ -499,7 +499,7 @@ everything is working.
 npx esrun src/index.ts
 ```
 
-### 3. Setup group metadata
+#### 3. Setup group metadata
 
 Before creating our group NFT, we must prepare and upload the group metadata. We
 are using devnet Irys (Arweave) to upload the image and metadata. This
@@ -559,7 +559,7 @@ Feel free to run the script and make sure everything uploads.
 npx esrun src/index.ts
 ```
 
-### 3. Create a mint with group and group pointer
+#### 3. Create a mint with group and group pointer
 
 Let's create the group NFT by creating a mint with the `metadata`,
 `metadata pointer`, `group` and `group pointer` extensions.
@@ -766,7 +766,7 @@ Now we can run the script and see the group NFT we created.
 npx esrun src/index.ts
 ```
 
-### 4. Setup member NFT Metadata
+#### 4. Setup member NFT Metadata
 
 Now that we've created our group NFT, we can create the member NFTs. But before
 we actually create them, we need to prepare their metadata.
@@ -853,7 +853,7 @@ const memberTokenMetadata: { mintKeypair: Keypair; metadata: TokenMetadata }[] =
   }));
 ```
 
-### 5. Create member NFTs
+#### 5. Create member NFTs
 
 Just like the group NFT, we need to create the member NFTs. Let's do this in a
 new file called `create-member.ts`. It will look very similar to the
@@ -1070,7 +1070,7 @@ npx esrun src/index.ts
 That's it! If you're having troubles feel free to check out the `solution`
 [branch in the repository](https://github.com/Unboxed-Software/solana-lab-group-member/tree/solution).
 
-# Challenge
+## Challenge
 
 Go create a NFT collection of your own using the the `group`, `group pointer`,
 `member` and `member pointer` extensions.

--- a/content/courses/token-extensions/immutable-owner.md
+++ b/content/courses/token-extensions/immutable-owner.md
@@ -4,6 +4,8 @@ objectives:
   - Create token accounts with an immutable owner
   - Explain the use cases of the immutable owner extension
   - Experiment with the rules of the extension
+description:
+  "Make a token that ensures the account storing the tokens cannot change owner."
 ---
 
 # Summary

--- a/content/courses/token-extensions/immutable-owner.md
+++ b/content/courses/token-extensions/immutable-owner.md
@@ -8,7 +8,7 @@ description:
   "Make a token that ensures the account storing the tokens cannot change owner."
 ---
 
-# Summary
+## Summary
 
 - The `immutable owner` extension ensures that once a token account is created,
   its owner is unchangeable, securing the ownership against any modifications.
@@ -19,7 +19,7 @@ description:
 - The `immutable owner` extension is a token account extension; enabled on each
   token account, not the mint.
 
-# Overview
+## Overview
 
 Associated Token Accounts (ATAs) are uniquely determined by the owner and the
 mint, streamlining the process of identifying the correct Token Account for a
@@ -37,7 +37,7 @@ unauthorized access and transfer attempts.
 It is important to note that this extension is a Token Account extension,
 meaning it's on the token account, not the mint.
 
-## Creating token account with immutable owner
+### Creating token account with immutable owner
 
 All Token Extensions Program ATAs have immutable owners enabled by default. If
 you want to create an ATA you may use `createAssociatedTokenAccount`.
@@ -123,13 +123,13 @@ return await sendAndConfirmTransaction(connection, transaction, [
 When the transaction with these three instructions is sent, a new token account
 is created with the immutable owner extension.
 
-# Lab
+## Lab
 
 In this lab, we'll be creating a token account with an immutable owner. We'll
 then write tests to check if the extension is working as intended by attempting
 to transfer ownership of the token account.
 
-### 1. Setup Environment
+#### 1. Setup Environment
 
 To get started, create an empty directory named `immutable-owner` and navigate
 to it. We'll be initializing a brand new project. Run `npm init -y` to make a
@@ -168,7 +168,7 @@ const [otherOwner, mintKeypair, ourTokenAccountKeypair] = makeKeypairs(3);
 const ourTokenAccount = ourTokenAccountKeypair.publicKey;
 ```
 
-### 2. Run validator node
+#### 2. Run validator node
 
 For the sake of this guide, we'll be running our own validator node.
 
@@ -189,7 +189,7 @@ Alternatively, if you’d like to use testnet or devnet, import the
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 ```
 
-### 3. Helpers
+#### 3. Helpers
 
 When we pasted the `index.ts` code from earlier, we added the following helpers:
 
@@ -206,7 +206,7 @@ Additionally, we have some initial accounts:
 - `otherOwner`: The token account we'll try to transfer ownership of the two
   immutable accounts to
 
-### 4. Create mint
+#### 4. Create mint
 
 Let's create the mint we'll be using for our token accounts.
 
@@ -228,7 +228,7 @@ const mint = await createMint(
 );
 ```
 
-### 5. Create Token Account with immutable owner
+#### 5. Create Token Account with immutable owner
 
 Remember, all ATAs come with the `immutable owner` extension. However, we're
 going to create a token account using a keypair. This requires us to create the
@@ -401,7 +401,7 @@ If you'd like to test that everything is working, feel free to run the script.
 npx esrun src/index.ts
 ```
 
-### 6. Tests
+#### 6. Tests
 
 **Test trying to transfer owner**
 
@@ -480,6 +480,6 @@ owner extension! If you are stuck at any point, you can find the working code on
 the `solution` branch of
 [this repository](https://github.com/Unboxed-Software/solana-lab-immutable-owner/tree/solution).
 
-# Challenge
+## Challenge
 
 Go create your own token account with an immutable owner.

--- a/content/courses/token-extensions/immutable-owner.md
+++ b/content/courses/token-extensions/immutable-owner.md
@@ -1,0 +1,483 @@
+---
+title: Immutable Owner
+objectives:
+  - Create token accounts with an immutable owner
+  - Explain the use cases of the immutable owner extension
+  - Experiment with the rules of the extension
+---
+
+# Summary
+
+- The `immutable owner` extension ensures that once a token account is created,
+  its owner is unchangeable, securing the ownership against any modifications.
+- Token accounts with this extension can have only one permanent state regarding
+  ownership: **Immutable**.
+- Associated Token Accounts (ATAs) have the `immutable owner` extension enabled
+  by default.
+- The `immutable owner` extension is a token account extension; enabled on each
+  token account, not the mint.
+
+# Overview
+
+Associated Token Accounts (ATAs) are uniquely determined by the owner and the
+mint, streamlining the process of identifying the correct Token Account for a
+specific owner. Initially, any token account could change its owner, even ATAs.
+This led to security concerns, as users could mistakenly send funds to an
+account no longer owned by the expected recipient. This can unknowingly lead to
+the loss of funds should the owner change.
+
+The `immutable owner` extension, which is automatically applied to ATAs,
+prevents any changes in ownership. This extension can also be enabled for new
+Token Accounts created through the Token Extensions Program, guaranteeing that
+once ownership is set it is permanent. This secures accounts against
+unauthorized access and transfer attempts.
+
+It is important to note that this extension is a Token Account extension,
+meaning it's on the token account, not the mint.
+
+## Creating token account with immutable owner
+
+All Token Extensions Program ATAs have immutable owners enabled by default. If
+you want to create an ATA you may use `createAssociatedTokenAccount`.
+
+Outside of ATAs, which enable the immutable owner extension by default, you can
+enable it manually on any Token Extensions Program token account.
+
+Initializing a token account with immutable owner involves three instructions:
+
+- `SystemProgram.createAccount`
+- `createInitializeImmutableOwnerInstruction`
+- `createInitializeAccountInstruction`
+
+Note: We are assuming a mint has already been created.
+
+The first instruction `SystemProgram.createAccount` allocates space on the
+blockchain for the token account. This instruction accomplishes three things:
+
+- Allocates `space`
+- Transfers `lamports` for rent
+- Assigns to its owning program
+
+```typescript
+const tokenAccountKeypair = Keypair.generate();
+const tokenAccount = tokenAccountKeypair.publicKey;
+const extensions = [ExtensionType.ImmutableOwner];
+
+const tokenAccountLen = getAccountLen(extensions);
+const lamports =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountLen);
+
+const createTokenAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: tokenAccount,
+  space: tokenAccountLen,
+  lamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+The second instruction `createInitializeImmutableOwnerInstruction` initializes
+the immutable owner extension.
+
+```typescript
+const initializeImmutableOwnerInstruction =
+  createInitializeImmutableOwnerInstruction(
+    tokenAccount,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+The third instruction `createInitializeAccountInstruction` initializes the token
+account.
+
+```typescript
+const initializeAccountInstruction = createInitializeAccountInstruction(
+  tokenAccount,
+  mint,
+  owner.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+Lastly, add all of these instructions to a transaction and send it to the
+blockchain.
+
+```ts
+const transaction = new Transaction().add(
+  createTokenAccountInstruction,
+  initializeImmutableOwnerInstruction,
+  initializeAccountInstruction,
+);
+
+transaction.feePayer = payer.publicKey;
+
+return await sendAndConfirmTransaction(connection, transaction, [
+  payer,
+  owner,
+  tokenAccountKeypair,
+]);
+```
+
+When the transaction with these three instructions is sent, a new token account
+is created with the immutable owner extension.
+
+# Lab
+
+In this lab, we'll be creating a token account with an immutable owner. We'll
+then write tests to check if the extension is working as intended by attempting
+to transfer ownership of the token account.
+
+### 1. Setup Environment
+
+To get started, create an empty directory named `immutable-owner` and navigate
+to it. We'll be initializing a brand new project. Run `npm init -y` to make a
+project with defaults.
+
+Next, we'll need to add our dependencies. Run the following to install the
+required packages:
+
+```bash
+npm i @solana-developers/helpers @solana/spl-token @solana/web3.js esrun dotenv typescript
+```
+
+Create a directory named `src`. In this directory, create a file named
+`index.ts`. This is where we will run checks against the rules of this
+extension. Paste the following code in `index.ts`:
+
+```ts
+import {
+  AuthorityType,
+  TOKEN_2022_PROGRAM_ID,
+  createMint,
+  setAuthority,
+} from "@solana/spl-token";
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+} from "@solana/web3.js";
+import { initializeKeypair, makeKeypairs } from "@solana-developers/helpers";
+
+const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+const payer = await initializeKeypair(connection);
+
+const [otherOwner, mintKeypair, ourTokenAccountKeypair] = makeKeypairs(3);
+const ourTokenAccount = ourTokenAccountKeypair.publicKey;
+```
+
+### 2. Run validator node
+
+For the sake of this guide, we'll be running our own validator node.
+
+In a separate terminal, run the following command: `solana-test-validator`. This
+will run the node and also log out some keys and values. The value we need to
+retrieve and use in our connection is the JSON RPC URL, which in this case is
+`http://127.0.0.1:8899`. We then use that in the connection to specify to use of
+the local RPC URL.
+
+```typescript
+const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+```
+
+Alternatively, if you’d like to use testnet or devnet, import the
+`clusterApiUrl` from `@solana/web3.js` and pass it to the connection as such:
+
+```typescript
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+```
+
+### 3. Helpers
+
+When we pasted the `index.ts` code from earlier, we added the following helpers:
+
+- `initializeKeypair`: This function creates the keypair for the `payer` and
+  also airdrops 2 testnet SOL to it
+- `makeKeypairs`: This function creates keypairs without airdropping any SOL
+
+Additionally, we have some initial accounts:
+
+- `payer`: Used to pay for and be the authority for everything
+- `mintKeypair`: Our mint
+- `ourTokenAccountKeypair`: The token account owned by the payer that we'll use
+  for testing
+- `otherOwner`: The token account we'll try to transfer ownership of the two
+  immutable accounts to
+
+### 4. Create mint
+
+Let's create the mint we'll be using for our token accounts.
+
+Inside of `src/index.ts`, the required dependencies will already be imported,
+along with the aforementioned accounts. Add the following `createMint` function
+beneath the existing code:
+
+```typescript
+// CREATE MINT
+const mint = await createMint(
+  connection,
+  payer,
+  mintKeypair.publicKey,
+  null,
+  2,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+### 5. Create Token Account with immutable owner
+
+Remember, all ATAs come with the `immutable owner` extension. However, we're
+going to create a token account using a keypair. This requires us to create the
+account, initialize the immutable owner extension, and initialize the account.
+
+Inside the `src` directory, create a new file named `token-helper.ts` and create
+a new function within it called `createTokenAccountWithImmutableOwner`. This
+function is where we'll be creating the associated token account with the
+immutable owner. The function will take the following arguments:
+
+- `connection`: The connection object
+- `mint`: Public key for the new mint
+- `payer`: Payer for the transaction
+- `owner`: Owner of the associated token account
+- `tokenAccountKeypair`: The token account keypair associated with the token
+  account
+
+```ts
+import {
+  ExtensionType,
+  TOKEN_2022_PROGRAM_ID,
+  createInitializeAccountInstruction,
+  createInitializeImmutableOwnerInstruction,
+  getAccountLen,
+} from "@solana/spl-token";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+
+export async function createTokenAccountWithImmutableOwner(
+  connection: Connection,
+  mint: PublicKey,
+  payer: Keypair,
+  owner: Keypair,
+  tokenAccountKeypair: Keypair,
+): Promise<string> {
+  // Create account instruction
+
+  // Enable immutable owner instruction
+
+  // Initialize account instruction
+
+  // Send to blockchain
+
+  return "TODO Replace with signature";
+}
+```
+
+The first step in creating the token account is reserving space on Solana with
+the **`SystemProgram.createAccount`** method. This requires specifying the
+payer's keypair, (the account that will fund the creation and provide SOL for
+rent exemption), the new token account's public key
+(`tokenAccountKeypair.publicKey`), the space required to store the token
+information on the blockchain, the amount of SOL (lamports) necessary to exempt
+the account from rent and the ID of the token program that will manage this
+token account (**`TOKEN_2022_PROGRAM_ID`**).
+
+```typescript
+// CREATE ACCOUNT INSTRUCTION
+const tokenAccount = tokenAccountKeypair.publicKey;
+
+const extensions = [ExtensionType.ImmutableOwner];
+
+const tokenAccountLen = getAccountLen(extensions);
+const lamports =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountLen);
+
+const createTokenAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: tokenAccount,
+  space: tokenAccountLen,
+  lamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+After the token account creation, the next instruction initializes the
+`immutable owner` extension. The `createInitializeImmutableOwnerInstruction`
+function is used to generate this instruction.
+
+```typescript
+// ENABLE IMMUTABLE OWNER INSTRUCTION
+const initializeImmutableOwnerInstruction =
+  createInitializeImmutableOwnerInstruction(
+    tokenAccount,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+We then add the initialize account instruction by calling
+`createInitializeAccountInstruction` and passing in the required arguments. This
+function is provided by the SPL Token package and it constructs a transaction
+instruction that initializes a new token account.
+
+```typescript
+// INITIALIZE ACCOUNT INSTRUCTION
+const initializeAccountInstruction = createInitializeAccountInstruction(
+  tokenAccount,
+  mint,
+  owner.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+Now that the instructions have been created, the token account can be created
+with an immutable owner.
+
+```typescript
+// SEND TO BLOCKCHAIN
+const transaction = new Transaction().add(
+  createTokenAccountInstruction,
+  initializeImmutableOwnerInstruction,
+  initializeAccountInstruction,
+);
+
+transaction.feePayer = payer.publicKey;
+
+const signature = await sendAndConfirmTransaction(connection, transaction, [
+  payer,
+  owner,
+  tokenAccountKeypair,
+]);
+
+return signature;
+```
+
+Now that we’ve added the functionality for `token-helper`, we can create our
+test token accounts. One of the two test token accounts will be created by
+calling `createTokenAccountWithImmutableOwner`. The other will be created with
+the baked-in SPL helper function `createAssociatedTokenAccount`. This helper
+will create an associated token account which by default includes an immutable
+owner. For the sake of this guide, we'll be testing against both of these
+approaches.
+
+Back in `index.ts` underneath the mint variable, create the following two token
+accounts:
+
+```
+// CREATE TEST TOKEN ACCOUNTS: Create explicitly with immutable owner instructions
+const createOurTokenAccountSignature = await createTokenAccountWithImmutableOwner(
+  connection,
+  mint,
+  payer,
+  payer,
+  ourTokenAccountKeypair
+);
+
+// CREATE TEST TOKEN ACCOUNTS: Create an associated token account with default immutable owner
+const associatedTokenAccount = await createAssociatedTokenAccount(
+  connection,
+  payer,
+  mint,
+  payer.publicKey,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+That's it for the token accounts! Now we can move on and start testing that the
+extension rules are applied correctly by running a few tests against it.
+
+If you'd like to test that everything is working, feel free to run the script.
+
+```bash
+npx esrun src/index.ts
+```
+
+### 6. Tests
+
+**Test trying to transfer owner**
+
+The first token account that is being created is the account is tied to
+`ourTokenAccountKeypair`. We'll be attempting to transfer ownership of the
+account to `otherOwner` which was generated earlier. This test is expected to
+fail as the new authority is not the owner of the account upon creation.
+
+Add the following code to your `src/index.ts` file:
+
+```typescript
+// TEST TRANSFER ATTEMPT ON IMMUTABLE ACCOUNT
+try {
+  await setAuthority(
+    connection,
+    payer,
+    ourTokenAccount,
+    payer.publicKey,
+    AuthorityType.AccountOwner,
+    otherOwner.publicKey,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  console.error("You should not be able to change the owner of the account.");
+} catch (error) {
+  console.log(
+    `✅ - We expected this to fail because the account is immutable, and cannot change owner.`,
+  );
+}
+```
+
+We can now invoke the `setAuthority` function by running
+`npx esrun src/index.ts`. We should see the following error logged out in the
+terminal, meaning the extension is working as we need it to:
+`✅ - We expected this to fail because the account is immutable, and cannot change owner.`
+
+**Test trying to transfer owner with associated token account**
+
+This test will attempt to transfer ownership to the Associated Token Account.
+This test is also expected to fail as the new authority is not the owner of the
+account upon creation.
+
+Below the previous test, add the following try/catch:
+
+```typescript
+// TEST TRANSFER ATTEMPT ON ASSOCIATED IMMUTABLE ACCOUNT
+try {
+  await setAuthority(
+    connection,
+    payer,
+    associatedTokenAccount,
+    payer.publicKey,
+    AuthorityType.AccountOwner,
+    otherOwner.publicKey,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  console.error("You should not be able to change the owner of the account.");
+} catch (error) {
+  console.log(
+    `✅ - We expected this to fail because the associated token account is immutable, and cannot change owner.`,
+  );
+}
+```
+
+Now we can run `npx esrun src/index.ts`. This test should log a failure message
+similar to the one from the previous test. This means that both of our token
+accounts are in fact immutable and working as intended.
+
+Congratulations! We’ve just created token accounts and tested the immutable
+owner extension! If you are stuck at any point, you can find the working code on
+the `solution` branch of
+[this repository](https://github.com/Unboxed-Software/solana-lab-immutable-owner/tree/solution).
+
+# Challenge
+
+Go create your own token account with an immutable owner.

--- a/content/courses/token-extensions/interest-bearing-token.md
+++ b/content/courses/token-extensions/interest-bearing-token.md
@@ -1,0 +1,697 @@
+---
+title: Interest Bearing Token
+objectives:
+  - Create a mint account with the interest bearing extension
+  - Explain the use cases of interest bearing tokens
+  - Experiment with the rules of the extension
+---
+
+# Summary
+
+- Creators can set an interest rate and store it directly on the mint account.
+- The underlying token quantity for interest bearing tokens remains unchanged.
+- The accrued interest can be displayed for UI purposes without the need to
+  frequently rebase or update to adjust for accrued interest.
+- The lab demonstrates configuring a mint account that is set to mint with an
+  interest rate. The test case also shows how to update the interest rate, along
+  with retrieving the rate from the token.
+
+# Overview
+
+Tokens with values that either increase or decrease over time have practical
+applications in the real world, with bonds being a prime example. Previously,
+the ability to reflect this dynamic in tokens was limited to the use of proxy
+contracts, necessitating frequent rebasing or updates.
+
+The `interest bearing token` extension helps with this. By leveraging the
+`interest bearing token` extension and the `amount_to_ui_amount` function, users
+can apply an interest rate to their tokens and retrieve the updated total,
+including interest, at any given moment.
+
+The calculation of interest is done continuously, factoring in the network's
+timestamp. However, discrepancies in the network's time could result in accrued
+interest being slightly less than anticipated, though this situation is
+uncommon.
+
+It's important to note that this mechanism does not generate new tokens and the
+displayed amount simply includes the accumulated interest, making the change
+purely aesthetic. That being said, this is a value stored on within the mint
+account and programs can take advantage of this to create functionality beyond
+pure aesthetics.
+
+## Adding interest rate to token
+
+Initializing an interest bearing token involves three instructions:
+
+- `SystemProgram.createAccount`
+- `createInitializeTransferFeeConfigInstruction`
+- `createInitializeMintInstruction`
+
+The first instruction `SystemProgram.createAccount` allocates space on the
+blockchain for the mint account. This instruction accomplishes three things:
+
+- Allocates `space`
+- Transfers `lamports` for rent
+- Assigns to it's owning program
+
+```typescript
+SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: mint,
+    space: mintLen,
+    lamports: mintLamports,
+    programId: TOKEN_2022_PROGRAM_ID,
+  }),
+```
+
+The second
+instruction `createInitializeInterestBearingMintInstruction` initializes the
+interest bearing token extension. The defining argument that dictates the
+interest rate will be a variable we create named `rate`. The `rate` is defined
+in [basis points](https://www.investopedia.com/terms/b/basispoint.asp).
+
+```typescript
+  createInitializeInterestBearingMintInstruction(
+    mint,
+    rateAuthority.publicKey,
+    rate,
+    TOKEN_2022_PROGRAM_ID,
+  ),
+```
+
+The third instruction `createInitializeMintInstruction` initializes the mint.
+
+```typescript
+createInitializeMintInstruction(
+  mint,
+  decimals,
+  mintAuthority.publicKey,
+  null,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+When the transaction with these three instructions is sent, a new interest
+bearing token is created with the specified rate configuration.
+
+## Fetching accumulated interest
+
+To retrieve the accumulated interest on a token at any given point, first use
+the `getAccount` function to fetch token information, including the amount and
+any associated data, passing in the connection, payer's token account, and the
+relevant program ID, `TOKEN_2022_PROGRAM_ID`.
+
+Next, utilize the `amountToUiAmount` function with the obtained token
+information, along with additional parameters such as connection, payer, and
+mint, to convert the token amount to its corresponding UI amount, which
+inherently includes any accumulated interest.
+
+```typescript
+const tokenInfo = await getAccount(
+  connection,
+  payerTokenAccount,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+/**
+ * Get the amount as a string using mint-prescribed decimals
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param mint           Mint for the account
+ * @param amount         Amount of tokens to be converted to Ui Amount
+ * @param programId      SPL Token program account
+ *
+ * @return Ui Amount generated
+ */
+const uiAmount = await amountToUiAmount(
+  connection,
+  payer,
+  mint,
+  tokenInfo.amount,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+console.log("UI Amount: ", uiAmount);
+```
+
+The return value of `uiAmount` is a string representation of the UI amount and
+will look similar to this: `0.0000005000001557528245`.
+
+## Update rate authority
+
+Solana provides a helper function, `setAuthority`, to set a new authority on an
+interest bearing token.
+
+Use the `setAuthority` function to assign a new authority to the account. You'll
+need to provide the `connection`, the account paying for transaction fees
+(payer), the token account to update (mint), the current authority's public key,
+the type of authority to update (in this case, 7 represents the `InterestRate`
+authority type), and the new authority's public key.
+
+After setting the new authority, use the `updateRateInterestBearingMint`
+function to update the interest rate for the account. Pass in the necessary
+parameters: `connection`, `payer`, `mint`, the new authority's public key, the
+updated interest rate, and the program ID.
+
+```typescript
+/**
+ * Assign a new authority to the account
+ *
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param account          Address of the account
+ * @param currentAuthority Current authority of the specified type
+ * @param authorityType    Type of authority to set
+ * @param newAuthority     New authority of the account
+ * @param multiSigners     Signing accounts if `currentAuthority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+
+await setAuthority(
+  connection,
+  payer,
+  mint,
+  rateAuthority,
+  AuthorityType.InterestRate, // Rate type (InterestRate)
+  otherAccount.publicKey, // new rate authority,
+  [],
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+await updateRateInterestBearingMint(
+  connection,
+  payer,
+  mint,
+  otherAccount, // new rate authority
+  10, // updated rate
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+# Lab
+
+In this lab, we're establishing Interest Bearing Tokens via the Token-2022
+program on Solana. We'll initialize these tokens with a specific interest rate,
+update the rate with proper authorization, and observe how interest accumulates
+on tokens over time.
+
+### 1. Setup Environment
+
+To get started, create an empty directory named `interest-bearing-token` and
+navigate to it. Run `npm init -y` to initialize a brand new project.
+
+Next, we'll need to add our dependencies. Run the following to install the
+required packages:
+
+```bash
+npm i @solana-developers/helpers @solana/spl-token @solana/web3.js esrun dotenv typescript
+```
+
+Create a directory named `src`. In this directory, create a file named
+`index.ts`. This is where we will run checks against the rules of this
+extension. Paste the following code in `index.ts`:
+
+```ts
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+
+import {
+  ExtensionType,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+  getMint,
+  getInterestBearingMintConfigState,
+  updateRateInterestBearingMint,
+  amountToUiAmount,
+  mintTo,
+  createAssociatedTokenAccount,
+  getAccount,
+  AuthorityType,
+} from "@solana/spl-token";
+
+import { initializeKeypair, makeKeypairs } from "@solana-developers/helpers";
+
+const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+const payer = await initializeKeypair(connection);
+const [otherAccount, mintKeypair] = makeKeypairs(2);
+const mint = mintKeypair.publicKey;
+const rateAuthority = payer;
+
+const rate = 32_767;
+
+// Create an interest-bearing token
+
+// Create an associated token account
+
+// Create the getInterestBearingMint function
+
+// Attempt to update the interest rate
+
+// Attempt to update the interest rate with the incorrect owner
+
+// Log the accrued interest
+
+// Log the interest-bearing mint configuration state
+
+// Update the rate authority and attempt to update the interest rate with the new authority
+```
+
+`index.ts` creates a connection to the specified validator node and calls
+`initializeKeypair`. It also has a few variables we will be using in the rest of
+this lab. The `index.ts` is where we'll end up calling the rest of our script
+once we've written it.
+
+### 2. Run validator node
+
+For the sake of this guide, we'll be running our own validator node.
+
+In a separate terminal, run the following command: `solana-test-validator`. This
+will run the node and also log out some keys and values. The value we need to
+retrieve and use in our connection is the JSON RPC URL, which in this case is
+`http://127.0.0.1:8899`. We then use that in the connection to specify to use
+the local RPC URL.
+
+`const connection = new Connection("http://127.0.0.1:8899", "confirmed");`
+
+### 3. Helpers
+
+When we pasted the `index.ts` code from earlier, we added the following helpers:
+
+- `initializeKeypair`: This function creates the keypair for the `payer` and
+  also airdrops 1 testnet SOL to it
+- `makeKeypairs`: This function creates keypairs without airdropping any SOL
+
+Additionally, we have some initial accounts:
+
+- `payer`: Used to pay for and be the authority for everything
+- `mintKeypair`: Our mint that will have the `interest bearing token` extension
+- `otherAccount`: The account we will use to attempt to update interest
+- `otherTokenAccountKeypair`: Another token used for testing
+
+### 4. Create Mint with interest bearing token
+
+This function is where we'll be creating the token such that all new tokens will
+be created with an interest rate. Create a new file inside of `src` named
+`token-helper.ts`.
+
+```typescript
+import {
+  TOKEN_2022_PROGRAM_ID,
+  createInitializeInterestBearingMintInstruction,
+  createInitializeMintInstruction,
+} from "@solana/spl-token";
+import {
+  sendAndConfirmTransaction,
+  Connection,
+  Keypair,
+  Transaction,
+  PublicKey,
+  SystemProgram,
+} from "@solana/web3.js";
+
+export async function createTokenWithInterestRateExtension(
+  connection: Connection,
+  payer: Keypair,
+  mint: PublicKey,
+  mintLen: number,
+  rateAuthority: Keypair,
+  rate: number,
+  mintKeypair: Keypair,
+) {
+  const mintAuthority = payer;
+  const decimals = 9;
+}
+```
+
+This function will take the following arguments:
+
+- `connection`: The connection object
+- `payer`: Payer for the transaction
+- `mint`: Public key for the new mint
+- `rateAuthority`: Keypair of the account that can modify the token, in this
+  case, it is `payer`
+- `rate`: Chosen interest rate for the token. In our case, this will be
+  `32_767`, or 32767, the max rate for the interest bearing token extension
+- `mintKeypair`: Keypair for the new mint
+
+When creating an interest bearing token, we must create the account instruction,
+add the interest instruction and initialize the mint itself. Inside of
+`createTokenWithInterestRateExtension` in `src/token-helper.ts` there are a few
+variables already created that will be used to create the interest bearing
+token. Add the following code beneath the declared variables:
+
+```ts
+const extensions = [ExtensionType.InterestBearingConfig];
+const mintLen = getMintLen(extensions);
+const mintLamports =
+  await connection.getMinimumBalanceForRentExemption(mintLen);
+
+const mintTransaction = new Transaction().add(
+  SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: mint,
+    space: mintLen,
+    lamports: mintLamports,
+    programId: TOKEN_2022_PROGRAM_ID,
+  }),
+  createInitializeInterestBearingMintInstruction(
+    mint,
+    rateAuthority.publicKey,
+    rate,
+    TOKEN_2022_PROGRAM_ID,
+  ),
+  createInitializeMintInstruction(
+    mint,
+    decimals,
+    mintAuthority.publicKey,
+    null,
+    TOKEN_2022_PROGRAM_ID,
+  ),
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  mintTransaction,
+  [payer, mintKeypair],
+  undefined,
+);
+```
+
+That's it for the token creation! Now we can move on and start adding tests.
+
+### 5. Establish required accounts
+
+Inside of `src/index.ts`, the starting code already has some values related to
+the creation of the interest bearing token.
+
+Underneath the existing `rate` variable, add the following function call to
+`createTokenWithInterestRateExtension` to create the interest bearing token.
+We'll also need to create an associated token account which we'll be using to
+mint the interest bearing tokens to and also run some tests to check if the
+accrued interest increases as expected.
+
+```typescript
+const rate = 32_767;
+
+// Create interest bearing token
+await createTokenWithInterestRateExtension(
+  connection,
+  payer,
+  mint,
+  rateAuthority,
+  rate,
+  mintKeypair,
+);
+
+// Create associated token account
+const payerTokenAccount = await createAssociatedTokenAccount(
+  connection,
+  payer,
+  mint,
+  payer.publicKey,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+## 6. Tests
+
+Before we start writing any tests, it would be helpful for us to have a function
+that takes in the `mint` and returns the current interest rate of that
+particular token.
+
+Let's utilize the `getInterestBearingMintConfigState` helper provided by the SPL
+library to do just that. We'll then create a function that is used in our tests
+to log out the current interest rate of the mint.
+
+The return value of this function is an object with the following values:
+
+- `rateAuthority`: Keypair of the account that can modify the token
+- `initializationTimestamp`: Timestamp of interest bearing token initialization
+- `preUpdateAverageRate`: Last rate before update
+- `lastUpdateTimestamp`: Timestamp of last update
+- `currentRate`: Current interest rate
+
+Add the following types and function:
+
+```typescript
+// Create getInterestBearingMint function
+interface GetInterestBearingMint {
+  connection: Connection;
+  mint: PublicKey;
+}
+
+async function getInterestBearingMint(inputs: GetInterestBearingMint) {
+  const { connection, mint } = inputs;
+  // retrieves information of the mint
+  const mintAccount = await getMint(
+    connection,
+    mint,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  // retrieves the interest state of mint
+  const interestBearingMintConfig =
+    await getInterestBearingMintConfigState(mintAccount);
+
+  // returns the current interest rate
+  return interestBearingMintConfig?.currentRate;
+}
+```
+
+**Updating interest rate**
+
+The Solana SPL library provides a helper function for updating the interest rate
+of a token named `updateRateInterestBearingMint`. For this function to work
+correctly, the `rateAuthority` of that token must be the same one of which the
+token was created. If the `rateAuthority` is incorrect, updating the token will
+result in a failure.
+
+Let's create a test to update the rate with the correct authority. Add the
+following function calls:
+
+```typescript
+// Attempt to update interest rate
+const initialRate = await getInterestBearingMint({ connection, mint });
+try {
+  await updateRateInterestBearingMint(
+    connection,
+    payer,
+    mint,
+    payer,
+    0, // updated rate
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+  const newRate = await getInterestBearingMint({ connection, mint });
+
+  console.log(
+    `✅ - We expected this to pass because the rate has been updated. Old rate: ${initialRate}. New rate: ${newRate}`,
+  );
+} catch (error) {
+  console.error("You should be able to update the interest.");
+}
+```
+
+Run `npx esrun src/index.ts`. We should see the following error logged out in
+the terminal, meaning the extension is working as intended and the interest rate
+has been updated:
+`✅ - We expected this to pass because the rate has been updated. Old rate: 32767. New rate: 0`
+
+**Updating interest rate with incorrect rate authority**
+
+In this next test, let's try and update the interest rate with the incorrect
+`rateAuthority`. Earlier we created a keypair named `otherAccount`. This will be
+what we use as the `otherAccount` to attempt the change the interest rate.
+
+Below the previous test we created add the following code:
+
+```typescript
+// Attempt to update the interest rate as the account other than the rate authority.
+try {
+  await updateRateInterestBearingMint(
+    connection,
+    otherAccount,
+    mint,
+    otherAccount, // incorrect authority
+    0, // updated rate
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+  console.log("You should be able to update the interest.");
+} catch (error) {
+  console.error(
+    `✅ - We expected this to fail because the owner is incorrect.`,
+  );
+}
+```
+
+Now run `npx esrun src/index.ts`. This is expected to fail and log out
+`✅ - We expected this to fail because the owner is incorrect.`
+
+**Mint tokens and read interest rate**
+
+So we’ve tested updating the interest rate. How do we check that the accrued
+interest increases when an account mints more tokens? We can use the
+`amountToUiAmount` and `getAccount` helpers from the SPL library to help us
+achieve this.
+
+Let's create a for loop that 5 times and mints 100 tokens per loop and logs out
+the new accrued interest:
+
+```typescript
+// Log accrued interest
+{
+  // Logs out interest on token
+  for (let i = 0; i < 5; i++) {
+    const rate = await getInterestBearingMint({ connection, mint });
+    await mintTo(
+      connection,
+      payer,
+      mint,
+      payerTokenAccount,
+      payer,
+      100,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+    const tokenInfo = await getAccount(
+      connection,
+      payerTokenAccount,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+    // Convert amount to UI amount with accrued interest
+    const uiAmount = await amountToUiAmount(
+      connection,
+      payer,
+      mint,
+      tokenInfo.amount,
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+    console.log(
+      `Amount with accrued interest at ${rate}: ${tokenInfo.amount} tokens = ${uiAmount}`,
+    );
+  }
+}
+```
+
+You should see something similar to the logs below:
+
+```typescript
+Amount with accrued interest at 32767: 100 tokens = 0.0000001000000207670422
+Amount with accrued interest at 32767: 200 tokens = 0.0000002000000623011298
+Amount with accrued interest at 32767: 300 tokens = 0.0000003000001246022661
+Amount with accrued interest at 32767: 400 tokens = 0.00000040000020767045426
+Amount with accrued interest at 32767: 500 tokens = 0.0000005000003634233328
+```
+
+As you can see, the interest rate increases as more tokens are minted!
+
+**Log mint config**
+
+If for some reason you need to retrieve the mint config state, we can utilize
+the `getInterestBearingMintConfigState` function we created earlier to display
+information about the interest bearing mint state.
+
+```ts
+// Log interest bearing mint config state
+const mintAccount = await getMint(
+  connection,
+  mint,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+// Get Interest Config for Mint Account
+const interestBearingMintConfig =
+  await getInterestBearingMintConfigState(mintAccount);
+
+console.log(
+  "\nMint Config:",
+  JSON.stringify(interestBearingMintConfig, null, 2),
+);
+```
+
+This should log out something that looks similar to this:
+
+```typescript
+Mint Config: {
+  "rateAuthority": "Ezv2bZZFTQEznBgTDmaPPwFCg7uNA5KCvMGBNvJvUmS",
+  "initializationTimestamp": 1709422265,
+  "preUpdateAverageRate": 32767,
+  "lastUpdateTimestamp": 1709422267,
+  "currentRate": 0
+}
+```
+
+## Update rate authority and interest rate
+
+Before we conclude this lab, let's set a new rate authority on the interest
+bearing token and attempt to update the interest rate. We do this by using the
+`setAuthority` function and passing in the original authority, specifying the
+rate type (in this case it is 7 for `InterestRate`) and passing the new
+authority's public key.
+
+Once we set the new authority, we can attempt to update the interest rate.
+
+```typescript
+// Update rate authority and attempt to update interest rate with new authority
+try {
+  await setAuthority(
+    connection,
+    payer,
+    mint,
+    rateAuthority,
+    AuthorityType.InterestRate, // Rate type (InterestRate)
+    otherAccount.publicKey, // new rate authority,
+    [],
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await updateRateInterestBearingMint(
+    connection,
+    payer,
+    mint,
+    otherAccount, // new authority
+    10, // updated rate
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  const newRate = await getInterestBearingMint({ connection, mint });
+
+  console.log(
+    `✅ - We expected this to pass because the rate can be updated with the new authority. New rate: ${newRate}`,
+  );
+} catch (error) {
+  console.error(
+    `You should be able to update the interest with new rate authority.`,
+  );
+}
+```
+
+This is expected to work and the new interest rate should be 10.
+
+Thats it! We’ve just created an interest bearing token, updated the interest
+rate and logged the updated state of the token!
+
+# Challenge
+
+Create your own interest bearing token.

--- a/content/courses/token-extensions/interest-bearing-token.md
+++ b/content/courses/token-extensions/interest-bearing-token.md
@@ -7,7 +7,7 @@ objectives:
 description: "Make a token that earns interest over time."
 ---
 
-# Summary
+## Summary
 
 - Creators can set an interest rate and store it directly on the mint account.
 - The underlying token quantity for interest bearing tokens remains unchanged.
@@ -17,7 +17,7 @@ description: "Make a token that earns interest over time."
   interest rate. The test case also shows how to update the interest rate, along
   with retrieving the rate from the token.
 
-# Overview
+## Overview
 
 Tokens with values that either increase or decrease over time have practical
 applications in the real world, with bonds being a prime example. Previously,
@@ -40,7 +40,7 @@ purely aesthetic. That being said, this is a value stored on within the mint
 account and programs can take advantage of this to create functionality beyond
 pure aesthetics.
 
-## Adding interest rate to token
+### Adding interest rate to token
 
 Initializing an interest bearing token involves three instructions:
 
@@ -95,7 +95,7 @@ createInitializeMintInstruction(
 When the transaction with these three instructions is sent, a new interest
 bearing token is created with the specified rate configuration.
 
-## Fetching accumulated interest
+### Fetching accumulated interest
 
 To retrieve the accumulated interest on a token at any given point, first use
 the `getAccount` function to fetch token information, including the amount and
@@ -140,7 +140,7 @@ console.log("UI Amount: ", uiAmount);
 The return value of `uiAmount` is a string representation of the UI amount and
 will look similar to this: `0.0000005000001557528245`.
 
-## Update rate authority
+### Update rate authority
 
 Solana provides a helper function, `setAuthority`, to set a new authority on an
 interest bearing token.
@@ -197,14 +197,14 @@ await updateRateInterestBearingMint(
 );
 ```
 
-# Lab
+## Lab
 
 In this lab, we're establishing Interest Bearing Tokens via the Token-2022
 program on Solana. We'll initialize these tokens with a specific interest rate,
 update the rate with proper authorization, and observe how interest accumulates
 on tokens over time.
 
-### 1. Setup Environment
+#### 1. Setup Environment
 
 To get started, create an empty directory named `interest-bearing-token` and
 navigate to it. Run `npm init -y` to initialize a brand new project.
@@ -269,7 +269,7 @@ const rate = 32_767;
 this lab. The `index.ts` is where we'll end up calling the rest of our script
 once we've written it.
 
-### 2. Run validator node
+#### 2. Run validator node
 
 For the sake of this guide, we'll be running our own validator node.
 
@@ -281,7 +281,7 @@ the local RPC URL.
 
 `const connection = new Connection("http://127.0.0.1:8899", "confirmed");`
 
-### 3. Helpers
+#### 3. Helpers
 
 When we pasted the `index.ts` code from earlier, we added the following helpers:
 
@@ -296,7 +296,7 @@ Additionally, we have some initial accounts:
 - `otherAccount`: The account we will use to attempt to update interest
 - `otherTokenAccountKeypair`: Another token used for testing
 
-### 4. Create Mint with interest bearing token
+#### 4. Create Mint with interest bearing token
 
 This function is where we'll be creating the token such that all new tokens will
 be created with an interest rate. Create a new file inside of `src` named
@@ -387,7 +387,7 @@ await sendAndConfirmTransaction(
 
 That's it for the token creation! Now we can move on and start adding tests.
 
-### 5. Establish required accounts
+#### 5. Establish required accounts
 
 Inside of `src/index.ts`, the starting code already has some values related to
 the creation of the interest bearing token.
@@ -422,7 +422,7 @@ const payerTokenAccount = await createAssociatedTokenAccount(
 );
 ```
 
-## 6. Tests
+### 6. Tests
 
 Before we start writing any tests, it would be helpful for us to have a function
 that takes in the `mint` and returns the current interest rate of that
@@ -640,7 +640,7 @@ Mint Config: {
 }
 ```
 
-## Update rate authority and interest rate
+### Update rate authority and interest rate
 
 Before we conclude this lab, let's set a new rate authority on the interest
 bearing token and attempt to update the interest rate. We do this by using the
@@ -693,6 +693,6 @@ This is expected to work and the new interest rate should be 10.
 Thats it! We’ve just created an interest bearing token, updated the interest
 rate and logged the updated state of the token!
 
-# Challenge
+## Challenge
 
 Create your own interest bearing token.

--- a/content/courses/token-extensions/interest-bearing-token.md
+++ b/content/courses/token-extensions/interest-bearing-token.md
@@ -4,6 +4,7 @@ objectives:
   - Create a mint account with the interest bearing extension
   - Explain the use cases of interest bearing tokens
   - Experiment with the rules of the extension
+description: "Make a token that earns interest over time."
 ---
 
 # Summary

--- a/content/courses/token-extensions/permanent-delegate.md
+++ b/content/courses/token-extensions/permanent-delegate.md
@@ -4,6 +4,9 @@ objectives:
   - Create a mint with a permanent delegate
   - Explain the use cases of permanent delegate
   - Experiment with the rules of the extension
+description:
+  "Create a token than can be permanently transferred or burned by a particular
+  account."
 ---
 
 # Summary

--- a/content/courses/token-extensions/permanent-delegate.md
+++ b/content/courses/token-extensions/permanent-delegate.md
@@ -9,7 +9,7 @@ description:
   account."
 ---
 
-# Summary
+## Summary
 
 - The permanent delegate holds global ownership over all token accounts
   associated with the mint
@@ -21,7 +21,7 @@ description:
   administrative functions, such as reassigning tokens, managing token supplies,
   and directly implementing specific policies or rules on the token accounts.
 
-# Overview
+## Overview
 
 The `permanent delegate` extension allows a `permanent delegate` for all tokens
 of the mint. This means one address is capable of transferring or burning any
@@ -45,7 +45,7 @@ the permanent delegate extension is a double-edged sword.
 This all being said - the `permanent delegate` is a very exciting extension that
 adds a world of possibilities to Solana tokens.
 
-## Initializing a permanent delegate to mint
+### Initializing a permanent delegate to mint
 
 Initializing a permanent delegate token involves three instructions:
 
@@ -98,7 +98,7 @@ createInitializeMintInstruction(
 When the transaction with these three instructions is sent, a new permanent
 delegate token is created with the specified configuration.
 
-## Transferring tokens as delegate
+### Transferring tokens as delegate
 
 The `transferChecked` function enables the permanent delegate to securely
 transfer tokens between accounts. This function makes sure that the token
@@ -138,7 +138,7 @@ await transferChecked(
 );
 ```
 
-## Burning tokens as delegate
+### Burning tokens as delegate
 
 The `burnChecked` function allows the permanent delegate to burn tokens from any
 token account of the mint. This function makes sure that the burn operation
@@ -176,7 +176,7 @@ await burnChecked(
 );
 ```
 
-## Assign permissions to a new delegate
+### Assign permissions to a new delegate
 
 The `approveChecked` function approves a delegate to transfer or burn up to a
 maximum number of tokens from an account. This allows the designated delegate to
@@ -234,13 +234,13 @@ await transferChecked(
 );
 ```
 
-# Lab
+## Lab
 
 In this lab, we'll explore the functionality of the `permanent delegate`
 extension by creating a mint account with a permanent delegate and testing
 various interactions with token accounts associated with that mint.
 
-### 1. Setup Environment
+#### 1. Setup Environment
 
 To get started, create an empty directory named `permanent-delegate` and
 navigate to it. We'll be initializing a brand new project. Run `npm init` and
@@ -324,7 +324,7 @@ once we've written it.
 If you run into an error in `initializeKeypair` with airdropping, follow the
 next step.
 
-### 2. Run validator node
+#### 2. Run validator node
 
 For the sake of this guide, we'll be running our own validator node.
 
@@ -345,7 +345,7 @@ Alternatively, if you’d like to use testnet or devnet, import the
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 ```
 
-### 3. Helpers
+#### 3. Helpers
 
 When we pasted the `index.ts` code from earlier, we added the following helpers:
 
@@ -356,7 +356,7 @@ When we pasted the `index.ts` code from earlier, we added the following helpers:
 Additionally we have some initial accounts and variables that will be used to
 test the `permanent delegate` extension!
 
-### 4. Create Mint with permanent delegate
+#### 4. Create Mint with permanent delegate
 
 When creating a mint token with default state, we must create the account
 instruction, initialize the default account state for the mint account and
@@ -519,7 +519,7 @@ export async function createTokenExtensionMintWithPermanentDelegate(
 }
 ```
 
-### 6. Create printBalances function
+#### 6. Create printBalances function
 
 We're going to be creating multiple tests that modify a token account's balance.
 To make it easier to follow along we should probably create a utility function
@@ -550,12 +550,12 @@ async function printBalances(
 }
 ```
 
-### 7. Test Setup
+#### 7. Test Setup
 
 Now that we have the ability to create a mint with a permanent delegate for all
 of its new mint accounts, let's write some tests to see how it functions.
 
-### 7.1 Create Mint with Permanent Delegate
+#### 7.1 Create Mint with Permanent Delegate
 
 Let's first create a mint with `payer` as the permanent delegate. To do this we
 call the `createTokenExtensionMintWithPermanentDelegate` function we just
@@ -572,7 +572,7 @@ await createTokenExtensionMintWithPermanentDelegate(
 );
 ```
 
-### 7.2 Create Test Token Accounts
+#### 7.2 Create Test Token Accounts
 
 Now, let's create three new Token accounts to test with. We can accomplish this
 by calling the `createAccount` helper provided by the SPL Token library. We will
@@ -613,7 +613,7 @@ const carolAccount = await createAccount(
 );
 ```
 
-### 7.3 Mint tokens to accounts
+#### 7.3 Mint tokens to accounts
 
 In the previous step, we created the 3 accounts we need to test the
 `permanent delegate` extension. Next, we need to mint tokens to those accounts
@@ -657,7 +657,7 @@ Bob: 100
 Carol: 100
 ```
 
-### 8. Tests
+#### 8. Tests
 
 Now let's write some tests to show the interactions that can be had with the
 `permanent delegate` extension.
@@ -705,7 +705,7 @@ We'll write the following tests:
    - Attempt to transfer tokens from Bob's account to Carol's account with Carol
      again, but overdraw her allotted control (expect this to fail).
 
-### 8.1 Transfer tokens with the correct delegate
+#### 8.1 Transfer tokens with the correct delegate
 
 In this test, `alice` attempts to transfer tokens from `bob` to herself. This
 test is expected to pass as `alice` is the permanent delegate and has control
@@ -752,7 +752,7 @@ We should see the following error logged out in the terminal, meaning the
 extension is working as intended.
 `✅ Since Alice is the permanent delegate, she has control over all token accounts of this mint`
 
-### 8.2 Transfer tokens with incorrect delegate
+#### 8.2 Transfer tokens with incorrect delegate
 
 In this test, `bob` is going to try to transfer tokens from `alice` to himself.
 Given that `bob` is not the permanent delegate, the attempt won't be successful.
@@ -794,7 +794,7 @@ Go ahead and run the script, the transaction should fail.
 npx esrun src/index.ts
 ```
 
-### 8.3 Transfer from one account to another with the correct delegate
+#### 8.3 Transfer from one account to another with the correct delegate
 
 Lets use the power of the permanent delegate extension to have `alice` transfer
 some tokens from `bob` to `carol`.
@@ -841,7 +841,7 @@ results. You will notice that `bob` now has 80 tokens:
 npx esrun src/index.ts
 ```
 
-### 8.4 Burn with correct delegate
+#### 8.4 Burn with correct delegate
 
 Now let's try and burn some of the tokens from `bob`. This test is expected to
 pass.
@@ -883,7 +883,7 @@ npx esrun src/index.ts
 
 Bob had 5 tokens burned and now only has 75 tokens. Poor Bob!
 
-### 8.5 Burn with incorrect delegate
+#### 8.5 Burn with incorrect delegate
 
 Let's try and burn tokens from an account using the incorrect delegate. This is
 expected to fail as `bob` doesn't have any control over the token accounts.
@@ -919,7 +919,7 @@ Run `npm start`. You will see the following message, indicating that the
 extension is working as intended:
 `✅ We expect this to fail since Bob is not the permanent delegate and has no control over the tokens`
 
-### 8.6. Assign delegate permissions to Carol and transfer
+#### 8.6. Assign delegate permissions to Carol and transfer
 
 With the `permanent delegate` extension, the initial delegate can grant a token
 account permission to hold a certain level of control over the mint tokens. In
@@ -977,7 +977,7 @@ Run the tests again. You will notice that `bob` now only has 65 tokens as
 `carol` has just transferred 10 of his tokens to herself:
 `npx esrun src/index.ts`
 
-### 8.7. Attempt to transfer again
+#### 8.7. Attempt to transfer again
 
 In the previous test, we approved `carol` to be able to transfer 10 tokens to
 herself. This means that she has reached the maximum amount of tokens to send
@@ -1016,6 +1016,6 @@ Run the tests one last time and you will see this message, meaning that the
 Thats it! You've just created a mint account with a permanent delegate and
 tested that the functionality all works!
 
-# Challenge
+## Challenge
 
 Create your own mint account with a permanent delegate.

--- a/content/courses/token-extensions/permanent-delegate.md
+++ b/content/courses/token-extensions/permanent-delegate.md
@@ -1,0 +1,1018 @@
+---
+title: Permanent Delegate
+objectives:
+  - Create a mint with a permanent delegate
+  - Explain the use cases of permanent delegate
+  - Experiment with the rules of the extension
+---
+
+# Summary
+
+- The permanent delegate holds global ownership over all token accounts
+  associated with the mint
+- The permanent delegate has unrestricted permissions to transfer and burn
+  tokens from any token account of that mint
+- This delegate role designates a trusted entity with comprehensive control.
+  Common use cases include sanction compliance and revocable access tokens.
+- With this level of access, the permanent delegate can carry out high-level
+  administrative functions, such as reassigning tokens, managing token supplies,
+  and directly implementing specific policies or rules on the token accounts.
+
+# Overview
+
+The `permanent delegate` extension allows a `permanent delegate` for all tokens
+of the mint. This means one address is capable of transferring or burning any
+token of that mint, from any token account. This makes the extension very
+powerful but can also be very risky. It gives a single address complete control
+over the token supply. This can be good for things like automatic payments,
+recovering drained wallets, and refunds. However, it's a double-edged sword, the
+`permanent delegate` could be stolen or abused. In the words of Uncle Ben, "With
+great power, comes great responsibility."
+
+Imagine a Solana based AirBnb, where NFTs that use permanent delegate are used
+as the keys to unlock the door. When you check-in, the NFT key will be
+transferred to you and you'll be able to enjoy your stay. At the end of your
+stay, the owner will transfer it back from you to them - since they are the
+`permanent delegate`. What happens if your wallet gets drained, or you lose
+access to the key? No worries, the owner can transfer the key from any account
+back to you! But on the other end, say the owner doesn't want you staying there
+anymore, they can revoke it at any time, and you'd be locked out. In this way,
+the permanent delegate extension is a double-edged sword.
+
+This all being said - the `permanent delegate` is a very exciting extension that
+adds a world of possibilities to Solana tokens.
+
+## Initializing a permanent delegate to mint
+
+Initializing a permanent delegate token involves three instructions:
+
+- `SystemProgram.createAccount`
+- `createInitializePermanentDelegateInstruction`
+- `createInitializeMintInstruction`
+
+The first instruction `SystemProgram.createAccount` allocates space on the
+blockchain for the mint account. This instruction accomplishes three things:
+
+- Allocates space
+- Transfers lamports for rent
+- Assigns to its owning program
+
+```typescript
+SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: mint,
+  space: mintLen,
+  lamports: mintLamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+}),
+```
+
+The second instruction `createInitializePermanentDelegateInstruction`
+initializes the permanent delegate extension. The defining argument that
+dictates the permanent delegate will be a variable we create named
+`permanentDelegate`.
+
+```typescript
+createInitializePermanentDelegateInstruction(
+  mint,
+  permanentDelegate.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+),
+```
+
+The third instruction `createInitializeMintInstruction` initializes the mint.
+
+```typescript
+createInitializeMintInstruction(
+  mint,
+  decimals,
+  mintAuthority.publicKey,
+  null,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+When the transaction with these three instructions is sent, a new permanent
+delegate token is created with the specified configuration.
+
+## Transferring tokens as delegate
+
+The `transferChecked` function enables the permanent delegate to securely
+transfer tokens between accounts. This function makes sure that the token
+transfer adheres to the mint's configured rules and requires the delegate to
+sign the transaction.
+
+```ts
+/**
+ * Approve a delegate to transfer up to a maximum number of tokens from an account, asserting the token mint and decimals
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param mint           Address of the mint
+ * @param account        Address of the account
+ * @param delegate       Account authorized to perform a transfer tokens from the source account
+ * @param owner          Owner of the source account
+ * @param amount         Maximum number of tokens the delegate may transfer
+ * @param decimals       Number of decimals in approved amount
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+await transferChecked(
+  connection,
+  payer,
+  bobAccount,
+  mint,
+  carolAccount,
+  permanentDelegate,
+  amountToTransfer,
+  decimals,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+## Burning tokens as delegate
+
+The `burnChecked` function allows the permanent delegate to burn tokens from any
+token account of the mint. This function makes sure that the burn operation
+complies with the mint's rules and requires the delegate to sign the
+transaction.
+
+```ts
+/**
+ * Burn tokens from an account, asserting the token mint and decimals
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param account        Account to burn tokens from
+ * @param mint           Mint for the account
+ * @param owner          Account owner
+ * @param amount         Amount to burn
+ * @param decimals       Number of decimals in amount to burn
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+await burnChecked(
+  connection,
+  payer,
+  bobAccount,
+  mint,
+  permanentDelegate,
+  amountToBurn,
+  decimals,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+## Assign permissions to a new delegate
+
+The `approveChecked` function approves a delegate to transfer or burn up to a
+maximum number of tokens from an account. This allows the designated delegate to
+perform token transfers on behalf of the account owner up to the specified
+limit.
+
+```ts
+/**
+ * Approve a delegate to transfer up to a maximum number of tokens from an account, asserting the token mint and
+ * decimals
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param mint           Address of the mint
+ * @param account        Address of the account
+ * @param delegate       Account authorized to perform a transfer tokens from the source account
+ * @param owner          Owner of the source account
+ * @param amount         Maximum number of tokens the delegate may transfer
+ * @param decimals       Number of decimals in approved amount
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+
+// Approve new delegate to perform actions
+await approveChecked(
+  connection,
+  payer,
+  mint,
+  bobAccount,
+  delegate.publicKey,
+  bob,
+  amountToApprove,
+  decimals,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+// Newly assigned delegate can now transfer from an account
+await transferChecked(
+  connection,
+  payer,
+  bobAccount,
+  mint,
+  carolAccount,
+  carol,
+  amountToTransfer,
+  decimals,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+# Lab
+
+In this lab, we'll explore the functionality of the `permanent delegate`
+extension by creating a mint account with a permanent delegate and testing
+various interactions with token accounts associated with that mint.
+
+### 1. Setup Environment
+
+To get started, create an empty directory named `permanent-delegate` and
+navigate to it. We'll be initializing a brand new project. Run `npm init` and
+follow through the prompts.
+
+Next, we'll need to add our dependencies. Run the following to install the
+required packages:
+
+```bash
+npm i @solana-developers/helpers @solana/spl-token @solana/web3.js esrun
+```
+
+Create a directory named `src`. In this directory, create a file named
+`index.ts`. This is where we will run checks against the rules of this
+extension. Paste the following code in `index.ts`:
+
+```ts
+import {
+  sendAndConfirmTransaction,
+  Connection,
+  Keypair,
+  SystemProgram,
+  Transaction,
+  PublicKey,
+} from "@solana/web3.js";
+
+import {
+  ExtensionType,
+  createInitializeMintInstruction,
+  createInitializePermanentDelegateInstruction,
+  mintTo,
+  createAccount,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+  transferChecked,
+} from "@solana/spl-token";
+import { initializeKeypair } from "@solana-developers/helpers";
+
+const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+const payer = await initializeKeypair(connection);
+
+const mintAuthority = payer;
+const mintKeypair = Keypair.generate();
+const mint = mintKeypair.publicKey;
+const permanentDelegate = payer;
+
+const extensions = [ExtensionType.PermanentDelegate];
+const mintLen = getMintLen(extensions);
+
+const decimals = 9;
+const amountToMint = 100;
+const amountToTransfer = 10;
+const amountToBurn = 5;
+
+// Create mint account with permanent delegate
+
+// Create delegate and destination token accounts
+
+// Mint tokens to accounts
+
+// Attempt to transfer with correct delegate
+
+// Attempt to transfer without correct delegate
+
+// Attempt to transfer from one account to another with correct delegate
+
+// Attempt to burn with correct delegate
+
+// Attempt to burn without correct delegate
+
+// Grant permission to an account to transfer tokens from a different token account
+
+// Try to transfer tokens again with Carol as the delegate, overdrawing her allotted control
+```
+
+`index.ts` creates a connection to the specified validator node and calls
+`initializeKeypair`. It also has a few variables we will be using in the rest of
+this lab. The `index.ts` is where we'll end up calling the rest of our script
+once we've written it.
+
+If you run into an error in `initializeKeypair` with airdropping, follow the
+next step.
+
+### 2. Run validator node
+
+For the sake of this guide, we'll be running our own validator node.
+
+In a separate terminal, run the following command: `solana-test-validator`. This
+will run the node and also log out some keys and values. The value we need to
+retrieve and use in our connection is the JSON RPC URL, which in this case is
+`http://127.0.0.1:8899`. We then use that in the connection to specify to use
+the local RPC URL.
+
+```typescript
+const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+```
+
+Alternatively, if you’d like to use testnet or devnet, import the
+`clusterApiUrl` from `@solana/web3.js` and pass it to the connection as such:
+
+```typescript
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+```
+
+### 3. Helpers
+
+When we pasted the `index.ts` code from earlier, we added the following helpers:
+
+- `initializeKeypair`: This function creates the keypair for the `payer` and
+  also airdrops some SOL to it
+- `makeKeypairs`: This function creates keypairs without airdropping any SOL
+
+Additionally we have some initial accounts and variables that will be used to
+test the `permanent delegate` extension!
+
+### 4. Create Mint with permanent delegate
+
+When creating a mint token with default state, we must create the account
+instruction, initialize the default account state for the mint account and
+initialize the mint itself.
+
+Create an asynchronous function named
+`createTokenExtensionMintWithPermanentDelegate` in `src/mint-helper.ts`. This
+function will create the mint such that all new mints will be created with a
+permanent delegate. The function will take the following arguments:
+
+- `connection`: The connection object
+- `payer`: Payer for the transaction
+- `mintKeypair`: Keypair for the new mint
+- `decimals`: Mint decimals
+- `permanentDelegate`: Assigned delegate keypair
+
+The first step in creating a mint is reserving space on Solana with the
+`SystemProgram.createAccount` method. This requires specifying the payer's
+keypair, (the account that will fund the creation and provide SOL for rent
+exemption), the new mint account's public key (`mintKeypair.publicKey`), the
+space required to store the mint information on the blockchain, the amount of
+SOL (lamports) necessary to exempt the account from rent and the ID of the token
+program that will manage this mint account (`TOKEN_2022_PROGRAM_ID`).
+
+```typescript
+const extensions = [ExtensionType.PermanentDelegate];
+const mintLen = getMintLen(extensions);
+const mintLamports =
+  await connection.getMinimumBalanceForRentExemption(mintLen);
+
+const createAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: mint,
+  space: mintLen,
+  lamports: mintLamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+After the mint account creation, the next step involves initializing it with a
+permanent delegate. The `createInitializePermanentDelegateInstruction` function
+is used to generate an instruction that enables the mint to set the permanent
+delegate of any new mint accounts.
+
+```typescript
+const initializePermanentDelegateInstruction =
+  createInitializePermanentDelegateInstruction(
+    mint,
+    permanentDelegate.publicKey,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+Next, let's add the mint instruction by calling
+`createInitializeMintInstruction` and passing in the required arguments. This
+function is provided by the SPL Token package and it constructs a transaction
+instruction that initializes a new mint.
+
+```typescript
+const initializeMintInstruction = createInitializeMintInstruction(
+  mint,
+  decimals,
+  mintAuthority.publicKey, // Designated Mint Authority
+  null, // No Freeze Authority
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+Lastly, let's add all of the instructions to a transaction and send it to the
+blockchain:
+
+```typescript
+const transaction = new Transaction().add(
+  createAccountInstruction,
+  initializePermanentDelegateInstruction,
+  initializeMintInstruction,
+);
+
+return await sendAndConfirmTransaction(connection, transaction, [
+  payer,
+  mintKeypair,
+]);
+```
+
+Putting it all together, the final `src/mint-helper.ts` file will look like
+this:
+
+```ts
+import {
+  ExtensionType,
+  TOKEN_2022_PROGRAM_ID,
+  createInitializeMintInstruction,
+  createInitializePermanentDelegateInstruction,
+  getMintLen,
+} from "@solana/spl-token";
+import {
+  Connection,
+  Keypair,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+
+/**
+ * Creates the mint with a permanent delegate
+ * @param connection
+ * @param payer
+ * @param mintKeypair
+ * @param decimals
+ * @param permanentDelegate
+ * @returns signature of the transaction
+ */
+export async function createTokenExtensionMintWithPermanentDelegate(
+  connection: Connection,
+  payer: Keypair,
+  mintKeypair: Keypair,
+  decimals: number = 2,
+  permanentDelegate: Keypair,
+): Promise<string> {
+  const mintAuthority = payer;
+  const mint = mintKeypair.publicKey;
+
+  const extensions = [ExtensionType.PermanentDelegate];
+  const mintLen = getMintLen(extensions);
+  const mintLamports =
+    await connection.getMinimumBalanceForRentExemption(mintLen);
+  const createAccountInstruction = SystemProgram.createAccount({
+    fromPubkey: payer.publicKey,
+    newAccountPubkey: mint,
+    space: mintLen,
+    lamports: mintLamports,
+    programId: TOKEN_2022_PROGRAM_ID,
+  });
+
+  const initializePermanentDelegateInstruction =
+    createInitializePermanentDelegateInstruction(
+      mint,
+      permanentDelegate.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+  const initializeMintInstruction = createInitializeMintInstruction(
+    mint,
+    decimals,
+    mintAuthority.publicKey, // Designated Mint Authority
+    null, // No Freeze Authority
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  const transaction = new Transaction().add(
+    createAccountInstruction,
+    initializePermanentDelegateInstruction,
+    initializeMintInstruction,
+  );
+
+  return await sendAndConfirmTransaction(connection, transaction, [
+    payer,
+    mintKeypair,
+  ]);
+}
+```
+
+### 6. Create printBalances function
+
+We're going to be creating multiple tests that modify a token account's balance.
+To make it easier to follow along we should probably create a utility function
+that prints all token account balances.
+
+At the bottom of the `src/index.ts` file add the following `printBalances`
+function:
+
+```typescript
+async function printBalances(
+  connection: Connection,
+  tokenAccounts: PublicKey[],
+  names: string[],
+) {
+  if (tokenAccounts.length !== names.length)
+    throw new Error("Names needs to be one to one with accounts");
+
+  for (let i = 0; i < tokenAccounts.length; i++) {
+    const tokenInfo = await getAccount(
+      connection,
+      tokenAccounts[i],
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+    console.log(`${names[i]}: ${tokenInfo.amount}`);
+  }
+}
+```
+
+### 7. Test Setup
+
+Now that we have the ability to create a mint with a permanent delegate for all
+of its new mint accounts, let's write some tests to see how it functions.
+
+### 7.1 Create Mint with Permanent Delegate
+
+Let's first create a mint with `payer` as the permanent delegate. To do this we
+call the `createTokenExtensionMintWithPermanentDelegate` function we just
+created in our `index.ts` file:
+
+```ts
+// Create mint account with permanent delegate
+await createTokenExtensionMintWithPermanentDelegate(
+  connection,
+  payer, // Also known as alice
+  mintKeypair,
+  decimals,
+  defaultState,
+);
+```
+
+### 7.2 Create Test Token Accounts
+
+Now, let's create three new Token accounts to test with. We can accomplish this
+by calling the `createAccount` helper provided by the SPL Token library. We will
+use the keypairs we generated at the beginning: `alice`, `bob`, and `carol`.
+
+In this lab, `alice` will be the permanent delegate.
+
+```typescript
+// Create delegate and destination token accounts
+const aliceAccount = await createAccount(
+  connection,
+  payer,
+  mint,
+  alice.publicKey,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+const bobAccount = await createAccount(
+  connection,
+  payer,
+  mint,
+  bob.publicKey,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+const carolAccount = await createAccount(
+  connection,
+  payer,
+  mint,
+  carol.publicKey,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+### 7.3 Mint tokens to accounts
+
+In the previous step, we created the 3 accounts we need to test the
+`permanent delegate` extension. Next, we need to mint tokens to those accounts
+before we write the tests.
+
+Add the `tokenAccounts` and `names` variables and then create a for loop that
+iterates over each account and mints 100 tokens to each account. Call the
+`printBalances` function so we can display the token balance of each account:
+
+```typescript
+// Mint tokens to accounts
+const tokenAccounts = [aliceAccount, bobAccount, carolAccount];
+const names = ["Alice", "Bob", "Carol"];
+
+for (const holder of tokenAccounts) {
+  await mintTo(
+    connection,
+    payer,
+    mint,
+    holder,
+    mintAuthority,
+    amountToMint,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+}
+
+console.log("Initial Balances: ");
+await printBalances(connection, tokenAccounts, names);
+```
+
+Start your local validator and run `npx esrun src/index.ts`. You should see the
+following in your terminal, indicating that our token accounts have had tokens
+minted to them:
+
+```bash
+Initial Balances:
+Alice: 100
+Bob: 100
+Carol: 100
+```
+
+### 8. Tests
+
+Now let's write some tests to show the interactions that can be had with the
+`permanent delegate` extension.
+
+We'll write the following tests:
+
+1. **Attempt to Transfer with Correct Delegate:**
+
+   - Have Alice transfer tokens from Bob's account to herself successfully since
+     she is the permanent delegate.
+   - Print balances to verify the transfer.
+
+2. **Attempt to Transfer without Correct Delegate:**
+
+   - Have Bob attempt to transfer tokens from Alice's account to himself (expect
+     this to fail since Bob isn't authorized).
+   - Print balances to verify the failure.
+
+3. **Attempt to Transfer from One Account to Another with Correct Delegate:**
+
+   - Have Alice transfer tokens from Bob's account to Carol's account.
+   - Print balances to verify the transfer.
+
+4. **Attempt to Burn with Correct Delegate:**
+
+   - Have Alice burn tokens from Bob's account successfully since she is the
+     permanent delegate.
+   - Print balances to verify the burning.
+
+5. **Attempt to Burn without Correct Delegate:**
+
+   - Have Bob attempt to burn tokens from Carol's account (expect this to fail
+     since Bob isn't authorized).
+   - Print balances to verify the failure.
+
+6. **Grant Permission to an Account to Transfer Tokens from a Different Token
+   Account:**
+
+   - Approve Carol to transfer tokens from Bob's account to herself.
+   - Transfer tokens from Bob's account to Carol's account.
+   - Print balances to verify the transfer.
+
+7. **Try to Transfer Tokens Again with Carol as the Delegate, Overdrawing Her
+   Allotted Control:**
+   - Attempt to transfer tokens from Bob's account to Carol's account with Carol
+     again, but overdraw her allotted control (expect this to fail).
+
+### 8.1 Transfer tokens with the correct delegate
+
+In this test, `alice` attempts to transfer tokens from `bob` to herself. This
+test is expected to pass as `alice` is the permanent delegate and has control
+over the token accounts of that mint.
+
+To do this, let's wrap a `transferChecked` function in a `try catch` and print
+out the balances of our accounts:
+
+```typescript
+// Attempt to transfer with correct delegate
+{
+  // Have Alice transfer tokens from Bob to herself ( Will Succeed )
+  try {
+    await transferChecked(
+      connection,
+      payer,
+      bobAccount,
+      mint,
+      aliceAccount,
+      alice,
+      amountToTransfer,
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+    console.log(
+      "✅ Since Alice is the permanent delegate, she has control over all token accounts of this mint",
+    );
+    await printBalances(connection, tokenAccounts, names);
+  } catch (error) {
+    console.log("Alice should be able to transfer Bob's tokens to Alice");
+  }
+}
+```
+
+Test this by running the script:
+
+```bash
+npx esrun src/index.ts
+```
+
+We should see the following error logged out in the terminal, meaning the
+extension is working as intended.
+`✅ Since Alice is the permanent delegate, she has control over all token accounts of this mint`
+
+### 8.2 Transfer tokens with incorrect delegate
+
+In this test, `bob` is going to try to transfer tokens from `alice` to himself.
+Given that `bob` is not the permanent delegate, the attempt won't be successful.
+
+Similar to the previous test we can create this test by calling
+`transferChecked` and then printing the balances:
+
+```typescript
+// Attempt to transfer without correct delegate
+{
+  // Have Bob try to transfer tokens from Alice to himself ( Will Fail )
+  try {
+    await transferChecked(
+      connection,
+      payer,
+      aliceAccount, // transfer from
+      mint,
+      bobAccount,
+      bob, // incorrect delegate
+      amountToTransfer,
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+    console.log("Bob should not be able to transfer tokens");
+  } catch (error) {
+    console.log(
+      "✅ We expect this to fail because Bob does not have authority over Alice's funds",
+    );
+    await printBalances(connection, tokenAccounts, names);
+  }
+}
+```
+
+Go ahead and run the script, the transaction should fail.
+
+```bash
+npx esrun src/index.ts
+```
+
+### 8.3 Transfer from one account to another with the correct delegate
+
+Lets use the power of the permanent delegate extension to have `alice` transfer
+some tokens from `bob` to `carol`.
+
+We expect this test to succeed. Remember, the permanent delegate has control
+over **all** token accounts of the mint.
+
+To test this, let's wrap a `transferChecked` function in a `try catch` and print
+the balances:
+
+```typescript
+// Attempt to transfer from one account to another with correct delegate
+{
+  // Have Alice transfer tokens from Bob to Carol
+  try {
+    await transferChecked(
+      connection,
+      payer,
+      bobAccount, // transfer from
+      mint,
+      carolAccount, // transfer to
+      alice,
+      amountToTransfer,
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+    console.log(
+      "✅ Since Alice is the permanent delegate, she has control and can transfer Bob's tokens to Carol",
+    );
+    await printBalances(connection, tokenAccounts, names);
+  } catch (error) {
+    console.log("Alice should be able to transfer Bob's tokens to Alice");
+  }
+}
+```
+
+In our first test we wrote, `bob` had 10 of his tokens transferred to `carol`.
+Up until this point `bob` has 90 tokens remaining. Run the test and see the
+results. You will notice that `bob` now has 80 tokens:
+
+```bash
+npx esrun src/index.ts
+```
+
+### 8.4 Burn with correct delegate
+
+Now let's try and burn some of the tokens from `bob`. This test is expected to
+pass.
+
+We'll do this by calling `burnChecked` and then printing out the balances:
+
+```typescript
+// Attempt to burn with correct delegate
+{
+  // Have Alice burn Bob's tokens
+  try {
+    await burnChecked(
+      connection,
+      payer,
+      bobAccount,
+      mint,
+      alice, // correct permanent delegate
+      amountToBurn, // in this case is 5
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+    console.log(
+      "✅ Since Alice is the permanent delegate, she has control and can burn Bob's tokens",
+    );
+    await printBalances(connection, tokenAccounts, names);
+  } catch (error) {
+    console.error("Alice should be able to burn Bob's tokens");
+  }
+}
+```
+
+Run the tests again:
+
+```bash
+npx esrun src/index.ts
+```
+
+Bob had 5 tokens burned and now only has 75 tokens. Poor Bob!
+
+### 8.5 Burn with incorrect delegate
+
+Let's try and burn tokens from an account using the incorrect delegate. This is
+expected to fail as `bob` doesn't have any control over the token accounts.
+
+```typescript
+// Attempt to burn without correct delegate
+{
+  // Have Bob try to burn tokens from Carol ( Will Fail )
+  try {
+    await burnChecked(
+      connection,
+      payer,
+      carolAccount,
+      mint,
+      bob, // wrong permanent delegate
+      amountToBurn,
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+    await printBalances(connection, tokenAccounts, names);
+    console.error("Bob should not be able to burn the tokens");
+  } catch (error) {
+    console.log(
+      "✅ We expect this to fail since Bob is not the permanent delegate and has no control over the tokens",
+    );
+  }
+}
+```
+
+Run `npm start`. You will see the following message, indicating that the
+extension is working as intended:
+`✅ We expect this to fail since Bob is not the permanent delegate and has no control over the tokens`
+
+### 8.6. Assign delegate permissions to Carol and transfer
+
+With the `permanent delegate` extension, the initial delegate can grant a token
+account permission to hold a certain level of control over the mint tokens. In
+this case, `alice` will allow `carol` to transfer some of the tokens from `bob`
+account to herself.
+
+For this to work we will need to set some boundaries for `carol`. Using the
+`approveChecked` function provided by the SPL Library, we can set the maximum
+number of tokens that can be transferred or burned by `carol`. This ensures that
+she can only transfer a specified amount, protecting the overall balance from
+excessive or unauthorized transfers.
+
+Add the following test:
+
+```typescript
+// Grant permission to an account to transfer tokens from a different token account
+{
+  // Approve Carol to transfer Bob's tokens to herself
+  await approveChecked(
+    connection,
+    payer,
+    mint,
+    bobAccount,
+    carol.publicKey,
+    bob,
+    amountToTransfer, // maximum amount to transfer
+    decimals,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  await transferChecked(
+    connection,
+    payer,
+    bobAccount,
+    mint,
+    carolAccount,
+    carol,
+    amountToTransfer,
+    decimals,
+    undefined,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+
+  console.log(
+    "✅ Since Alice is the permanent delegate, she can allow Carol to transfer Bob's tokens to Carol",
+  );
+  await printBalances(connection, tokenAccounts, names);
+}
+```
+
+Run the tests again. You will notice that `bob` now only has 65 tokens as
+`carol` has just transferred 10 of his tokens to herself:
+`npx esrun src/index.ts`
+
+### 8.7. Attempt to transfer again
+
+In the previous test, we approved `carol` to be able to transfer 10 tokens to
+herself. This means that she has reached the maximum amount of tokens to send
+from another account. Let's write a test and attempt to transfer another 10
+tokens to herself. This is expected to fail.
+
+```typescript
+// Try to transfer tokens again with Carol as the delegate, overdrawing her allotted control
+{
+  // Try to transfer again with Carol as the delegate overdrawing her allotted control
+  try {
+    await transferChecked(
+      connection,
+      payer,
+      bobAccount,
+      mint,
+      carolAccount,
+      carol, // Owner - whoever has the authority to transfer tokens on behalf of the destination account
+      amountToTransfer,
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    );
+  } catch (e) {
+    console.log(
+      `✅ We expect this to fail since Carol already transferred ${amountToTransfer} tokens and has no more allotted`,
+    );
+  }
+}
+```
+
+Run the tests one last time and you will see this message, meaning that the
+`✅ We expect this to fail since Carol already transferred 10 tokens and has no more allotted`
+
+Thats it! You've just created a mint account with a permanent delegate and
+tested that the functionality all works!
+
+# Challenge
+
+Create your own mint account with a permanent delegate.

--- a/content/courses/token-extensions/required-memo.md
+++ b/content/courses/token-extensions/required-memo.md
@@ -5,6 +5,7 @@ objectives:
   - Transfer with memo
   - Transfer without memo
   - Disable required memo
+description: "Create a token that requires a short note on every transfer."
 ---
 
 # Summary

--- a/content/courses/token-extensions/required-memo.md
+++ b/content/courses/token-extensions/required-memo.md
@@ -1,0 +1,606 @@
+---
+title: Required Memo
+objectives:
+  - Create a token account with required memo on transfer
+  - Transfer with memo
+  - Transfer without memo
+  - Disable required memo
+---
+
+# Summary
+
+- The `required memo` extension allows developers to mandate that all incoming
+  transfers to a token account include a memo, facilitating enhanced transaction
+  tracking and user identification.
+- When a transfer is initiated without a memo, the transaction will fail.
+- The `required memo` extension can be disabled by calling
+  `disableRequiredMemoTransfers`.
+
+# Overview
+
+For certain applications, such as exchanges or financial services, tracking the
+purpose or origin of a transaction is crucial. The `required memo` extension
+specifies that a memo is necessary for every incoming transfer to a token
+account. This requirement ensures that each transaction is accompanied by
+additional information, which can be used for compliance, auditing, or
+user-specific purposes. If the need for strict tracking diminishes, the
+requirement can be adjusted to make memos optional, offering flexibility in how
+transactions are handled and recorded.
+
+It is important to note that this is a token account extension, not a mint
+extension. This means individual token accounts need to enable this feature. And
+like all extensions, this will only work with Token Extensions Program tokens.
+
+## Creating token with required memo
+
+Initializing a token account with required memo involves three instructions:
+
+- `SystemProgram.createAccount`
+- `initializeAccountInstruction`
+- `createEnableRequiredMemoTransfersInstruction`
+
+The first instruction `SystemProgram.createAccount` allocates space on the
+blockchain for the token account. This instruction accomplishes three things:
+
+- Allocates `space`
+- Transfers `lamports` for rent
+- Assigns to it's owning program
+
+```tsx
+const accountLen = getAccountLen([ExtensionType.MemoTransfer]);
+const lamports = await connection.getMinimumBalanceForRentExemption(accountLen);
+
+const createAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: tokenAccountKeypair.publicKey,
+  space: accountLen,
+  lamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+The second instruction `createInitializeAccountInstruction` initializes the
+account instruction.
+
+```tsx
+const initializeAccountInstruction = createInitializeAccountInstruction(
+  tokenAccountKeypair.publicKey,
+  mint,
+  payer.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+The third instruction `createEnableRequiredMemoTransfersInstruction` initializes
+the token account with required memo.
+
+```tsx
+const enableRequiredMemoTransfersInstruction =
+  createEnableRequiredMemoTransfersInstruction(
+    tokenAccountKeypair.publicKey,
+    payer.publicKey,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+When the transaction with these three instructions is sent, a new token account
+is created with the required memo extension.
+
+```tsx
+const transaction = new Transaction().add(
+  createAccountInstruction,
+  initializeAccountInstruction,
+  enableRequiredMemoTransfersInstruction,
+);
+
+const transactionSignature = await sendAndConfirmTransaction(
+  connection,
+  transaction,
+  [payer, tokenAccountKeypair], // Signers
+);
+```
+
+## Transferring with required memo
+
+When transferring to a token account with the `required memo` instruction
+enabled, you need to send a memo first within the same transaction. We do this
+by creating a memo instruction to call the Memo program. Then, we add in our
+transfer instruction.
+
+```ts
+const message = "Hello, Solana";
+
+const transaction = new Transaction().add(
+  new TransactionInstruction({
+    keys: [{ pubkey: payer.publicKey, isSigner: true, isWritable: true }],
+    data: Buffer.from(message, "utf-8"), // Memo message. In this case it is "Hello, Solana"
+    programId: new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"), // Memo program that validates keys and memo message
+  }),
+  createTransferInstruction(
+    ourTokenAccount,
+    otherTokenAccount, // Has required memo
+    payer.publicKey,
+    amountToTransfer,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  ),
+);
+await sendAndConfirmTransaction(connection, transaction, [payer]);
+```
+
+## Disabling required memo
+
+The required memo extension can be disabled given you have the authority to
+modify the token account. To do this, simply call the
+`disableRequiredMemoTransfers` function and pass in the required arguments.
+
+```tsx
+/**
+ * Disable memo transfers on the given account
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param account        Account to modify
+ * @param owner          Owner of the account
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+await disableRequiredMemoTransfers(
+  connection,
+  payer,
+  otherTokenAccount,
+  payer,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+# Lab
+
+In this lab, we'll create a token account with the required memo extension.
+We'll then write tests to check if the extension is working as intended by
+attempting to transfer funds with and without a memo.
+
+### 1. Setup Environment
+
+To get started, create an empty directory named `required-memo` and navigate to
+it. We'll be initializing a brand new project. Run `npm init` and follow through
+the prompts.
+
+Next, we'll need to add our dependencies. Run the following to install the
+required packages:
+
+```bash
+npm i @solana-developers/helpers @solana/spl-token @solana/web3.js esrun dotenv typescript
+```
+
+Create a directory named `src`. In this directory, create a file named
+`index.ts`. This is where we will run checks against the rules of this
+extension. Paste the following code in `index.ts`:
+
+```ts
+import {
+  TOKEN_2022_PROGRAM_ID,
+  getAccount,
+  mintTo,
+  createTransferInstruction,
+  createMint,
+  disableRequiredMemoTransfers,
+  enableRequiredMemoTransfers,
+} from "@solana/spl-token";
+import {
+  sendAndConfirmTransaction,
+  Connection,
+  Transaction,
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
+// import { createTokenWithMemoExtension } from "./token-helper"; // We'll uncomment this later
+import { initializeKeypair, makeKeypairs } from "@solana-developers/helpers";
+
+require("dotenv").config();
+
+const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+const payer = await initializeKeypair(connection);
+const mintDecimals = 9;
+
+const [ourTokenAccountKeypair, otherTokenAccountKeypair] = makeKeypairs(2);
+const ourTokenAccount = ourTokenAccountKeypair.publicKey;
+const otherTokenAccount = otherTokenAccountKeypair.publicKey;
+
+const amountToMint = 1000;
+const amountToTransfer = 300;
+
+// CREATE MINT
+
+// CREATE TOKENS
+
+// MINT TOKENS
+
+// ATTEMPT TO TRANSFER WITHOUT MEMO
+
+// ATTEMPT TO TRANSFER WITH MEMO
+
+// DISABLE MEMO EXTENSION AND TRANSFER
+```
+
+### 2. Run validator node
+
+For the sake of this guide, we'll be running our own validator node.
+
+In a separate terminal, run the following command: `solana-test-validator`. This
+will run the node and also log out some keys and values. The value we need to
+retrieve and use in our connection is the JSON RPC URL, which in this case is
+`http://127.0.0.1:8899`. We then use that in the connection to specify to use
+the local RPC URL.
+
+`const connection = new Connection("http://127.0.0.1:8899", "confirmed");`
+
+Alternatively, if you’d like to use testnet or devnet, import the
+`clusterApiUrl` from `@solana/web3.js` and pass it to the connection as such:
+
+```typescript
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+```
+
+### 3. Helpers
+
+When we pasted the `index.ts` code from earlier, we added the following helpers
+provided by the `@solana-developers/helpers` package and some starting
+variables.
+
+- `initializeKeypair`: This function creates the keypair for the `payer` and
+  also airdrops 1 testnet SOL to it
+- `makeKeypairs`: This function creates keypairs without airdropping any SOL
+
+### 4. Create the mint
+
+First things first, since the `required memo` extension is a token extension, we
+don't need to do anything fancy with the mint. It just needs to be a Token
+Extensions Program mint. That being said, we can just create one using the
+`createMint` function.
+
+Let's do this in `src/index.ts`:
+
+```tsx
+// CREATE MINT
+const mint = await createMint(
+  connection,
+  payer,
+  payer.publicKey,
+  null,
+  mintDecimals,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+### 5. Create Token Account with required memo
+
+Let's create a new file `src/token-helper.ts` and create a new function within
+it called `createTokenWithMemoExtension`. As the name implies, we'll use this to
+create our token accounts with the `required memo` extension enabled. The
+function will take the following arguments:
+
+- `connection`: The connection object
+- `mint`: Public key for the new mint
+- `payer`: Payer for the transaction
+- `tokenAccountKeypair`: The token account keypair associated with the token
+  account
+
+```ts
+import {
+  TOKEN_2022_PROGRAM_ID,
+  getAccountLen,
+  ExtensionType,
+  createInitializeAccountInstruction,
+  createEnableRequiredMemoTransfersInstruction,
+} from "@solana/spl-token";
+import {
+  sendAndConfirmTransaction,
+  Connection,
+  Keypair,
+  Transaction,
+  PublicKey,
+  SystemProgram,
+} from "@solana/web3.js";
+
+export async function createTokenWithMemoExtension(
+  connection: Connection,
+  payer: Keypair,
+  tokenAccountKeypair: Keypair,
+  mint: PublicKey,
+): Promise<string> {
+  // CREATE ACCOUNT INSTRUCTION
+
+  // CREATE INITIALIZE ACCOUNT INSTRUCTION
+
+  // CREATE ENABLE REQUIRED MEMO TRANSFER INSTRUCTION
+
+  // SEND AND CONFIRM TRANSACTION
+
+  return await "TODO FINISH FUNCTION";
+}
+```
+
+Let's start adding our code.
+
+The first step in creating the token account is reserving space on Solana with
+the `SystemProgram.createAccount` method:
+
+```tsx
+// CREATE ACCOUNT INSTRUCTION
+const accountLen = getAccountLen([ExtensionType.MemoTransfer]);
+const lamports = await connection.getMinimumBalanceForRentExemption(accountLen);
+
+const createAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: tokenAccountKeypair.publicKey,
+  space: accountLen,
+  lamports,
+  programId: TOKEN_2022_PROGRAM_ID,
+});
+```
+
+Now we need to initialize the token account. To create this instruction we call
+`createInitializeAccountInstruction` and pass in the required arguments. This
+function is provided by the SPL Token package and it constructs a transaction
+instruction that initializes a new token account.
+
+```tsx
+// CREATE INITIALIZE ACCOUNT INSTRUCTION
+const initializeAccountInstruction = createInitializeAccountInstruction(
+  tokenAccountKeypair.publicKey,
+  mint,
+  payer.publicKey,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+The last instruction we need is the one that enables the required memo. We get
+this by calling the `createEnableRequiredMemoTransfersInstruction` function.
+When the required memos are enabled, any transfer of tokens into the account
+must include a memo.
+
+```tsx
+// CREATE ENABLE REQUIRED MEMO TRANSFERS INSTRUCTION
+const enableRequiredMemoTransfersInstruction =
+  createEnableRequiredMemoTransfersInstruction(
+    tokenAccountKeypair.publicKey,
+    payer.publicKey,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+Lastly, let's add all of the instructions to a transaction, send it to the
+blockchain and return the signature
+
+```tsx
+// SEND AND CONFIRM TRANSACTION
+const transaction = new Transaction().add(
+  createAccountInstruction,
+  initializeAccountInstruction,
+  enableRequiredMemoTransfersInstruction,
+);
+
+const transactionSignature = await sendAndConfirmTransaction(
+  connection,
+  transaction,
+  [payer, tokenAccountKeypair], // Signers
+);
+
+return transactionSignature;
+```
+
+Let's go back to `index.ts` and create two new token accounts:
+`ourTokenAccountKeypair` and `otherTokenAccountKeypair` using our newly created
+function.
+
+```typescript
+// CREATE TOKENS
+await createTokenWithMemoExtension(
+  connection,
+  payer,
+  ourTokenAccountKeypair,
+  mint,
+);
+
+await createTokenWithMemoExtension(
+  connection,
+  payer,
+  otherTokenAccountKeypair,
+  mint,
+);
+```
+
+Lastly, let's call `mintTo` to mint some initial tokens to
+`ourTokenAccountKeypair`:
+
+```ts
+// MINT TOKENS
+await mintTo(
+  connection,
+  payer,
+  mint,
+  ourTokenAccount,
+  payer,
+  amountToMint,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+```
+
+Note: The `required memo` extension only requires a memo on transferring, not
+minting.
+
+### 6. Tests
+
+Now that we've created some accounts with the `required memo` instruction. Let's
+write some tests to see how they function.
+
+We'll write 3 tests in total:
+
+- Transferring without a memo
+- Transferring with a memo
+- Disabling Required Memo extension and transferring without a memo
+
+### 6.1 Transfer without Memo
+
+This first test will attempt to transfer tokens from `ourTokenAccount` to
+`otherTokenAccount`. This test is expected to fail as there is no memo attached
+to the transaction.
+
+```tsx
+// ATTEMPT TO TRANSFER WITHOUT MEMO
+try {
+  const transaction = new Transaction().add(
+    createTransferInstruction(
+      ourTokenAccount,
+      otherTokenAccount,
+      payer.publicKey,
+      amountToTransfer,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+  );
+
+  await sendAndConfirmTransaction(connection, transaction, [payer]);
+
+  console.error("You should not be able to transfer without a memo.");
+} catch (error) {
+  console.log(
+    `✅ - We expected this to fail because you need to send a memo with the transfer.`,
+  );
+}
+```
+
+Run this test, you should see the following error logged out in the terminal,
+meaning the extension is working as intended:
+`✅ - We expected this to fail because you need to send a memo with the transfer.`
+
+```bash
+npx esrun src/index.ts
+```
+
+### 6.2 Test transfer with memo
+
+This test will attempt to transfer tokens with a memo. This test is expected to
+pass. Pay extra attention to the first instruction - It is the part of the
+transaction that adds the memo instruction to it:
+
+```tsx
+// ATTEMPT TO TRANSFER WITH MEMO
+const message = "Hello, Solana";
+
+const transaction = new Transaction().add(
+  new TransactionInstruction({
+    keys: [{ pubkey: payer.publicKey, isSigner: true, isWritable: true }],
+    data: Buffer.from(message, "utf-8"), // Memo message. In this case it is "Hello, Solana"
+    programId: new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"), // Memo program that validates keys and memo message
+  }),
+
+  createTransferInstruction(
+    ourTokenAccount,
+    otherTokenAccount,
+    payer.publicKey,
+    amountToTransfer,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  ),
+);
+await sendAndConfirmTransaction(connection, transaction, [payer]);
+
+const accountAfterMemoTransfer = await getAccount(
+  connection,
+  otherTokenAccount,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+console.log(
+  `✅ - We have transferred ${accountAfterMemoTransfer.amount} tokens to ${otherTokenAccount} with the memo: ${message}`,
+);
+```
+
+Run the test and see that it passes:
+
+```bash
+npx esrun src/index.ts
+```
+
+### 6.3 Test transfer with disabled memo
+
+In our last test, we'll disable the `required memo` extension on the
+`otherTokenAccount` and send it some tokens without a memo. We expect this to
+pass.
+
+```tsx
+// DISABLE MEMO EXTENSION AND TRANSFER
+await disableRequiredMemoTransfers(
+  connection,
+  payer,
+  otherTokenAccount,
+  payer,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+// Transfer tokens to otherTokenAccount
+const transfer = new Transaction().add(
+  createTransferInstruction(
+    ourTokenAccount,
+    otherTokenAccount,
+    payer.publicKey,
+    amountToTransfer,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  ),
+);
+
+await sendAndConfirmTransaction(connection, transfer, [payer]);
+
+const accountAfterDisable = await getAccount(
+  connection,
+  otherTokenAccount,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+// Re-enable memo transfers to show it exists
+await enableRequiredMemoTransfers(
+  connection,
+  payer,
+  otherTokenAccount,
+  payer,
+  undefined,
+  undefined,
+  TOKEN_2022_PROGRAM_ID,
+);
+
+console.log(
+  `✅ - We have transferred ${accountAfterDisable.amount} tokens to ${otherTokenAccount} without a memo.`,
+);
+```
+
+Run the tests. You will notice that `otherTokenAccount` now has 600 tokens,
+meaning it has successfully transferred without a memo after disabling the
+extension.
+
+```bash
+npx esrun src/index.ts
+```
+
+Congratulations! We’ve just tested the required memo extension!
+
+# Challenge
+
+Go create your own token account with required memo.

--- a/content/courses/token-extensions/required-memo.md
+++ b/content/courses/token-extensions/required-memo.md
@@ -8,7 +8,7 @@ objectives:
 description: "Create a token that requires a short note on every transfer."
 ---
 
-# Summary
+## Summary
 
 - The `required memo` extension allows developers to mandate that all incoming
   transfers to a token account include a memo, facilitating enhanced transaction
@@ -17,7 +17,7 @@ description: "Create a token that requires a short note on every transfer."
 - The `required memo` extension can be disabled by calling
   `disableRequiredMemoTransfers`.
 
-# Overview
+## Overview
 
 For certain applications, such as exchanges or financial services, tracking the
 purpose or origin of a transaction is crucial. The `required memo` extension
@@ -32,7 +32,7 @@ It is important to note that this is a token account extension, not a mint
 extension. This means individual token accounts need to enable this feature. And
 like all extensions, this will only work with Token Extensions Program tokens.
 
-## Creating token with required memo
+### Creating token with required memo
 
 Initializing a token account with required memo involves three instructions:
 
@@ -102,7 +102,7 @@ const transactionSignature = await sendAndConfirmTransaction(
 );
 ```
 
-## Transferring with required memo
+### Transferring with required memo
 
 When transferring to a token account with the `required memo` instruction
 enabled, you need to send a memo first within the same transaction. We do this
@@ -130,7 +130,7 @@ const transaction = new Transaction().add(
 await sendAndConfirmTransaction(connection, transaction, [payer]);
 ```
 
-## Disabling required memo
+### Disabling required memo
 
 The required memo extension can be disabled given you have the authority to
 modify the token account. To do this, simply call the
@@ -161,13 +161,13 @@ await disableRequiredMemoTransfers(
 );
 ```
 
-# Lab
+## Lab
 
 In this lab, we'll create a token account with the required memo extension.
 We'll then write tests to check if the extension is working as intended by
 attempting to transfer funds with and without a memo.
 
-### 1. Setup Environment
+#### 1. Setup Environment
 
 To get started, create an empty directory named `required-memo` and navigate to
 it. We'll be initializing a brand new project. Run `npm init` and follow through
@@ -230,7 +230,7 @@ const amountToTransfer = 300;
 // DISABLE MEMO EXTENSION AND TRANSFER
 ```
 
-### 2. Run validator node
+#### 2. Run validator node
 
 For the sake of this guide, we'll be running our own validator node.
 
@@ -249,7 +249,7 @@ Alternatively, if you’d like to use testnet or devnet, import the
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 ```
 
-### 3. Helpers
+#### 3. Helpers
 
 When we pasted the `index.ts` code from earlier, we added the following helpers
 provided by the `@solana-developers/helpers` package and some starting
@@ -259,7 +259,7 @@ variables.
   also airdrops 1 testnet SOL to it
 - `makeKeypairs`: This function creates keypairs without airdropping any SOL
 
-### 4. Create the mint
+#### 4. Create the mint
 
 First things first, since the `required memo` extension is a token extension, we
 don't need to do anything fancy with the mint. It just needs to be a Token
@@ -282,7 +282,7 @@ const mint = await createMint(
 );
 ```
 
-### 5. Create Token Account with required memo
+#### 5. Create Token Account with required memo
 
 Let's create a new file `src/token-helper.ts` and create a new function within
 it called `createTokenWithMemoExtension`. As the name implies, we'll use this to
@@ -442,7 +442,7 @@ await mintTo(
 Note: The `required memo` extension only requires a memo on transferring, not
 minting.
 
-### 6. Tests
+#### 6. Tests
 
 Now that we've created some accounts with the `required memo` instruction. Let's
 write some tests to see how they function.
@@ -453,7 +453,7 @@ We'll write 3 tests in total:
 - Transferring with a memo
 - Disabling Required Memo extension and transferring without a memo
 
-### 6.1 Transfer without Memo
+#### 6.1 Transfer without Memo
 
 This first test will attempt to transfer tokens from `ourTokenAccount` to
 `otherTokenAccount`. This test is expected to fail as there is no memo attached
@@ -491,7 +491,7 @@ meaning the extension is working as intended:
 npx esrun src/index.ts
 ```
 
-### 6.2 Test transfer with memo
+#### 6.2 Test transfer with memo
 
 This test will attempt to transfer tokens with a memo. This test is expected to
 pass. Pay extra attention to the first instruction - It is the part of the
@@ -537,7 +537,7 @@ Run the test and see that it passes:
 npx esrun src/index.ts
 ```
 
-### 6.3 Test transfer with disabled memo
+#### 6.3 Test transfer with disabled memo
 
 In our last test, we'll disable the `required memo` extension on the
 `otherTokenAccount` and send it some tokens without a memo. We expect this to
@@ -602,6 +602,6 @@ npx esrun src/index.ts
 
 Congratulations! We’ve just tested the required memo extension!
 
-# Challenge
+## Challenge
 
 Go create your own token account with required memo.

--- a/content/courses/token-extensions/token-extensions-in-the-client.md
+++ b/content/courses/token-extensions/token-extensions-in-the-client.md
@@ -1,5 +1,5 @@
 ---
-title: Support the Token Extensions Program from a Client
+title: Use Token Extensions from a Client
 objectives:
   - Learn how to effectively integrate multiple Solana token programs within
     client applications

--- a/content/courses/token-extensions/token-extensions-onchain.md
+++ b/content/courses/token-extensions/token-extensions-onchain.md
@@ -1,5 +1,5 @@
 ---
-title: Supporting Token Extensions Program in onchain programs
+title: Use Token Extensions in onchain programs
 objectives:
   - Accept both token programs' accounts, and mints in your program
   - Explain the differences between the Token Program and Token Extension

--- a/content/courses/token-extensions/transfer-hook.md
+++ b/content/courses/token-extensions/transfer-hook.md
@@ -1,12 +1,12 @@
 ---
 title: Transfer Hook
-
 objectives:
   - Create a program that applies the "transfer-hook" interface
-
   - Create a mint with a transfer hook
-
   - Transfer a token with a transfer hook successfully
+description:
+  "Create a token that invokes a function in an onchain program whenever the
+  token in transferred."
 ---
 
 # Summary

--- a/content/courses/token-extensions/transfer-hook.md
+++ b/content/courses/token-extensions/transfer-hook.md
@@ -557,8 +557,8 @@ pub fn fallback<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>
 
 ### Using transfer hooks from the frontend
 
-Now that we've looked at the on-chain portion, let's look at how we interact
-with them in the frontend.
+Now that we've looked at the onchain portion, let's look at how we interact with
+them in the frontend.
 
 Let's assume we have a deployed Solana program that follows the Transfer Hook
 Interface.

--- a/content/courses/token-extensions/transfer-hook.md
+++ b/content/courses/token-extensions/transfer-hook.md
@@ -1,0 +1,1875 @@
+---
+title: Transfer Hook
+
+objectives:
+  - Create a program that applies the "transfer-hook" interface
+
+  - Create a mint with a transfer hook
+
+  - Transfer a token with a transfer hook successfully
+---
+
+# Summary
+
+- The `transfer hook` extension allows developers to run custom logic on their
+  tokens on every transfer
+
+- When a token has a transfer hook, the Token Extensions Program will invoke the
+  transfer hook instruction on every token transfer
+
+- For the program to be able to act as a transfer hook program, it needs to
+  implement the `TransferHook` interface
+
+- Transfer hooks may use additional accounts beyond those involved in a normal,
+  non-hooked transfer. These are called 'extra accounts' and must be provided by
+  the transfer instruction, and are set up in in `extra-account-metas` when
+  creating the token mint.
+
+- Within the transfer hook CPI, the sender, mint, receiver and owner are all
+  de-escalated, meaning they are read-only to the hook. Meaning none of those
+  accounts can sign or be written to.
+
+# Overview
+
+The `transfer-hook` extension allows custom onchain logic to be run after each
+transfer within the same transaction. More specifically, the `transfer-hook`
+extension requires a 'hook' or 'callback' in the form of a Solana program
+following the
+[Transfer Hook Interface](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook/interface).
+Then every time any token of that mint is transferred the Token Extensions
+Program calls this 'hook' as a CPI.
+
+Additionally, the `transfer-hook` extension also stores `extra-account-metas`,
+which are any additional accounts needed for the hook to function.
+
+This extension allows many new use cases, including:
+
+- Enforcing artist royalty payments to transfer NFTs.
+- Stopping tokens from being transferred to known bad actors (blocklists).
+- Requiring accounts to own a particular NFT to receive a token (allowlists).
+- Token analytics.
+
+In this lesson, we'll explore how to implement transfer hooks onchain and work
+with them in the frontend.
+
+## Implementing transfer hooks onchain
+
+The first part of creating a mint with a `transfer hook` is to find or create an
+onchain program that follows the
+[Transfer Hook Interface](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook/interface).
+
+The
+[Transfer Hook Interface](https://github.com/solana-labs/solana-program-library/blob/master/token/transfer-hook/interface/src/instruction.rs)
+specifies the transfer hook program includes:
+
+- `Execute` (required): An instruction handler that the Token Extensions Program
+  invokes on every token transfer
+
+- `InitializeExtraAccountMetaList` (optional): creates an account
+  (`extra_account_meta_list`) that stores a list of additional accounts (i.e.
+  those needed by the transfer hook program, beyond the accounts needed for a
+  simple transfer) required by the `Execute` instruction
+
+- `UpdateExtraAccountMetaList` (optional): updates the list of additional
+  accounts by overwriting the existing list
+
+Technically it's not required to implement the `InitializeExtraAccountMetaList`
+instruction using the interface, but it's still required to have the
+`extra_account_meta_list` account. This account can be created by any
+instruction on a Transfer Hook program. However, the Program Derived Address
+(PDA) for the account must be derived using the following seeds:
+
+- The hard-coded string `extra-account-metas`
+
+- The Mint Account address
+
+- The Transfer Hook program ID
+
+```typescript
+const [pda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("extra-account-metas"), mint.publicKey.toBuffer()],
+  program.programId, // transfer hook program ID
+);
+```
+
+By storing the extra accounts required by the `Execute` instruction in the
+`extra_account_meta_list` PDA, these accounts can be automatically added to a
+token transfer instruction from the client. We'll see how to do that in the
+off-chain section.
+
+### 1. `initialize_extra_account_meta_list` instruction:
+
+When we transfer a token using the Token Extensions Program, the program will
+examine our mint to determine if it has a transfer hook. If a transfer hook is
+present, the Token Extensions Program will initiate a CPI (cross-program
+invocation) to our transfer hook program. The Token Extensions Program will then
+pass all the accounts in the transfer (including the extra accounts specified in
+the `extra_account_meta_list`) to the transfer hook program. However, before
+passing the 4 essential accounts (`sender`, `mint`, `receiver`, `owner`), it
+will de-escalate them (i.e. remove the mutable or signing abilities for security
+reasons).
+
+In other words, when our hook receives these accounts, they will be read-only.
+The transfer hook program cannot modify these accounts, nor can it sign any
+transactions with them. Although we cannot alter or sign with any of these four
+accounts, we can specify `is_signer` and `is_writable` to any of the additional
+accounts in the `extra_account_meta_list` PDA. Additionally, we can use the
+`extra_account_meta_list` PDA as a signer for any new data accounts specified in
+the hook program.
+
+The `extra_account_meta_list` has to be created before any transfer occurs. It's
+also worth noting that we can update the list of accounts in the
+`extra_account_meta_list` by implementing and using the
+`UpdateExtraAccountMetaList` instruction if necessary.
+
+The `extra_account_meta_list` is just a list of `ExtraAccountMeta`. Let's take a
+look at the struct `ExtraAccountMeta`
+[in the source code](https://github.com/solana-labs/solana-program-library/blob/4f1668510adef2117ee3c043bd26b79789e67c8d/libraries/tlv-account-resolution/src/account.rs#L90):
+
+```rust
+impl ExtraAccountMeta {
+    /// Create a `ExtraAccountMeta` from a public key
+    /// This represents standard `AccountMeta`
+    pub fn new_with_pubkey(
+        pubkey: &Pubkey,
+        is_signer: bool,
+        is_writable: bool,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminator: 0,
+            address_config: pubkey.to_bytes(),
+            is_signer: is_signer.into(),
+            is_writable: is_writable.into(),
+        })
+    }
+
+    /// Create an `ExtraAccountMeta` PDA from a list of seeds
+    pub fn new_with_seeds(
+        seeds: &[Seed],
+        is_signer: bool,
+        is_writable: bool,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminator: 1,
+            address_config: Seed::pack_into_address_config(seeds)?,
+            is_signer: is_signer.into(),
+            is_writable: is_writable.into(),
+        })
+    }
+
+    /// Create an `ExtraAccountMeta` PDA for an external program from a list of seeds
+    /// This PDA belongs to a program elsewhere in the account list, rather
+    /// than the executing program. For a PDA on the executing program, use
+    /// `ExtraAccountMeta::new_with_seeds`.
+    pub fn new_external_pda_with_seeds(
+        program_index: u8,
+        seeds: &[Seed],
+        is_signer: bool,
+        is_writable: bool,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminator: program_index
+                .checked_add(U8_TOP_BIT)
+                .ok_or(AccountResolutionError::InvalidSeedConfig)?,
+            address_config: Seed::pack_into_address_config(seeds)?,
+            is_signer: is_signer.into(),
+            is_writable: is_writable.into(),
+        })
+    }
+```
+
+We have three methods for creating an `ExtraAccountMeta`:
+
+1. `ExtraAccountMeta::new_with_pubkey` - For any normal account (not a program
+   account)
+
+2. `ExtraAccountMeta::new_with_seeds` - For a program account PDA from the
+   calling transfer hook program
+
+3. `ExtraAccountMeta::new_external_pda_with_seeds` - For a program account PDA
+   from a different external program
+
+Now that we know the accounts we can store them in `extra_account_meta_list`.
+Let's talk about the `InitializeExtraAccountMetaList` instruction itself. For
+most implementations, it should simply just create the `extra_account_meta_list`
+account and load it up with any additional accounts it needs.
+
+Let's take a look at a simple example where we'll initialize an
+`extra_account_meta_list` with two additional arbitrary accounts, `some_account`
+and a `pda_account`. The `initialize_extra_account_meta_list` function will do
+the following:
+
+1. Prepare the accounts we need to store in the `extra_account_meta_list`
+   account as a vector (we'll discuss that in-depth in a moment).
+
+2. Calculate the size and rent required to store the list of
+   `ExtraAccountMetas`.
+
+3. Make a CPI to the System Program to create an account and set the Transfer
+   Hook Program as the owner, and then initialize the account data to store the
+   list of `ExtraAccountMetas`.
+
+```rust
+#[derive(Accounts)]
+pub struct InitializeExtraAccountMetaList<'info> {
+  #[account(mut)]
+  payer: Signer<'info>,
+
+ /// CHECK: ExtraAccountMetaList Account, must use these seeds
+  #[account(
+        mut,
+        seeds = [b"extra-account-metas", mint.key().as_ref()],
+        bump
+    )]
+  pub extra_account_meta_list: AccountInfo<'info>,
+  pub mint: InterfaceAccount<'info, Mint>,
+
+  pub system_program: Program<'info, System>,
+
+  // Accounts to add to the extra-account-metas
+  pub some_account: UncheckedAccount<'info>,
+  #[account(seeds = [b"some-seed"], bump)]
+  pub pda_account: UncheckedAccount<'info>,
+
+}
+
+pub fn initialize_extra_account_meta_list(ctx: Context<InitializeExtraAccountMetaList>) -> Result<()> {
+  let account_metas = vec![
+    ExtraAccountMeta::new_with_pubkey(&ctx.accounts.some_account.key(), false, true)?, // Read only
+    ExtraAccountMeta::new_with_seeds(
+      &[
+        Seed::Literal {
+          bytes: "some-seed".as_bytes().to_vec(),
+        },
+      ],
+      true, // is_signer
+      true // is_writable
+    )?,
+  ];
+
+  // calculate account size
+  let account_size = ExtraAccountMetaList::size_of(account_metas.len())? as u64;
+
+  // calculate minimum required lamports
+  let lamports = Rent::get()?.minimum_balance(account_size as usize);
+
+  let mint = ctx.accounts.mint.key();
+  let signer_seeds: &[&[&[u8]]] = &[&[b"extra-account-metas", &mint.as_ref(), &[ctx.bumps.extra_account_meta_list]]];
+
+  // create ExtraAccountMetaList account
+  create_account(
+    CpiContext::new(ctx.accounts.system_program.to_account_info(), CreateAccount {
+      from: ctx.accounts.payer.to_account_info(),
+      to: ctx.accounts.extra_account_meta_list.to_account_info(),
+    }).with_signer(signer_seeds),
+    lamports,
+    account_size,
+    ctx.program_id
+  )?;
+
+  // initialize ExtraAccountMetaList account with extra accounts
+  ExtraAccountMetaList::init::<ExecuteInstruction>(
+    &mut ctx.accounts.extra_account_meta_list.try_borrow_mut_data()?,
+    &account_metas
+  )?;
+
+  Ok(())
+}
+```
+
+Let's dive a little deeper into the `ExtraAccountMeta` you can store.
+
+You can directly store the account address, store the seeds to derive a PDA of
+the program itself and store the seeds to derive a PDA for a program other than
+the Transfer Hook program.
+
+The first method is straightforward `ExtraAccountMeta::new_with_pubkey`; you
+just need an account address. You can pass it to the instruction or get it from
+a library (like the system program or the token program), or you can even
+hardcode it.
+
+However, the most interesting part here is storing the seeds, and it could
+either be a PDA of the transfer hook program itself or a PDA of another program
+like an associated token account. We can do both of them by using
+`ExtraAccountMeta::new_with_seeds` and
+`ExtraAccountMeta::new_external_pda_with_seeds`, respectively, and pass the
+seeds to them.
+
+To learn how we could pass the seeds, let's take a look at the source code
+itself:
+
+```rust
+pub fn new_with_seeds(
+  seeds: &[Seed],
+  is_signer: bool,
+  is_writable: bool,
+)
+
+pub fn new_external_pda_with_seeds(
+  program_index: u8,
+  seeds: &[Seed],
+  is_signer: bool,
+  is_writable: bool,
+)
+```
+
+Both of these methods are similar; the only change is we need to pass the
+`program_id` for the PDAs that are not of our program in the
+`new_external_pda_with_seeds` method. Other than that we need to provide a list
+of seeds (which we'll talk about soon) and two booleans for `is_signer` and
+`is_writable` to determine if the account should be a signer or writable.
+
+Providing the seeds themselves takes a little explanation. Hard-coded literal
+seeds are easy enough, but what happens if you want a seed to be variable, say
+created with the public key of a passed-in account? To make sense of this, let's
+break it down to make it easier to understand. First, take a look at the seed
+enum implementation from
+[spl_tlv_account_resolution::seeds::Seed](https://github.com/solana-labs/solana-program-library/blob/master/libraries/tlv-account-resolution/src/seeds.rs):
+
+```rust
+pub enum Seed
+    /// Uninitialized configuration byte space
+    Uninitialized,
+    /// A literal hard-coded argument
+    /// Packed as:
+    ///     * 1 - Discriminator
+    ///     * 1 - Length of literal
+    ///     * N - Literal bytes themselves
+    Literal {
+        /// The literal value represented as a vector of bytes.
+        ///
+        /// For example, if a literal value is a string literal,
+        /// such as "my-seed", this value would be
+        /// `"my-seed".as_bytes().to_vec()`.
+        bytes: Vec<u8>,
+    },
+    /// An instruction-provided argument, to be resolved from the instruction
+    /// data
+    /// Packed as:
+    ///     * 1 - Discriminator
+    ///     * 1 - Start index of instruction data
+    ///     * 1 - Length of instruction data starting at index
+    InstructionData {
+        /// The index where the bytes of an instruction argument begin
+        index: u8,
+        /// The length of the instruction argument (number of bytes)
+        ///
+        /// Note: Max seed length is 32 bytes, so `u8` is appropriate here
+        length: u8,
+    },
+    /// The public key of an account from the entire accounts list.
+    /// Note: This includes any extra accounts required.
+    ///
+    /// Packed as:
+    ///     * 1 - Discriminator
+    ///     * 1 - Index of account in the accounts list
+    AccountKey {
+        /// The index of the account in the entire accounts list
+        index: u8,
+    },
+    /// An argument to be resolved from the inner data of some account
+    /// Packed as:
+    ///     * 1 - Discriminator
+    ///     * 1 - Index of account in the accounts list
+    ///     * 1 - Start index of account data
+    ///     * 1 - Length of account data starting at index
+    AccountData {
+        /// The index of the account in the entire accounts list
+        account_index: u8,
+        /// The index where the bytes of an account data argument begin
+        data_index: u8,
+        /// The length of the argument (number of bytes)
+        ///
+        /// Note: Max seed length is 32 bytes, so `u8` is appropriate here
+        length: u8,
+    },
+}
+```
+
+As we can see from the code above, there are four main ways to provide seeds:
+
+1. A literal hard-coded argument, such as the string `"some-seed"`.
+
+2. An instruction-provided argument, to be resolved from the instruction data.
+   This can be done by giving the start index and the length of the data we want
+   to have as a seed.
+
+3. The public key of an account from the entire accounts list. This can be done
+   by giving the index of the account (we'll talk about this more soon).
+
+4. An argument to be resolved from the inner data of some account. This can be
+   done by giving the index of the account, the start index of the data, along
+   with the length of the data we want to have as a seed.
+
+To use the 2 last methods of setting the seed, you need to get the account
+index. This represents the index of the account passed into the `Execute`
+function of the hook. The indexes are standardized:
+
+- index 0-3 will always be, `source`, `mint`, `destination`, and `owner`
+  respectively
+
+- index 4: will be the `extra_account_meta_list`
+
+- index 5+: will be in whatever order you create your `account_metas`
+
+```rust
+    // index 0-3 are the accounts required for token transfer (source, mint, destination, owner)
+    // index 4 is the extra_account_meta_list account
+  let account_metas = vec![
+    // index 5 - some_account
+    ExtraAccountMeta::new_with_pubkey(&ctx.accounts.some_account.key(), false, true)?,
+    // index 6 - pda_account
+    ExtraAccountMeta::new_with_seeds(
+      &[
+        Seed::Literal {
+          bytes: "some-seed".as_bytes().to_vec(),
+        },
+      ],
+      true, // is_signer
+      true // is_writable
+    )?,
+  ];
+```
+
+Now, let's say that the `pda_account` was created from "some-seed" and belonged
+to `some_account`. This is where we can specify the account key index:
+
+```rust
+  // index 0-3 are the accounts required for token transfer (source, mint, destination, owner)
+  // index 4 is the extra_account_meta_list account
+  let account_metas = vec![
+    // index 5 - some_account
+    ExtraAccountMeta::new_with_pubkey(&ctx.accounts.some_account.key(), false, true)?,
+    // index 6 - pda_account
+    ExtraAccountMeta::new_with_seeds(
+      &[
+        Seed::AccountKey {
+          index: 5, // index of `some_account`
+        },
+        Seed::Literal {
+          bytes: "some-seed".as_bytes().to_vec(),
+        },
+      ],
+      true, // is_signer
+      true // is_writable
+    )?,
+  ];
+```
+
+Note: remember that the accounts indexed 0-4 are defined by the `Execute`
+function of the transfer hook. They are: `source`, `mint`, `destination`,
+`owner`, `extra_account_meta_list` respectively. The first four of which, are
+de-escalated, or read-only. These will always be read-only. If you try to be
+sneaky and add any of these first four accounts into the
+`extra_account_meta_list`, they will always be interpreted as read-only, even if
+you specify them differently with `is_writable` or `is_signer`.
+
+### 2. `transfer_hook` Instruction
+
+In Anchor, when the `Execute` function is called, it looks for and calls the
+`transfer_hook` instruction. It is the place where we can implement our custom
+logic for the token transfer.
+
+When the Token Extensions Program invokes our program, it will invoke this
+instruction and pass to it all the accounts plus the amount of the transfer that
+just happened. The first 5 accounts will always be `source`, `mint`,
+`destination`, `owner`, `extraAccountMetaList`, and the rest are the extra
+accounts that we added to the `ExtraAccountMetaList` account if there is any.
+
+Let's take a look at an example `TransferHook` struct for this instruction:
+
+```rust
+// Order of accounts matters for this struct.
+// The first 4 accounts are the accounts required for token transfer (source, mint, destination, owner)
+// Remaining accounts are the extra accounts required from the ExtraAccountMetaList account
+// These accounts are provided via CPI to this program from the Token Extensions Program
+#[derive(Accounts)]
+pub struct TransferHook<'info> {
+  #[account(token::mint = mint, token::authority = owner)]
+  pub source_token: InterfaceAccount<'info, TokenAccount>,
+  pub mint: InterfaceAccount<'info, Mint>,
+  #[account(token::mint = mint)]
+  pub destination_token: InterfaceAccount<'info, TokenAccount>,
+  /// CHECK: source token account owner
+  /// This account is not being checked because it is used for ownership validation within the `transfer_hook` instruction.
+  pub owner: UncheckedAccount<'info>,
+
+  /// CHECK: ExtraAccountMetaList Account,
+  /// This account list is not being checked because it is used dynamically within the program logic.
+  #[account(seeds = [b"extra-account-metas", mint.key().as_ref()], bump)]
+  pub extra_account_meta_list: UncheckedAccount<'info>,
+
+  // Accounts to add to the extra-account-metas
+  pub some_account: UncheckedAccount<'info>,
+  #[account(seeds = [b"some-seed"], bump)]
+  pub pda_account: UncheckedAccount<'info>,
+}
+```
+
+As mentioned in the comment, the order here matters; we need the first 5
+accounts as shown above, and then the rest of the accounts need to follow the
+order of the accounts in the `extraAccountMetaList` account.
+
+Other than that, you can write any functionality you want in within the transfer
+hook. But remember, if the hook fails, the entire transaction fails.
+
+```rust
+  pub fn transfer_hook(ctx: Context<TransferHook>, amount: u64) -> Result<()> {
+    // do your logic here
+    Ok(())
+  }
+```
+
+### 3. Fallback
+
+One last caveat to the onchain portion of transfer hooks: when dealing with
+Anchor, we need to specify a `fallback` instruction in the Anchor program to
+handle the Cross-Program Invocation (CPI) from the Token Extensions Program.
+
+This is necessary because Anchor generates instruction discriminators
+differently from the ones used in the Transfer Hook interface instructions. The
+instruction discriminator for the `transfer_hook` instruction will not match the
+one for the Transfer Hook interface.
+
+Next, versions of Anchor should solve this for us, but for now, we can implement
+this simple workaround:
+
+```rust
+// fallback instruction handler as work-around to anchor instruction discriminator check
+pub fn fallback<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>], data: &[u8]) -> Result<()> {
+  let instruction = TransferHookInstruction::unpack(data)?;
+
+  // match instruction discriminator to transfer hook interface execute instruction
+  // token2022 program CPIs this instruction on token transfer
+  match instruction {
+      TransferHookInstruction::Execute { amount } => {
+      let amount_bytes = amount.to_le_bytes();
+
+      // invoke custom transfer hook instruction on our program
+      __private::__global::transfer_hook(program_id, accounts, &amount_bytes)
+      }
+      _ => {
+      return Err(ProgramError::InvalidInstructionData.into());
+      }
+  }
+}
+```
+
+## Using transfer hooks from the frontend
+
+Now that we've looked at the on-chain portion, let's look at how we interact
+with them in the frontend.
+
+Let's assume we have a deployed Solana program that follows the Transfer Hook
+Interface.
+
+In order to create a mint with a transfer hook and ensure successful transfers,
+follow these steps:
+
+1. Create the mint with the transfer hook extension and point to the onchain
+   transfer hook program you want to use.
+
+2. Initialize the `extraAccountList` account. This step must be done before any
+   transfer, and it is the responsibility of the mint owner/creator. It only
+   needs to happen once for each mint.
+
+3. Make sure to pass all the required accounts when invoking the transfer
+   instruction from the Token Extensions Program.
+
+### Create a Mint with the `Transfer-Hook` Extension:
+
+To create a mint with the transfer-hook extension, we need three instructions:
+
+1. `createAccount` - Reserves space on the blockchain for the mint account
+
+2. `createInitializeTransferHookInstruction` - initializes the transfer hook
+   extension, this takes the transfer hook's program address as a parameter.
+
+3. `createInitializeMintInstruction` - Initializes the mint.
+
+```ts
+const extensions = [ExtensionType.TransferHook];
+
+const mintLen = getMintLen(extensions);
+
+const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+const transaction = new Transaction().add(
+  // Allocate the mint account
+  SystemProgram.createAccount({
+    fromPubkey: wallet.publicKey,
+    newAccountPubkey: mint.publicKey,
+    space: mintLen,
+    lamports: lamports,
+    programId: TOKEN_2022_PROGRAM_ID,
+  }),
+  // Initialize the transfer hook extension and point to our program
+  createInitializeTransferHookInstruction(
+    mint.publicKey,
+    wallet.publicKey,
+    program.programId, // Transfer Hook Program ID
+    TOKEN_2022_PROGRAM_ID,
+  ),
+  // Initialize mint instruction
+  createInitializeMintInstruction(mint.publicKey, decimals, wallet.publicKey, null, TOKEN_2022_PROGRAM_ID),
+```
+
+### Initialize `ExtraAccountMetaList` account:
+
+The next step of getting the mint ready for any transactions is initializing the
+`ExtraAccountMetaList`. Generally, this is done by calling the
+`initializeExtraAccountMetaList` function on the program containing the transfer
+hook. Since this is part of the Transfer Hook Interface, this should be
+standardized. Additionally, if the transfer hook program was made with Anchor,
+it will most likely have autogenerated IDLs, which are TypeScript interfaces
+that represent the instructions and accounts of the program. This makes it easy
+to interact with the program from the client side.
+
+If you made your own program in Anchor, the IDLs will be in the `target/idl`
+folder after compilation. Inside tests or client code you can access the methods
+directly from `anchor.workspace.program_name.method`:
+
+```ts
+import * as anchor from "@coral-xyz/anchor";
+
+const program = anchor.workspace.TransferHook as anchor.Program<TransferHook>;
+// now program.method will give you the methods of the program
+```
+
+so to initialize the `ExtraAccountMetaList` all that we need to do is to call
+the `initializeExtraAccountMetaList` from the methods and pass the right
+accounts to it, you can use the autocomplete feature to get more help with that
+
+```ts
+const initializeExtraAccountMetaListInstruction = await program.methods
+  .initializeExtraAccountMetaList()
+  .accounts({
+    mint: mint.publicKey,
+    extraAccountMetaList: extraAccountMetaListPDA,
+    anotherMint: crumbMint.publicKey,
+  })
+  .instruction();
+
+const transaction = new Transaction().add(
+  initializeExtraAccountMetaListInstruction,
+);
+```
+
+After calling `initializeExtraAccountMetaList`, you're all set to transfer
+tokens with the transfer hook enabled mint.
+
+### Transfer tokens successfully:
+
+To actually transfer tokens with the `transfer hook` extension, you need to call
+`createTransferCheckedWithTransferHookInstruction`. This is a special helper
+function provided by `@solana/spl-token` that will gather and submit all of the
+needed extra accounts needed to be specified in the `ExtraAccountMetaList`.
+
+```ts
+const transferInstruction =
+  await createTransferCheckedWithTransferHookInstruction(
+    connection,
+    sourceTokenAccount,
+    mint.publicKey,
+    destinationTokenAccount,
+    wallet.publicKey,
+    BigInt(1), // amount
+    0, // Decimals
+    [],
+    "confirmed",
+    TOKEN_2022_PROGRAM_ID,
+  );
+```
+
+Under the hood, the `createTransferCheckedWithTransferHookInstruction` method
+will examine if the mint has a transfer hook, if it does it will get the extra
+accounts and add them to the transfer instruction.
+[Take a look at the source code](https://github.com/solana-labs/solana-program-library/blob/8ae0c89c12cf05d0787ee349dd5454e1dcbe4a4f/token/js/src/extensions/transferHook/instructions.ts#L261)
+
+```ts
+/**
+ * Construct an transferChecked instruction with extra accounts for transfer hook
+ *
+ * @param connection            Connection to use
+ * @param source                Source account
+ * @param mint                  Mint to update
+ * @param destination           Destination account
+ * @param owner                 Owner of the source account
+ * @param amount                The amount of tokens to transfer
+ * @param decimals              Number of decimals in transfer amount
+ * @param multiSigners          The signer account(s) for a multisig
+ * @param commitment            Commitment to use
+ * @param programId             SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export async function createTransferCheckedWithTransferHookInstruction(
+  connection: Connection,
+  source: PublicKey,
+  mint: PublicKey,
+  destination: PublicKey,
+  owner: PublicKey,
+  amount: bigint,
+  decimals: number,
+  multiSigners: (Signer | PublicKey)[] = [],
+  commitment?: Commitment,
+  programId = TOKEN_PROGRAM_ID,
+) {
+  const instruction = createTransferCheckedInstruction(
+    source,
+    mint,
+    destination,
+    owner,
+    amount,
+    decimals,
+    multiSigners,
+    programId,
+  );
+
+  const mintInfo = await getMint(connection, mint, commitment, programId);
+  const transferHook = getTransferHook(mintInfo);
+
+  if (transferHook) {
+    await addExtraAccountMetasForExecute(
+      connection,
+      instruction,
+      transferHook.programId,
+      source,
+      mint,
+      destination,
+      owner,
+      amount,
+      commitment,
+    );
+  }
+
+  return instruction;
+}
+```
+
+## Theoretical Example - Artist Royalties
+
+Let's take what we know about the `transfer hook` extension and conceptually try
+to understand how we could implement artist royalties for NFTs. If you're not
+familiar, an artist royalty is a fee paid on any sale of an NFT. Historically,
+these were more suggestions than enforcements, since at any time, a user could
+strike a private deal and exchange their NFT for payment on a platform or
+program that did not enforce these royalties. That being said, we can get a
+little closer with transfer hooks.
+
+**First Approach** - Transfer SOL right from the `owner` to the artist right in
+the hook. Although this may sound like a good avenue to try, it won't work, for
+two reasons. First, the hook would not know how much to pay the artist - this is
+because the transfer hook does not take any arguments other than the needed
+`source`, `mint`, `destination`, `owner`, `extraAccountMetaList`, and all of the
+accounts within the list. Secondly, we would be paying from the `owner` to the
+artist, which cannot be done since `owner` is deescalated. It cannot sign and it
+cannot be written to - this means we don't have the authority to update
+`owner`'s balance. Although we can't use this approach, it's a good way to
+showcase the limitations of the transfer hook.
+
+**Second Approach** - Create a data PDA owned by the `extraAccountMetaList` that
+tracks if the royalty has been paid. If it has, allow the transfer, if it has
+not, deny it. This approach is multi step and would require an additional
+function in the transfer hook program.
+
+Say we have a new function called `payRoyalty` in our transfer hook program.
+This function would be required to:
+
+1. Create a data PDA owned by the `extraAccountMetaList`
+
+a. This account would hold information about the trade
+
+2. Transfer the amount for the royalty from the `owner` to the artist.
+
+3. Update the data PDA with the sale information
+
+Then you'd transfer, and all the transfer hook should do is check the sales data
+on the PDA. It would allow or disallow the transfer from there.
+
+Remember this the above is just a theoretical discussion and is in no way
+all-encompassing. For example, how would you enforce the prices of the NFTs? Or,
+what if the owner of the NFT wants to transfer it to a different wallet of
+theirs - should there be an approved list of "allowed" wallets? Or, should the
+artist be a signer involved in every sale/transfer? This system design makes for
+a great homework assignment!
+
+# Lab
+
+In this lab we'll explore how transfer hooks work by creating a Cookie Crumb
+program. We'll have a Cookie NFT that has a transfer hook which will mint a
+Crumb SFT (NFT with a supply > 1) to the sender after each transfer - leaving a
+"crumb trail". A fun side effect is we'll able to tell how many times this NFT
+has been transferred just by looking at the crumb supply.
+
+## 0. Setup
+
+### 1. Verify Solana/Anchor/Rust Versions
+
+We'll be interacting with the `Token Extensions Program` in this lab and that
+requires you to have the Solana CLI version ≥ 1.18.1.
+
+To check your version run:
+
+```bash
+solana --version
+```
+
+If the version printed out after running `solana --version` is less than
+`1.18.0` then you can update the CLI version manually. Note, at the time of
+writing this, you cannot simply run the `solana-install update` command. This
+command will not update the CLI to the correct version for us, so we have to
+explicitly download version `1.18.0`. You can do so with the following command:
+
+```bash
+solana-install init 1.18.1
+```
+
+If you run into this error at any point attempting to build the program, that
+likely means you do not have the correct version of the Solana CLI installed.
+
+```bash
+anchor build
+error: package `solana-program v1.18.1` cannot be built because it requires rustc 1.72.0 or newer, while the currently active rustc version is 1.68.0-dev
+Run:
+cargo update -p solana-program@1.18.0 --precise ver
+where `ver` is the latest version of `solana-program` supporting rustc 1.68.0-dev
+```
+
+You will also want the latest version of the Anchor CLI installed. You can
+follow the steps to
+[update Anchor via avm](https://www.anchor-lang.com/docs/avm)
+
+or simply run
+
+```bash
+avm install latest
+avm use latest
+```
+
+At the time of writing, the latest version of the Anchor CLI is `0.30.1`
+
+Now, we should have all the correct versions installed.
+
+### 2. Get starter code
+
+Let's grab the starter branch.
+
+```bash
+git clone https://github.com/Unboxed-Software/solana-lab-transfer-hooks
+cd solana-lab-transfer-hooks
+git checkout starter
+```
+
+### 3. Update Program ID and Anchor Keypair
+
+Once in the starter branch, run
+
+```bash
+anchor keys sync
+```
+
+This syncs your program key with the one in the `Anchor.toml` and the declared
+program id in the `programs/transfer-hook/src/lib.rs` file.
+
+The last thing you have to do is set your keypair path in `Anchor.toml`:
+
+```toml
+[provider]
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+```
+
+### 4. Confirm the program builds
+
+Let's build the starter code to confirm we have everything configured correctly.
+If it does not build, please revisit the steps above.
+
+```bash
+anchor build
+```
+
+You can safely ignore the warnings of the build script, these will go away as we
+add in the necessary code. But at the end, you should see a message like this:
+
+```bash
+Finished release [optimized] target(s)
+```
+
+Feel free to run the provided tests to make sure the rest of the dev environment
+is set up correctly. You'll have to install the node dependencies using `npm` or
+`yarn`. The tests should run, but they'll all fail until we have completed our
+program.
+
+```bash
+yarn install
+anchor test
+```
+
+We will be filling these tests in later.
+
+## 1. Write the transfer hook program
+
+In this section we'll dive into writing the onchain transfer hook program using
+anchor, all the code will go into the `programs/transfer-hook/src/lib.rs` file.
+
+Take a look inside `lib.rs`, you'll notice we have some starter code:
+
+Three instructions
+
+- `initialize_extra_account_meta_list`
+
+- `transfer_hook`
+
+- `fallback`
+
+Two instruction account structs
+
+- `InitializeExtraAccountMetaList`
+
+- `TransferHook`.
+
+- The `initialize_extra_account_meta_list` function initializes the additional
+  accounts needed for the transfer hook.
+
+- The `transfer_hook` is the actual CPI called "after" the transfer has been
+  made.
+
+- The `fallback` is an anchor adapter function we have to fill out.
+
+We're going to look at each in depth.
+
+### 1. Initialize Extra Account Meta List instruction
+
+The cookie transfer hook program needs some extra accounts to be able to mint
+the crumbs within the `transfer_hook` function, these are:
+
+1. `crumb_mint` - The "crumb" mint account of the token to be minted by the
+   transfer_hook instruction.
+
+2. `crumb_mint_ata` - The associated token account of the crumb mint of the
+   person sending the cookie.
+
+3. `mint_authority` - For the crumb mint, this will be the account owned by the
+   transfer hook program
+
+4. `token_program` - this mint will be a regular SPL token mint.
+
+5. `associated_token_program` - needed to construct the ATA
+
+We are going to store these accounts in the `extra_account_meta_list` account,
+by invoking the instruction `initialize_extra_account_meta_list` and passing the
+required accounts to it.
+
+First, we have to build the struct `InitializeExtraAccountMetaList`, then we can
+write the instruction itself.
+
+**`InitializeExtraAccountMetaList` Struct**
+
+The Instruction requires the following accounts:
+
+1. `extra_account_meta_list` - The PDA that will hold the extra account.
+
+2. `crumb_mint` - The mint account of the crumb token.
+
+3. `mint` - The mint account of the cookie NFT.
+
+4. `mint_authority` - The mint authority account of the crumb token. - This is a
+   PDA seeded by `b"mint-authority"`
+
+5. `payer` - The account that will pay for the creation of the
+   `extra_account_meta_list` account.
+
+6. `token_program` - The token program account.
+
+7. `system_program` - The system program account.
+
+The code for the struct will go as follows:
+
+```rust
+#[derive(Accounts)]
+pub struct InitializeExtraAccountMetaList<'info> {
+  #[account(mut)]
+  payer: Signer<'info>,
+
+  /// CHECK: ExtraAccountMetaList Account, must use these seeds
+  #[account(
+        mut,
+        seeds = [b"extra-account-metas", mint.key().as_ref()],
+        bump
+    )]
+  pub extra_account_meta_list: AccountInfo<'info>,
+  pub mint: InterfaceAccount<'info, Mint>,
+  pub token_program: Interface<'info, TokenInterface>,
+  pub system_program: Program<'info, System>,
+
+  #[account(mint::authority = mint_authority)]
+  pub crumb_mint: InterfaceAccount<'info, Mint>,
+
+  /// CHECK: mint authority Account for crumb mint
+  #[account(seeds = [b"mint-authority"], bump)]
+  pub mint_authority: UncheckedAccount<'info>,
+}
+```
+
+Note that we are not specifying the `crumb_mint_ata` or the
+`associated_token_program`. This is because the `crumb_mint_ata` is variable and
+will be driven by the other accounts in the `extra_account_meta_list`, and
+`associated_token_program` will be hardcoded.
+
+Also, notice we are asking Anchor to drive the `mint_authority` account from the
+seed `b"mint-authority"`. The resulting PDA allows the program itself to sign
+for the mint.
+
+**`initialize_extra_account_meta_list` Instruction**
+
+Let's write the `initialize_extra_account_meta_list` function, it will do the
+following:
+
+1. List the accounts required for the transfer hook instruction inside a vector.
+
+2. Calculate the size and rent required to store the list of
+   `extra_account_meta_list`.
+
+3. Make a CPI to the System Program to create an account and set the Transfer
+   Hook Program as the owner.
+
+4. Initialize the account data to store the list of `extra_account_meta_list`.
+
+here is the code for it:
+
+```rust
+pub fn initialize_extra_account_meta_list(ctx: Context<InitializeExtraAccountMetaList>) -> Result<()> {
+  // index 0-3 are the accounts required for token transfer (source, mint, destination, owner)
+  // index 4 is the extra_account_meta_list account
+  let account_metas = vec![
+    // index 5, Token program
+    ExtraAccountMeta::new_with_pubkey(&token::ID, false, false)?,
+    // index 6, Associated Token program
+    ExtraAccountMeta::new_with_pubkey(&associated_token_id, false, false)?,
+    // index 7, crumb mint
+    ExtraAccountMeta::new_with_pubkey(&ctx.accounts.crumb_mint.key(), false, true)?, // is_writable true
+    // index 8, mint authority
+    ExtraAccountMeta::new_with_seeds(
+      &[
+        Seed::Literal {
+          bytes: "mint-authority".as_bytes().to_vec(),
+        },
+      ],
+      false, // is_signer
+      false // is_writable
+    )?,
+    // index 9, crumb mint ATA
+    ExtraAccountMeta::new_external_pda_with_seeds(
+      6, // associated token program index
+      &[
+        Seed::AccountKey { index: 3 }, // owner index
+        Seed::AccountKey { index: 5 }, // token program index
+        Seed::AccountKey { index: 7 }, // crumb mint index
+      ],
+      false, // is_signer
+      true // is_writable
+    )?
+  ];
+
+  // calculate account size
+  let account_size = ExtraAccountMetaList::size_of(account_metas.len())? as u64;
+  // calculate minimum required lamports
+  let lamports = Rent::get()?.minimum_balance(account_size as usize);
+
+  let mint = ctx.accounts.mint.key();
+  let signer_seeds: &[&[&[u8]]] = &[&[b"extra-account-metas", &mint.as_ref(), &[ctx.bumps.extra_account_meta_list]]];
+
+  // Create ExtraAccountMetaList account
+  create_account(
+    CpiContext::new(ctx.accounts.system_program.to_account_info(), CreateAccount {
+      from: ctx.accounts.payer.to_account_info(),
+      to: ctx.accounts.extra_account_meta_list.to_account_info(),
+    }).with_signer(signer_seeds),
+    lamports,
+    account_size,
+    ctx.program_id
+  )?;
+
+  // Initialize the account data to store the list of ExtraAccountMetas
+  ExtraAccountMetaList::init::<ExecuteInstruction>(
+    &mut ctx.accounts.extra_account_meta_list.try_borrow_mut_data()?,
+    &account_metas
+  )?;
+
+  Ok(())
+}
+```
+
+Pay careful attention to the indexes for each account. Most notably, see that
+`index 9` is the index for the `crumb_mint_ata` account. It constructs the ATA
+using `ExtraAccountMeta::new_external_pda_with_seeds` and pass in the seeds from
+other accounts by their index. Specifically, the ATA belongs to whatever `owner`
+calls the transfer. So when a cookie is sent, the crumb will be minted to the
+sender.
+
+### 2. Transfer Hook instruction
+
+In this step, we'll implement the `transfer_hook` instruction. This instruction
+will be called by the Token Extensions Program when a token transfer occurs.
+
+The `transfer_hook` instruction will mint one crumb token each time a cookie
+transfer occurs.
+
+Again we'll have a struct `TransferHook` that will hold the accounts required
+for the instruction.
+
+**`TransferHook` Struct**
+
+In our program the `TransferHook` struct will have 10 accounts:
+
+1. `source_token` - The source token account from which the NFT is transferred.
+
+2. `mint` - The mint account of the Cookie NFT.
+
+3. `destination_token` - The destination token account to which the NFT is
+   transferred.
+
+4. `owner` - The owner of the source token account.
+
+5. `extra_account_meta_list` - The ExtraAccountMetaList account that stores the
+   additional accounts required by the transfer_hook instruction
+
+6. `token_program` - The token program account.
+
+7. `associated_token_program` - The associated token program account.
+
+8. `crumb_mint` - The mint account of the token to be minted by the
+   transfer_hook instruction.
+
+9. `mint_authority` - The mint authority account of the token to be minted by
+   the transfer_hook instruction.
+
+10. `crumb_mint_ata` - The `owner`'s ATA of the crumb mint
+
+> Very Important Note: The order of accounts in this struct matters. This is the
+> order in which the Token Extensions Program provides these accounts when it
+> invokes this Transfer Hook program.
+
+Here is the instruction struct:
+
+```rust
+// Order of accounts matters for this struct.
+// The first 4 accounts are the accounts required for token transfer (source, mint, destination, owner)
+// Remaining accounts are the extra accounts required from the ExtraAccountMetaList account
+// These accounts are provided via CPI to this program from the Token Extensions Program
+
+#[derive(Accounts)]
+pub struct TransferHook<'info> {
+  #[account(token::mint = mint, token::authority = owner)]
+  pub source_token: InterfaceAccount<'info, TokenAccount>,
+  pub mint: InterfaceAccount<'info, Mint>,
+  #[account(token::mint = mint)]
+  pub destination_token: InterfaceAccount<'info, TokenAccount>,
+  /// CHECK: source token account owner
+  pub owner: UncheckedAccount<'info>,
+  /// CHECK: ExtraAccountMetaList Account,
+  #[account(seeds = [b"extra-account-metas", mint.key().as_ref()], bump)]
+  pub extra_account_meta_list: UncheckedAccount<'info>,
+  pub token_program: Interface<'info, TokenInterface>,
+  pub associated_token_program: Program<'info, AssociatedToken>,
+  pub crumb_mint: InterfaceAccount<'info, Mint>,
+  /// CHECK: mint authority Account,
+  #[account(seeds = [b"mint-authority"], bump)]
+  pub mint_authority: UncheckedAccount<'info>,
+  #[account(
+        token::mint = crumb_mint,
+        token::authority = owner,
+    )]
+  pub crumb_mint_ata: InterfaceAccount<'info, TokenAccount>,
+}
+```
+
+**`transfer_hook` Instruction**
+
+This instruction is fairly simple, it will only make one CPI to the Token
+Program to mint a new crumb token for each transfer, all that we need to do is
+to pass the right accounts to the `mint_to` CPI.
+
+Since the mint_authority is a PDA of the transfer hook program itself, the
+program can sign for it. Therefore we'll use `new_with_signer` and pass
+mint_authority seeds as the signer seeds.
+
+```rust
+pub fn transfer_hook(ctx: Context<TransferHook>, _amount: u64) -> Result<()> {
+  let signer_seeds: &[&[&[u8]]] = &[&[b"mint-authority", &[ctx.bumps.mint_authority]]];
+
+  // mint a crumb token for each transaction
+  token::mint_to(
+    CpiContext::new_with_signer(
+      ctx.accounts.token_program.to_account_info(),
+      token::MintTo {
+        mint: ctx.accounts.crumb_mint.to_account_info(),
+        to: ctx.accounts.crumb_mint_ata.to_account_info(),
+        authority: ctx.accounts.mint_authority.to_account_info(),
+      },
+      signer_seeds
+    ),
+    1
+  ).unwrap();
+
+  Ok(())
+}
+```
+
+You may have noticed that we are using `token::mint_to` instead of
+`token_2022::mint_to`, additionally in the `extra_account_meta_list` we're
+saving the Token Program, not the Token Extensions Program. This is because the
+crumb SFT _has_ to be a Token Program mint, not a Token Extensions Program mint.
+The reason why is interesting: when first writing this, we wanted to make both
+the Cookie and Crumb tokens to be Token Extensions Program mints. However, when
+we did this, we would get a very interesting error: `No Reentrancy`. This
+happens because the transfer hook is called as a CPI from within the Token
+Extensions Program, and Solana does not allow
+[recursive CPIs into the same program](https://defisec.info/solana_top_vulnerabilities).
+
+To illustrate:
+
+```text
+Token Extensions Program -CPI-> Transfer Hook Program -❌CPI❌-> Token Extensions Progra
+Token Extensions Program -CPI-> Transfer Hook Program -✅CPI✅-> Token Progra
+```
+
+So, that's why we're making the crumb SFT a Token Program mint.
+
+### 3. Fallback instruction
+
+The last instruction we have to fill out is the `fallback`, this is necessary
+because Anchor generates instruction discriminators differently from the ones
+used in Transfer Hook interface instructions. The instruction discriminator for
+the `transfer_hook` instruction will not match the one for the Transfer Hook
+interface.
+
+Newer versions of Anchor should solve this for us, but for now, we can implement
+this simple workaround:
+
+```rust
+// fallback instruction handler as a workaround to anchor instruction discriminator check
+pub fn fallback<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>], data: &[u8]) -> Result<()> {
+  let instruction = TransferHookInstruction::unpack(data)?;
+
+  // match instruction discriminator to transfer hook interface execute instruction
+  // token2022 program CPIs this instruction on token transfer
+  match instruction {
+      TransferHookInstruction::Execute { amount } => {
+      let amount_bytes = amount.to_le_bytes();
+
+      // invoke custom transfer hook instruction on our program
+      __private::__global::transfer_hook(program_id, accounts, &amount_bytes)
+      }
+      _ => {
+      return Err(ProgramError::InvalidInstructionData.into());
+      }
+  }
+}
+```
+
+### 4. Build the program
+
+Let's make sure our program builds and that tests are runnable before we
+continue actually writing tests for it.
+
+```bash
+anchor test
+```
+
+This command will build, deploy and run tests within the `tests/` directory.
+
+If you're seeing any errors try to go through the steps again and make sure you
+didn't miss anything.
+
+## 2. Write the tests
+
+Now we'll write some TS scripts to test our code. All of our tests will live
+inside `tests/anchor.ts`.
+
+The outline of what will we do here is:
+
+1. Understand the environment
+
+2. Run the (empty) tests
+
+3. Write the "Create Cookie NFT with Transfer Hook and Metadata" test
+
+4. Write the "Create Crumb Mint" test
+
+5. Write the "Initializes ExtraAccountMetaList Account" test
+
+6. Write the "Transfer and Transfer Back" test
+
+### 1. Understand the environment
+
+When anchor projects are created, they come configured to create typescript
+tests with `mocha` and `chai`. When you look at `tests/anchor.ts` you'll see
+everything already set up with the tests we'll create.
+
+The following functionality is already provided to you:
+
+1. Get the program IDL.
+
+2. Get the wallet.
+
+3. Get the connection.
+
+4. Set up the environment
+
+5. Airdrop some SOLs into the wallet if needed before running any of the tests.
+
+6. 4 empty tests that we'll talk about later
+
+Let's get familiar with the accounts pre-setup for us:
+
+- `payerWallet`: This is the wallet from `Anchor.toml`, it will be used to pay
+  for everything
+
+- `cookieMint`: The Token Extensions Program mint we'll attach metadata and the
+  transfer hook to
+
+- `crumbMint`: The Token Program mint we'll attach metadata to, this will be
+  what's minted as a result of the transfer hook
+
+- `recipient`: Another wallet to send the cookie to/from
+
+- `sourceCookieAccount`: The ATA of the payer and the cookie mint
+
+- `extraAccountMetaListPDA`: Where we will store all of the extra accounts for
+  our hook
+
+- `crumbMintAuthority`: The authority to mint the crumb, owned by the Transfer
+  Hook program
+
+We've also provided two sets of hardcoded metadata for the Cookie NFT and the
+Crumb SFT.
+
+- `cookieMetadata`
+
+- `crumbMetadata`
+
+### 2. Running the tests
+
+Since the Crumb SFT is a Token Program mint, to attach metadata to it, we need
+to create a Metaplex metadata account. To do this, we need to include the
+Metaplex program. This has been provided for you.
+
+If you take a look at `Anchor.toml` you'll see that we load in the Metaplex bpf
+at the genesis block. This gives our testing validator access to the account.
+
+```toml
+[test]
+startup_wait = 5000
+shutdown_wait = 2000
+upgradeable = false
+
+[[test.genesis]]
+address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+program = "tests/metaplex_token_metadata_program.so"
+```
+
+If you wish to run a separate local validator to look at the explorer links, you
+can. However, you need to start your local validator such that it loads in the
+Metaplex program at genesis.
+
+In a separate terminal within the project directory run:
+
+```bash
+solana-test-validator --bpf-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s ./tests/metaplex_token_metadata_program.so
+```
+
+Then you can test with:
+
+```bash
+anchor test --skip-local-validator
+```
+
+### 3. Write the "Create Cookie NFT with Transfer Hook and Metadata" test
+
+Our first test will create our Cookie NFT, which will have metadata and our
+transfer hook attached.
+
+To accomplish all of this we will create several instructions:
+
+- `SystemProgram.createAccount`: Saves space for the mint on the blockchain
+
+- `createInitializeMetadataPointerInstruction`: Points to the mint itself since
+  the metadata will be stored within the mint
+
+- `createInitializeTransferHookInstruction`: Configures the transfer function to
+  call our transfer hook program
+
+- `createInitializeMintInstruction`: Initializes the mint account
+
+- `createInitializeInstruction`: Adds the metadata to the mint
+
+- `createAssociatedTokenAccountInstruction`: Creates the ATA for the mint to be
+  minted to - owned by the payer
+
+- `createMintToInstruction`: Mints one NFT to the ATA
+
+- `createSetAuthorityInstruction`: Revokes the mint authority, making a true
+  non-fungible token.
+
+Send all of these instructions in a transaction to the blockchain up and you
+have Cookie NFT:
+
+```ts
+it("Creates a Cookie NFT with Transfer Hook and Metadata", async () => {
+  // NFTs have 0 decimals
+  const decimals = 0;
+
+  const extensions = [
+    ExtensionType.TransferHook,
+    ExtensionType.MetadataPointer,
+  ];
+  const mintLen = getMintLen(extensions);
+  const metadataLen = TYPE_SIZE + LENGTH_SIZE + pack(cookieMetadata).length;
+  const lamports = await connection.getMinimumBalanceForRentExemption(
+    mintLen + metadataLen,
+  );
+
+  const transaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payerWallet.publicKey,
+      newAccountPubkey: cookieMint.publicKey,
+      space: mintLen,
+      lamports: lamports,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeMetadataPointerInstruction(
+      cookieMint.publicKey, //mint
+      payerWallet.publicKey, //authority
+      cookieMint.publicKey, //metadata address
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeTransferHookInstruction(
+      cookieMint.publicKey, // mint
+      payerWallet.publicKey, // authority
+      program.programId, // Transfer Hook Program ID
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeMintInstruction(
+      cookieMint.publicKey, // mint
+      decimals, // decimals
+      payerWallet.publicKey, // mint authority
+      null, // freeze authority
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createInitializeInstruction({
+      programId: TOKEN_2022_PROGRAM_ID,
+      mint: cookieMint.publicKey,
+      metadata: cookieMint.publicKey,
+      name: cookieMetadata.name,
+      symbol: cookieMetadata.symbol,
+      uri: cookieMetadata.uri,
+      mintAuthority: payerWallet.publicKey,
+      updateAuthority: payerWallet.publicKey,
+    }),
+    createAssociatedTokenAccountInstruction(
+      payerWallet.publicKey, // payer
+      sourceCookieAccount, // associated token account
+      payerWallet.publicKey, // owner
+      cookieMint.publicKey, // mint
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createMintToInstruction(
+      cookieMint.publicKey, // mint
+      sourceCookieAccount, // destination
+      payerWallet.publicKey, // authority
+      1, // amount - NFTs there will only be one
+      [], // multi signers
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    createSetAuthorityInstruction(
+      // revoke mint authority
+      cookieMint.publicKey, // mint
+      payerWallet.publicKey, // current authority
+      AuthorityType.MintTokens, // authority type
+      null, // new authority
+      [], // multi signers
+      TOKEN_2022_PROGRAM_ID,
+    ),
+  );
+
+  const txSig = await sendAndConfirmTransaction(connection, transaction, [
+    payerWallet.payer,
+    cookieMint,
+  ]);
+  console.log(getExplorerLink("transaction", txSig, "localnet"));
+});
+```
+
+Feel free to run the first test to make sure everything is working:
+
+```bash
+anchor test
+```
+
+### 4. Write the "Create Crumb Mint" test
+
+Now that we have our cookie NFT, we need our crumb SFTs. Creating the crumbs
+that will be minted on each transfer of our cookie will be our second test.
+
+Remember our crumbs are a Token Program mint, and to attach metadata we need to
+use Metaplex.
+
+First, we need to grab some Metaplex accounts and format our metadata.
+
+To format our metadata, we need to satisfy Metaplex's `DataV2` struct - for
+this, we only need to append some additional fields to our `crumbMetadata`.
+
+The Metaplex accounts we will need are:
+
+- `TOKEN_METADATA_PROGRAM_ID`: The Metaplex program
+
+- `metadataPDA`: The metadata account PDA derived from our `crumbMint`
+
+Lastly, to create our crumb, we need the following instructions:
+
+- `SystemProgram.createAccount`: Saves space for our mint
+
+- `createInitializeMintInstruction`: Initializes our mint
+
+- `createCreateMetadataAccountV3Instruction`: Creates the metadata account
+
+- `createSetAuthorityInstruction`: This sets the mint authority to the
+  `crumbMintAuthority`, which is the PDA our transfer hook program owns
+
+Putting it all together we get the following:
+
+```ts
+it("Create Crumb Mint", async () => {
+  // SFT Should have 0 decimals
+  const decimals = 0;
+
+  const size = MINT_SIZE;
+
+  const lamports = await connection.getMinimumBalanceForRentExemption(size);
+
+  const TOKEN_METADATA_PROGRAM_ID = new PublicKey(
+    "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+  );
+
+  const metadataData: DataV2 = {
+    ...crumbMetadata,
+    sellerFeeBasisPoints: 0,
+    creators: null,
+    collection: null,
+    uses: null,
+  };
+
+  const metadataPDAAndBump = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("metadata"),
+      TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+      crumbMint.publicKey.toBuffer(),
+    ],
+    TOKEN_METADATA_PROGRAM_ID,
+  );
+
+  const metadataPDA = metadataPDAAndBump[0];
+
+  const transaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payerWallet.publicKey,
+      newAccountPubkey: crumbMint.publicKey,
+      space: size,
+      lamports: lamports,
+      programId: TOKEN_PROGRAM_ID,
+    }),
+    createInitializeMintInstruction(
+      crumbMint.publicKey, // mint
+      decimals, // decimals
+      payerWallet.publicKey, // mint authority
+      null, // freeze authority
+      TOKEN_PROGRAM_ID,
+    ),
+    createCreateMetadataAccountV3Instruction(
+      {
+        metadata: metadataPDA,
+        mint: crumbMetadata.mint,
+        mintAuthority: payerWallet.publicKey,
+        payer: payerWallet.publicKey,
+        updateAuthority: payerWallet.publicKey,
+      },
+      {
+        createMetadataAccountArgsV3: {
+          collectionDetails: null,
+          data: metadataData,
+          isMutable: true,
+        },
+      },
+    ),
+    createSetAuthorityInstruction(
+      // set authority to transfer hook PDA
+      crumbMint.publicKey, // mint
+      payerWallet.publicKey, // current authority
+      AuthorityType.MintTokens, // authority type
+      crumbMintAuthority, // new authority
+      [], // multi signers
+      TOKEN_PROGRAM_ID,
+    ),
+  );
+
+  const txSig = await sendAndConfirmTransaction(
+    provider.connection,
+    transaction,
+    [payerWallet.payer, crumbMint],
+    { skipPreflight: true },
+  );
+
+  console.log(getExplorerLink("transaction", txSig, "localnet"));
+});
+```
+
+### 5. Write the "Initializes ExtraAccountMetaList Account" test
+
+Our next test is the last step of setup before we can start transferring our
+cookie and seeing the transfer hook work. We need to create the
+`ExtraAccountMetaList` account.
+
+We only need to execute one instruction this time:
+`initializeExtraAccountMetaList`. This is the function that we've implemented.
+
+Remember it takes the following additional accounts:
+
+- `mint`: The cookie mint
+
+- `extraAccountMetaList`: The PDA that holds the extra accounts
+
+- `crumbMint`: The crumb mint
+
+```ts
+// Account to store extra accounts required by the transfer hook instruction
+it("Initializes ExtraAccountMetaList Account", async () => {
+  const initializeExtraAccountMetaListInstruction = await program.methods
+    .initializeExtraAccountMetaList()
+    .accounts({
+      mint: cookieMint.publicKey,
+      extraAccountMetaList: extraAccountMetaListPDA,
+      crumbMint: crumbMint.publicKey,
+    })
+    .instruction();
+
+  const transaction = new Transaction().add(
+    initializeExtraAccountMetaListInstruction,
+  );
+
+  const txSig = await sendAndConfirmTransaction(
+    provider.connection,
+    transaction,
+    [payerWallet.payer],
+    {
+      skipPreflight: true,
+      commitment: "confirmed",
+    },
+  );
+
+  console.log(getExplorerLink("transaction", txSig, "localnet"));
+});
+```
+
+### 6. Write the "Transfer and Transfer Back" test
+
+Our last test is to transfer our cookie back and forth and see that our crumbs
+have been minted to both `payerWallet` and `recipient`.
+
+But before we transfer, we have to create the ATAs to hold the cookie and crumb
+tokens for both the `payerWallet` and `recipient`. We can do this by calling
+`getOrCreateAssociatedTokenAccount`. And we only need to do this to get the
+following: `destinationCookieAccount`, `sourceCrumbAccount` and,
+`destinationCrumbAccount`,
+
+because `sourceCookieAccount` was created when we minted the NFT.
+
+To transfer, we call `createTransferCheckedWithTransferHookInstruction`. This
+takes the following:
+
+- `connection`: Connection to use
+
+- `source`: Source token account
+
+- `mint`: Mint to transfer
+
+- `destination`: Destination token account
+
+- `owner`: Owner of the source token account
+
+- `amount`: Amount to transfer
+
+- `decimals`: Decimals of the mint
+
+- `multiSigners`: The signer account(s) for a multisig
+
+- `commitment`: Commitment to use
+
+- `programId`: SPL Token program account
+
+We will call this twice, to and from the `recipient`.
+
+You may notice that this does not take any of the additional accounts we need
+for the transfer hook like the `crumbMint` for example. This is because this
+function fetches the `extraAccountMeta` for us and automatically includes all of
+the accounts needed! That being said, it is asynchronous, so we will have to
+`await` it.
+
+Lastly, after the transfers, we'll grab the crumb mint and assert the total
+supply is two, and that both the `sourceCrumbAccount` and the
+`destinationCrumbAccount` have some crumbs.
+
+Putting this all together we get our final test:
+
+```ts
+it("Transfer and Transfer Back", async () => {
+  const amount = BigInt(1);
+  const decimals = 0;
+
+  // Create all of the needed ATAs
+  const destinationCookieAccount = (
+    await getOrCreateAssociatedTokenAccount(
+      connection,
+      payerWallet.payer,
+      cookieMint.publicKey,
+      recipient.publicKey,
+      false,
+      undefined,
+      { commitment: "confirmed" },
+      TOKEN_2022_PROGRAM_ID,
+    )
+  ).address;
+
+  const sourceCrumbAccount = (
+    await getOrCreateAssociatedTokenAccount(
+      connection,
+      payerWallet.payer,
+      crumbMint.publicKey,
+      payerWallet.publicKey,
+      false,
+      undefined,
+      { commitment: "confirmed" },
+      TOKEN_PROGRAM_ID,
+    )
+  ).address;
+
+  const destinationCrumbAccount = (
+    await getOrCreateAssociatedTokenAccount(
+      connection,
+      payerWallet.payer,
+      crumbMint.publicKey,
+      recipient.publicKey,
+      false,
+      undefined,
+      { commitment: "confirmed" },
+      TOKEN_PROGRAM_ID,
+    )
+  ).address;
+
+  // Standard token transfer instruction
+  const transferInstruction =
+    await createTransferCheckedWithTransferHookInstruction(
+      connection,
+      sourceCookieAccount,
+      cookieMint.publicKey,
+      destinationCookieAccount,
+      payerWallet.publicKey,
+      amount,
+      decimals, // Decimals
+      [],
+      "confirmed",
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+  const transferBackInstruction =
+    await createTransferCheckedWithTransferHookInstruction(
+      connection,
+      destinationCookieAccount,
+      cookieMint.publicKey,
+      sourceCookieAccount,
+      recipient.publicKey,
+      amount,
+      decimals, // Decimals
+      [],
+      "confirmed",
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+  const transaction = new Transaction().add(
+    transferInstruction,
+    transferBackInstruction,
+  );
+  const txSig = await sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [payerWallet.payer, recipient],
+    {
+      skipPreflight: true,
+    },
+  );
+
+  console.log(getExplorerLink("transaction", txSig, "localnet"));
+
+  const mintInfo = await getMint(
+    connection,
+    crumbMint.publicKey,
+    "processed",
+    TOKEN_PROGRAM_ID,
+  );
+
+  const sourceCrumbAccountInfo = await getAccount(
+    connection,
+    sourceCrumbAccount,
+    "processed",
+    TOKEN_PROGRAM_ID,
+  );
+
+  const destinationCrumbAccountInfo = await getAccount(
+    connection,
+    destinationCrumbAccount,
+    "processed",
+    TOKEN_PROGRAM_ID,
+  );
+
+  expect(Number(mintInfo.supply)).to.equal(2);
+  expect(Number(sourceCrumbAccountInfo.amount)).to.equal(1);
+  expect(Number(destinationCrumbAccountInfo.amount)).to.equal(1);
+
+  console.log("\nCrumb Count:", Number(mintInfo.supply));
+  console.log("Source Crumb Amount:", Number(sourceCrumbAccountInfo.amount));
+  console.log(
+    "Destination Crumb Amount\n",
+    Number(destinationCrumbAccountInfo.amount),
+  );
+});
+```
+
+Go ahead and run all of the tests:
+
+```bash
+anchor test
+```
+
+They should all be passing!
+
+If you want to take a look at any of the Explorer links do the following:
+
+In a separate terminal within the project directory run:
+
+```bash
+solana-test-validator --bpf-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s ./tests/metaplex_token_metadata_program.so
+```
+
+Then you can test with:
+
+```bash
+anchor test --skip-local-validator
+```
+
+Thats it! You've created a mint with a transfer hook!
+
+# Challenge
+
+Amend the transfer hook such that anyone who has a crumb cannot get their cookie
+back.

--- a/content/courses/token-extensions/transfer-hook.md
+++ b/content/courses/token-extensions/transfer-hook.md
@@ -9,7 +9,7 @@ description:
   token in transferred."
 ---
 
-# Summary
+## Summary
 
 - The `transfer hook` extension allows developers to run custom logic on their
   tokens on every transfer
@@ -29,7 +29,7 @@ description:
   de-escalated, meaning they are read-only to the hook. Meaning none of those
   accounts can sign or be written to.
 
-# Overview
+## Overview
 
 The `transfer-hook` extension allows custom onchain logic to be run after each
 transfer within the same transaction. More specifically, the `transfer-hook`
@@ -52,7 +52,7 @@ This extension allows many new use cases, including:
 In this lesson, we'll explore how to implement transfer hooks onchain and work
 with them in the frontend.
 
-## Implementing transfer hooks onchain
+### Implementing transfer hooks onchain
 
 The first part of creating a mint with a `transfer hook` is to find or create an
 onchain program that follows the
@@ -97,7 +97,7 @@ By storing the extra accounts required by the `Execute` instruction in the
 token transfer instruction from the client. We'll see how to do that in the
 off-chain section.
 
-### 1. `initialize_extra_account_meta_list` instruction:
+#### 1. `initialize_extra_account_meta_list` instruction:
 
 When we transfer a token using the Token Extensions Program, the program will
 examine our mint to determine if it has a transfer hook. If a transfer hook is
@@ -464,7 +464,7 @@ sneaky and add any of these first four accounts into the
 `extra_account_meta_list`, they will always be interpreted as read-only, even if
 you specify them differently with `is_writable` or `is_signer`.
 
-### 2. `transfer_hook` Instruction
+#### 2. `transfer_hook` Instruction
 
 In Anchor, when the `Execute` function is called, it looks for and calls the
 `transfer_hook` instruction. It is the place where we can implement our custom
@@ -520,7 +520,7 @@ hook. But remember, if the hook fails, the entire transaction fails.
   }
 ```
 
-### 3. Fallback
+#### 3. Fallback
 
 One last caveat to the onchain portion of transfer hooks: when dealing with
 Anchor, we need to specify a `fallback` instruction in the Anchor program to
@@ -555,7 +555,7 @@ pub fn fallback<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>
 }
 ```
 
-## Using transfer hooks from the frontend
+### Using transfer hooks from the frontend
 
 Now that we've looked at the on-chain portion, let's look at how we interact
 with them in the frontend.
@@ -576,7 +576,7 @@ follow these steps:
 3. Make sure to pass all the required accounts when invoking the transfer
    instruction from the Token Extensions Program.
 
-### Create a Mint with the `Transfer-Hook` Extension:
+#### Create a Mint with the `Transfer-Hook` Extension:
 
 To create a mint with the transfer-hook extension, we need three instructions:
 
@@ -614,7 +614,7 @@ const transaction = new Transaction().add(
   createInitializeMintInstruction(mint.publicKey, decimals, wallet.publicKey, null, TOKEN_2022_PROGRAM_ID),
 ```
 
-### Initialize `ExtraAccountMetaList` account:
+#### Initialize `ExtraAccountMetaList` account:
 
 The next step of getting the mint ready for any transactions is initializing the
 `ExtraAccountMetaList`. Generally, this is done by calling the
@@ -658,7 +658,7 @@ const transaction = new Transaction().add(
 After calling `initializeExtraAccountMetaList`, you're all set to transfer
 tokens with the transfer hook enabled mint.
 
-### Transfer tokens successfully:
+#### Transfer tokens successfully:
 
 To actually transfer tokens with the `transfer hook` extension, you need to call
 `createTransferCheckedWithTransferHookInstruction`. This is a special helper
@@ -747,7 +747,7 @@ export async function createTransferCheckedWithTransferHookInstruction(
 }
 ```
 
-## Theoretical Example - Artist Royalties
+### Theoretical Example - Artist Royalties
 
 Let's take what we know about the `transfer hook` extension and conceptually try
 to understand how we could implement artist royalties for NFTs. If you're not
@@ -794,7 +794,7 @@ theirs - should there be an approved list of "allowed" wallets? Or, should the
 artist be a signer involved in every sale/transfer? This system design makes for
 a great homework assignment!
 
-# Lab
+## Lab
 
 In this lab we'll explore how transfer hooks work by creating a Cookie Crumb
 program. We'll have a Cookie NFT that has a transfer hook which will mint a
@@ -802,9 +802,9 @@ Crumb SFT (NFT with a supply > 1) to the sender after each transfer - leaving a
 "crumb trail". A fun side effect is we'll able to tell how many times this NFT
 has been transferred just by looking at the crumb supply.
 
-## 0. Setup
+### 0. Setup
 
-### 1. Verify Solana/Anchor/Rust Versions
+#### 1. Verify Solana/Anchor/Rust Versions
 
 We'll be interacting with the `Token Extensions Program` in this lab and that
 requires you to have the Solana CLI version ≥ 1.18.1.
@@ -851,7 +851,7 @@ At the time of writing, the latest version of the Anchor CLI is `0.30.1`
 
 Now, we should have all the correct versions installed.
 
-### 2. Get starter code
+#### 2. Get starter code
 
 Let's grab the starter branch.
 
@@ -861,7 +861,7 @@ cd solana-lab-transfer-hooks
 git checkout starter
 ```
 
-### 3. Update Program ID and Anchor Keypair
+#### 3. Update Program ID and Anchor Keypair
 
 Once in the starter branch, run
 
@@ -880,7 +880,7 @@ cluster = "Localnet"
 wallet = "~/.config/solana/id.json"
 ```
 
-### 4. Confirm the program builds
+#### 4. Confirm the program builds
 
 Let's build the starter code to confirm we have everything configured correctly.
 If it does not build, please revisit the steps above.
@@ -908,7 +908,7 @@ anchor test
 
 We will be filling these tests in later.
 
-## 1. Write the transfer hook program
+### 1. Write the transfer hook program
 
 In this section we'll dive into writing the onchain transfer hook program using
 anchor, all the code will go into the `programs/transfer-hook/src/lib.rs` file.
@@ -939,7 +939,7 @@ Two instruction account structs
 
 We're going to look at each in depth.
 
-### 1. Initialize Extra Account Meta List instruction
+#### 1. Initialize Extra Account Meta List instruction
 
 The cookie transfer hook program needs some extra accounts to be able to mint
 the crumbs within the `transfer_hook` function, these are:
@@ -1108,7 +1108,7 @@ other accounts by their index. Specifically, the ATA belongs to whatever `owner`
 calls the transfer. So when a cookie is sent, the crumb will be minted to the
 sender.
 
-### 2. Transfer Hook instruction
+#### 2. Transfer Hook instruction
 
 In this step, we'll implement the `transfer_hook` instruction. This instruction
 will be called by the Token Extensions Program when a token transfer occurs.
@@ -1237,7 +1237,7 @@ Token Extensions Program -CPI-> Transfer Hook Program -✅CPI✅-> Token Progra
 
 So, that's why we're making the crumb SFT a Token Program mint.
 
-### 3. Fallback instruction
+#### 3. Fallback instruction
 
 The last instruction we have to fill out is the `fallback`, this is necessary
 because Anchor generates instruction discriminators differently from the ones
@@ -1269,7 +1269,7 @@ pub fn fallback<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>
 }
 ```
 
-### 4. Build the program
+#### 4. Build the program
 
 Let's make sure our program builds and that tests are runnable before we
 continue actually writing tests for it.
@@ -1283,7 +1283,7 @@ This command will build, deploy and run tests within the `tests/` directory.
 If you're seeing any errors try to go through the steps again and make sure you
 didn't miss anything.
 
-## 2. Write the tests
+### 2. Write the tests
 
 Now we'll write some TS scripts to test our code. All of our tests will live
 inside `tests/anchor.ts`.
@@ -1302,7 +1302,7 @@ The outline of what will we do here is:
 
 6. Write the "Transfer and Transfer Back" test
 
-### 1. Understand the environment
+#### 1. Understand the environment
 
 When anchor projects are created, they come configured to create typescript
 tests with `mocha` and `chai`. When you look at `tests/anchor.ts` you'll see
@@ -1350,7 +1350,7 @@ Crumb SFT.
 
 - `crumbMetadata`
 
-### 2. Running the tests
+#### 2. Running the tests
 
 Since the Crumb SFT is a Token Program mint, to attach metadata to it, we need
 to create a Metaplex metadata account. To do this, we need to include the
@@ -1386,7 +1386,7 @@ Then you can test with:
 anchor test --skip-local-validator
 ```
 
-### 3. Write the "Create Cookie NFT with Transfer Hook and Metadata" test
+#### 3. Write the "Create Cookie NFT with Transfer Hook and Metadata" test
 
 Our first test will create our Cookie NFT, which will have metadata and our
 transfer hook attached.
@@ -1508,7 +1508,7 @@ Feel free to run the first test to make sure everything is working:
 anchor test
 ```
 
-### 4. Write the "Create Crumb Mint" test
+#### 4. Write the "Create Crumb Mint" test
 
 Now that we have our cookie NFT, we need our crumb SFTs. Creating the crumbs
 that will be minted on each transfer of our cookie will be our second test.
@@ -1625,7 +1625,7 @@ it("Create Crumb Mint", async () => {
 });
 ```
 
-### 5. Write the "Initializes ExtraAccountMetaList Account" test
+#### 5. Write the "Initializes ExtraAccountMetaList Account" test
 
 Our next test is the last step of setup before we can start transferring our
 cookie and seeing the transfer hook work. We need to create the
@@ -1672,7 +1672,7 @@ it("Initializes ExtraAccountMetaList Account", async () => {
 });
 ```
 
-### 6. Write the "Transfer and Transfer Back" test
+#### 6. Write the "Transfer and Transfer Back" test
 
 Our last test is to transfer our cookie back and forth and see that our crumbs
 have been minted to both `payerWallet` and `recipient`.
@@ -1869,7 +1869,7 @@ anchor test --skip-local-validator
 
 Thats it! You've created a mint with a transfer hook!
 
-# Challenge
+## Challenge
 
 Amend the transfer hook such that anyone who has a crumb cannot get their cookie
 back.


### PR DESCRIPTION
This is the content from https://github.com/Unboxed-Software/solana-course/pull/375 - Unboxed final PR for their Token Extensions work. 

 - Lessons are added to the `token-extensions` course
 - Descriptions are added, headers are adjusted to start from h2

That PR included some changes to other files (I asked unboxed to do those in a separate PR but oh well), but it mostly seems to be fixes we've already applied - see https://github.com/solana-foundation/developer-content/pull/301

