### PR TITLE
Add isHidden to courses and hide outdated Unboxed courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ the Solana ecosystem and displayed on
 
 There are a few primary types of Solana Developer content within this repo:
 
-- [`docs`](#solana-docs) - The [core documentation](https://solana.com/docs) for
-  the Solana blockchain
-- [`guides`](#developer-guides) - Long form tutorials focused on a specific
+- [`courses`](#cources) - multiple lessons comprehensively covering a given
+  topic, with both a read session and and an interactive lab for each lesson
+- [`docs`](#docs) - the [core documentation](https://solana.com/docs) for the
+  Solana blockchain
+- [`guides`](#developer-guides) - long form tutorials focused on a specific
   topic related to Solana development, like building dApps and programs
-- [`resources`](#developer-resources) - Collection of the popular frameworks,
-  sdks, documentation sites, and developer tools from around the ecosystem
+- [`resources`](#developer-resources) - collection of popular frameworks, SDKs,
+  documentation sites, and developer tools from around the ecosystem
 
-### Solana Docs
+### Courses
+
+### Docs
 
 The core [Solana Documentation](https://solana.com/docs) is housed within this
 repo, including the documentation for the
@@ -29,8 +33,7 @@ repo, including the documentation for the
 The "core documentation" within this repo is generalized to the Solana protocol
 as a whole and not the specific implementations of any given Validator client.
 
-If you are looking for the documentation of a specific Validator client's
-implementation, consult their respective documentation:
+For specific validator clients, consult their respective documentation:
 
 | Validator Client         | Repo                                                               | Website                                                |
 | ------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------ |

--- a/content/courses/connecting-to-offchain-data/metadata.yml
+++ b/content/courses/connecting-to-offchain-data/metadata.yml
@@ -5,3 +5,4 @@ lessons:
   - oracles
   - verifiable-randomness-functions
 priority: 20
+isHidden: true

--- a/content/courses/native-onchain-development/metadata.yml
+++ b/content/courses/native-onchain-development/metadata.yml
@@ -1,6 +1,6 @@
 author: unboxed
 title: Native onchain program development
-description: "Learn how to build Solana programs  without using Anchor."
+description: "Learn how to build Solana programs without using Anchor."
 lessons:
   - hello-world-program
   - deserialize-instruction-data
@@ -12,3 +12,4 @@ lessons:
   - deserialize-custom-data-frontend
   - paging-ordering-filtering-data-frontend
 priority: 50
+isHidden: true

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -490,6 +490,17 @@ export const CourseRecord = defineDocumentType(() => ({
       type: "number",
       resolve: () => DEFAULT_PRIORITY,
     },
+
+    // Some of the Unboxed courses are out of date, so they are hidden from the
+    // UI (their URLs remain available to editors and users that know them)
+    // while we get them updated.
+    isHidden: {
+      type: "boolean",
+      description:
+        "Hide this course from the course list (does not affect URL availability)",
+      required: false,
+      default: false,
+    },
   },
 }));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,9 +51,6 @@ type NavItemBase = {
   href?: string;
   sidebarSortOrder?: number;
   metaOnly?: boolean;
-  /**
-   *
-   */
   items?: Array<any>;
   altRoutes?: string[] | undefined;
   isSkippedInNav?: boolean;


### PR DESCRIPTION
This adds an `isHidden` field to courses, and hides `native-onchain-development` and `connecting-to-offchain-data`  while we get a CFP together to update them.  

Other minor fixes: add `courses` to the content types mentioned in the README.

Note there is a second PR for solana-com repo https://github.com/solana-foundation/solana-com/pull/15 to use this field.