### PR TITLE
security-intro.md - fix: hyperlinks to courses

### DIFF
--- a/content/courses/program-security/security-intro.md
+++ b/content/courses/program-security/security-intro.md
@@ -15,8 +15,8 @@ course off Coral's
 [Sealevel Attacks](https://github.com/coral-xyz/sealevel-attacks) repo.
 
 We've covered program security in our
-[Anchor](/content/courses/onchain-development/) and
-[native Rust](/content/courses/native-onchain-development/) development courses
+[Anchor](/content/courses/onchain-development.md) and
+[native Rust](/content/courses/native-onchain-development.md) development courses
 because we wanted to make sure that anyone deploying programs to Mainnet right
 out of the gates had at least a basic understanding of security. And if that’s
 you then hopefully the fundamental principles you learned in that lesson have

--- a/content/courses/program-security/security-intro.md
+++ b/content/courses/program-security/security-intro.md
@@ -15,8 +15,8 @@ course off Coral's
 [Sealevel Attacks](https://github.com/coral-xyz/sealevel-attacks) repo.
 
 We've covered program security in our
-[Anchor](/developers/courses/onchain-development/) and
-[native Rust](/developers/courses/native-onchain-development/) development
+[Anchor](/content/courses/onchain-development/) and
+[native Rust](/content/courses/native-onchain-development/) development
 courses because we wanted to make sure that anyone deploying programs to Mainnet
 right out of the gates had at least a basic understanding of security. And if
 that’s you then hopefully the fundamental principles you learned in that lesson

--- a/content/courses/program-security/security-intro.md
+++ b/content/courses/program-security/security-intro.md
@@ -16,11 +16,11 @@ course off Coral's
 
 We've covered program security in our
 [Anchor](/content/courses/onchain-development/) and
-[native Rust](/content/courses/native-onchain-development/) development
-courses because we wanted to make sure that anyone deploying programs to Mainnet
-right out of the gates had at least a basic understanding of security. And if
-that’s you then hopefully the fundamental principles you learned in that lesson
-have led to you avoiding some common Solana exploits on your own.
+[native Rust](/content/courses/native-onchain-development/) development courses
+because we wanted to make sure that anyone deploying programs to Mainnet right
+out of the gates had at least a basic understanding of security. And if that’s
+you then hopefully the fundamental principles you learned in that lesson have
+led to you avoiding some common Solana exploits on your own.
 
 This unit is meant to build on top of that lesson with two goals in mind:
 


### PR DESCRIPTION
### Problem

The hyperlinks to the Anchor and native Rust programs were incorrect or duplicated.

### Summary of Changes

- Updated hyperlinks for the Anchor and native Rust programs to ensure they point to the correct courses.



<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->