### PR TITLE
Update deprecated rpc methods

### DIFF
--- a/docs/rpc/deprecated/confirmTransaction.mdx
+++ b/docs/rpc/deprecated/confirmTransaction.mdx
@@ -1,0 +1,13 @@
+---
+sidebarLabel: confirmTransaction
+title: confirmTransaction RPC Method
+hideTableOfContents: true
+---
+
+Fetch the current status of a transaction signature (processed, confirmed,
+finalized).
+
+<Callout type={"warning"} title={"Deprecated Method"}>
+  This method is expected to be removed in `solana-core` v2.0. Please use
+  [getSignatureStatuses](/docs/rpc/http/getSignatureStatuses) instead.
+</Callout>

--- a/docs/rpc/deprecated/getFeeRateGovernor.mdx
+++ b/docs/rpc/deprecated/getFeeRateGovernor.mdx
@@ -10,7 +10,8 @@ altRoutes:
 Returns the fee rate governor information from the root bank
 
 <Callout type={"warning"} title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0.
+  This method is expected to be removed in `solana-core` v2.0. Please use
+  [getFeeForMessage](/docs/rpc/http/getFeeForMessage) instead.
 </Callout>
 
 <DocSideBySide>

--- a/docs/rpc/deprecated/getSignatureConfirmation.mdx
+++ b/docs/rpc/deprecated/getSignatureConfirmation.mdx
@@ -1,0 +1,13 @@
+---
+sidebarLabel: getSignatureConfirmation
+title: getSignatureConfirmation RPC Method
+hideTableOfContents: true
+---
+
+Fetch the current status of a transaction signature (processed, confirmed,
+finalized).
+
+<Callout type={"warning"} title={"Deprecated Method"}>
+  This method is expected to be removed in `solana-core` v2.0. Please use
+  [getSignatureStatuses](/docs/rpc/http/getSignatureStatuses) instead.
+</Callout>

--- a/docs/rpc/deprecated/getSignatureStatus.mdx
+++ b/docs/rpc/deprecated/getSignatureStatus.mdx
@@ -1,0 +1,13 @@
+---
+sidebarLabel: getSignatureStatus
+title: getSignatureStatus RPC Method
+hideTableOfContents: true
+---
+
+Fetch the current status of a transaction signature (processed, confirmed,
+finalized).
+
+<Callout type={"warning"} title={"Deprecated Method"}>
+  This method is expected to be removed in `solana-core` v2.0. Please use
+  [getSignatureStatuses](/docs/rpc/http/getSignatureStatuses) instead.
+</Callout>

--- a/docs/rpc/deprecated/getStakeActivation.mdx
+++ b/docs/rpc/deprecated/getStakeActivation.mdx
@@ -8,6 +8,13 @@ altRoutes:
 
 Returns epoch activation information for a stake account
 
+<Callout type={"warning"} title={"Deprecated Method"}>
+  This method is expected to be removed in `solana-core` v2.0. Please use [this
+  alternative
+  approach](https://gist.github.com/joncinque/ccd5166a857d629f30b2c01cd010041d)
+  instead.
+</Callout>
+
 <DocSideBySide>
 
 <DocLeftSide>


### PR DESCRIPTION
Update docs deprecated rpc methods pages to match the [Agave v2.0 Transition Guide](https://github.com/anza-xyz/agave/wiki/Agave-v2.0-Transition-Guide#step-2-review-removed-rpc-endpoints-and-sdk-elements).

- Moved `getStakeActivation` page to deprecated section
- Added recommended alternative to `getFeeRateGovernor` page
- Added pages to deprecated section for `confirmTransaction`, `getSignatureStatus`, `getSignatureConfirmation`. 
  Just adding these pages as placeholders to point to recommended v2 alternatives.
   The code example `curl` commands for deprecated methods already return "Method not found" on devnet endpoint:
  ```
  {"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}
  ```
  
 However, I'm not entirely sure what `getSignatureConfirmation` refers to. 
 Assuming its [`get_signature_confirmation_status`](https://github.com/anza-xyz/agave/blob/master/rpc/src/rpc.rs#L1445), but there doesn't seem to be a `getSignatureConfirmation` method in [legacy solana-web3.js](https://github.com/solana-labs/solana-web3.js/blob/legacy-publish/src/connection.ts).
  