### PR TITLE
Change how dotenv is imported

### DIFF
--- a/content/courses/intro-to-solana/intro-to-cryptography.md
+++ b/content/courses/intro-to-solana/intro-to-cryptography.md
@@ -218,7 +218,8 @@ SECRET_KEY="[(a series of numbers)]"
 We can then load the keypair from the environment. Update `generate-keypair.ts`:
 
 ```typescript
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config();
 import { getKeypairFromEnvironment } from "@solana-developers/helpers";
 
 const keypair = getKeypairFromEnvironment("SECRET_KEY");


### PR DESCRIPTION
This error is shwoing when using 
```
import "dotenv/config"
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'D:\Coding\Solana\solKeyPair\node_modules\.bin\node_modules\dotenv\config.js' imported from D:\Coding\Solana\solKeyPair\node_modules\.bin\esrun-1723634828132.tmp.mjs Did you mean to import ../../dotenv/config.js?

IF you use this then this error will be gonr

### Problem



### Summary of Changes



Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->