### PR TITLE
update/anchor-pda link and version

### DIFF
--- a/content/courses/onchain-development/anchor-pdas.md
+++ b/content/courses/onchain-development/anchor-pdas.md
@@ -38,7 +38,7 @@ reallocate accounts, and close accounts.
 ### PDAs with Anchor
 
 Recall that
-[PDAs](https://github.com/Unboxed-Software/solana-course/blob/main/content/pda)
+[PDAs](https://github.com/Unboxed-Software/solana-course/blob/main/content/pda.md)
 are derived using a list of optional seeds, a bump seed, and a program ID.
 Anchor provides a convenient way to validate a PDA with the `seeds` and `bump`
 constraints.
@@ -230,7 +230,7 @@ To use `init_if_needed`, you must first enable the feature in `Cargo.toml`.
 
 ```rust
 [dependencies]
-anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
+anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
 ```
 
 Once you’ve enabled the feature, you can include the constraint in the


### PR DESCRIPTION
### Problem

- The link to information about `PDA` led to a non-existent repo readMe
- anchor version `0.25.0` in dependencies

### Summary of Changes

- Fixed the link to the pda readMe
- Updated the anchor verison to `0.30.1` in dependencies

link before the update :

![image](https://github.com/user-attachments/assets/c6d387de-edcc-4313-9b41-d6bd53a20d4d)
