### PR TITLE
update/anchor-pda

### DIFF
--- a/content/courses/onchain-development/anchor-pdas.md
+++ b/content/courses/onchain-development/anchor-pdas.md
@@ -38,7 +38,7 @@ reallocate accounts, and close accounts.
 ### PDAs with Anchor
 
 Recall that
-[PDAs](https://github.com/Unboxed-Software/solana-course/blob/main/content/pda)
+[PDAs](https://github.com/Unboxed-Software/solana-course/blob/main/content/pda.md)
 are derived using a list of optional seeds, a bump seed, and a program ID.
 Anchor provides a convenient way to validate a PDA with the `seeds` and `bump`
 constraints.
@@ -230,7 +230,7 @@ To use `init_if_needed`, you must first enable the feature in `Cargo.toml`.
 
 ```rust
 [dependencies]
-anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
+anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
 ```
 
 Once you’ve enabled the feature, you can include the constraint in the


### PR DESCRIPTION
### Problem

- The link to get a deeper understanding of PDAs was leading to a **non-existing repo**
- Dependency in `Cargo.toml` was outdated


### Summary of Changes

- Fixed the `404 link` and added a valid link to the `https://github.com/Unboxed-Software/solana-course/blob/main/content/pda.md` readMe
- Updated dependency to the latest anchor version `0.30.1`

![image](https://github.com/user-attachments/assets/88b5f903-f6c9-423c-a3f8-41b9ebb1bc46)
