### PR TITLE
security-intro.md - fix: hyperlinks to courses

### DIFF
--- a/content/courses/program-security/security-intro.md
+++ b/content/courses/program-security/security-intro.md
@@ -15,8 +15,8 @@ course off Coral's
 [Sealevel Attacks](https://github.com/coral-xyz/sealevel-attacks) repo.
 
 We've covered program security in our
-[Anchor](/developers/courses/onchain-development/) and
-[native Rust](/developers/courses/native-onchain-development/) development
+[Anchor](/content/courses/onchain-development/) and
+[native Rust](/content/courses/native-onchain-development/) development
 courses because we wanted to make sure that anyone deploying programs to Mainnet
 right out of the gates had at least a basic understanding of security. And if
 that’s you then hopefully the fundamental principles you learned in that lesson


### PR DESCRIPTION
### Problem

The hyperlinks to the Anchor and native Rust programs were incorrect.


### Summary of Changes

Updated hyperlinks for the Anchor and native Rust programs to ensure they point to the correct courses.




<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->