### PR TITLE
Improves the program derived addresses content

### DIFF
--- a/content/courses/native-onchain-development/program-derived-addresses.md
+++ b/content/courses/native-onchain-development/program-derived-addresses.md
@@ -22,17 +22,20 @@ description: "Get a deeper understanding of PDAs."
 
 ### What is a Program Derived Address?
 
-Program Derived Addresses (PDAs) are account addresses designed to be signed for
-by a program rather than a secret key. As the name suggests, PDAs are derived
-using a program ID. Optionally, the program finds the derived accounts using the
-ID and a set of "seeds". More on this later, but these seeds will play a role in
-using PDAs for data storage and retrieval.
+Program Derived Addresses (PDAs) are addresses that, instead of being public
+keys, are calculated (or 'found') based on a combination of:
+
+- The program ID
+- A set of "seeds" determined by the programmer.
+
+More on this later, but these seeds will play a role in using PDAs for data
+storage and retrieval.
 
 PDAs serve two main functions:
 
 1. Provide a deterministic way to find a given item of data for a program
-2. Authorize the program that derives a PDA to sign on its behalf, just as a
-   user signs with their secret key.
+2. Authorize the program that owns a PDA to sign on the PDAs behalf, just like a
+   user signs for their own account using their secret key.
 
 This lesson will focus on using PDAs to find and store data. We'll discuss
 signing with a PDA more thoroughly in a future lesson, where we will cover
@@ -43,45 +46,22 @@ Cross-Program Invocations (CPIs).
 Technically, PDAs are _found_ or _derived_ based on a program ID and one or more
 input seeds.
 
-Solana's cryptographic algorithm uses the Ed25519 Elliptic Curve (Ed25519), a
-deterministic signature scheme, to generate corresponding public and secret
-keys, which are called keypairs.
+Unlike other Solana accounts, PDAs are not public keys and don't have secret
+keys. Since public keys are on Solana's Ed25519 curve, PDAs are sometimes called
+'off curve addresses'.
 
-Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. PDAs are not
-public keys and don't have secret keys. This property of PDAs is essential for
-programs to be able to sign on their behalf, but we'll cover that in a future
-lesson.
-
-PDAs are application-specific, and their seeds must be unique for each PDA
-account. A hashing function deterministically generates a PDA by digesting the
-program ID and seeds.
-
-```rust
-// Pseudocode to show how a PDA address is derived
-/// where `hash` is a hash function whose result is
-/// 32 bytes, e.g., SHA256
-let seeds = &[&[]]; // An array of bytes of a seed
-let hasher = hashing_algorithm::Hasher();
-
-for seed in seeds {
- 	hash(seed);
-}
-
-// Should return 32-byte array
-let output: [u8;32] = hasher.finalize();
-
-// Return a Public key
-solana_program::pubkey::Pubkey::from(output)
-
-```
+PDAs are found using a hashing function that deterministically generates a PDA
+using the program ID and seeds. Both Solana frontend and backend code can
+determine an address using the program ID and seeds, and the same program with
+the same seeds always results in the same Program Derived Address.
 
 ### Seeds
 
-“Seeds” are optional inputs in the `find_program_address` method to derive a
-PDA. For example, seeds can be any combination of public keys, inputs provided
-by a user, or hard-coded values. A PDA can also be derived using only the
-program ID and no additional seeds. However, using seeds to find our PDAs allows
-us to create an arbitrary number of accounts that our program can own.
+“Seeds” are inputs in the `find_program_address` function, this method provides
+an additional seed called a “bump seed.” The find*program_address method adds a
+numeric seed called a bump seed that ensures the result is \_off* on the Ed25519
+curve, ie, is not a valid public key and does not have a corresponding secret
+key.
 
 While you, the developer, determine the seeds to pass into the
 `find_program_address`, this method provides an additional seed called a “bump

--- a/content/courses/native-onchain-development/program-derived-addresses.md
+++ b/content/courses/native-onchain-development/program-derived-addresses.md
@@ -12,7 +12,7 @@ description: "Get a deeper understanding of PDAs."
 
 - A **Program Derived Address** (PDA) is derived from a **program ID** and an
   optional list of **seeds**
-- PDAs are owned and controlled by the program they are derived from
+- The program that derives PDAs owns and controls them.
 - PDA derivation provides a deterministic way to find data based on the seeds
   used for the derivation
 - Seeds can be used to map to the data stored in a separate PDA account
@@ -24,256 +24,371 @@ description: "Get a deeper understanding of PDAs."
 
 Program Derived Addresses (PDAs) are account addresses designed to be signed for
 by a program rather than a secret key. As the name suggests, PDAs are derived
-using a program ID. Optionally, these derived accounts can also be found using
-the ID along with a set of "seeds." More on this later, but these seeds will
-play an important role in how we use PDAs for data storage and retrieval.
+using a program ID. Optionally, the program finds the derived accounts using the
+ID and a set of "seeds". More on this later, but these seeds will play a role in
+using PDAs for data storage and retrieval.
 
 PDAs serve two main functions:
 
 1. Provide a deterministic way to find a given item of data for a program
-2. Authorize the program from which a PDA was derived to sign on its behalf in
-   the same way a user may sign with their secret key
+2. Authorize the program that derives a PDA to sign on its behalf, just as a
+   user signs with their secret key.
 
-In this lesson we'll focus on using PDAs to find and store data. We'll discuss
-signing with a PDA more thoroughly in a future lesson where we cover Cross
-Program Invocations (CPIs).
+This lesson will focus on using PDAs to find and store data. We'll discuss
+signing with a PDA more thoroughly in a future lesson, where we will cover
+Cross-Program Invocations (CPIs).
 
 ### Finding PDAs
 
-PDAs are not technically created. Rather, they are _found_ or _derived_ based on
-a program ID and one or more input seeds.
+Technically, PDAs are _found_ or _derived_ based on a program ID and one or more
+input seeds.
 
-Solana keypairs can be found on what is called the Ed25519 Elliptic Curve
-(Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to
-generate corresponding public and secret keys. Together, we call these keypairs.
+Solana's cryptographic algorithm uses the Ed25519 Elliptic Curve (Ed25519), a
+deterministic signature scheme, to generate corresponding public and secret
+keys, which are called keypairs.
 
-Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. This means
-PDAs are not public keys, and don't have private keys. This property of PDAs is
-essential for programs to be able to sign on their behalf, but we'll cover that
-in a future lesson.
+Alternatively, PDAs are addresses that lie _off_ the Ed25519 curve. PDAs are not
+public keys and don't have secret keys. This property of PDAs is essential for
+programs to be able to sign on their behalf, but we'll cover that in a future
+lesson.
 
-To find a PDA within a Solana program, we'll use the `find_program_address`
-function. This function takes an optional list of “seeds” and a program ID as
-inputs, and then returns the PDA and a bump seed.
+PDAs are application-specific, and their seeds must be unique for each PDA
+account. A hashing function deterministically generates a PDA by digesting the
+program ID and seeds.
 
 ```rust
-let (pda, bump_seed) = Pubkey::find_program_address(&[user.key.as_ref(), user_input.as_bytes().as_ref(), "SEED".as_bytes()], program_id)
+// Pseudocode to show how a PDA address is derived
+/// where `hash` is a hash function whose result is
+/// 32 bytes, e.g., SHA256
+let seeds = &[&[]]; // An array of bytes of a seed
+let hasher = hashing_algorithm::Hasher();
+
+for seed in seeds {
+ 	hash(seed);
+}
+
+// Should return 32-byte array
+let output: [u8;32] = hasher.finalize();
+
+// Return a Public key
+solana_program::pubkey::Pubkey::from(output)
+
 ```
 
-#### Seeds
+### Seeds
 
-“Seeds” are optional inputs used in the `find_program_address` function to
-derive a PDA. For example, seeds can be any combination of public keys, inputs
-provided by a user, or hardcoded values. A PDA can also be derived using only
-the program ID and no additional seeds. Using seeds to find our PDAs, however,
-allows us to create an arbitrary number of accounts that our program can own.
+“Seeds” are optional inputs in the `find_program_address` method to derive a
+PDA. For example, seeds can be any combination of public keys, inputs provided
+by a user, or hard-coded values. A PDA can also be derived using only the
+program ID and no additional seeds. However, using seeds to find our PDAs allows
+us to create an arbitrary number of accounts that our program can own.
 
 While you, the developer, determine the seeds to pass into the
-`find_program_address` function, the function itself provides an additional seed
-called a "bump seed." The cryptographic function for deriving a PDA results in a
-key that lies _on_ the Ed25519 curve about 50% of the time. To ensure that the
-result _is not_ on the Ed25519 curve and therefore does not have a secret key,
-the `find_program_address` function adds a numeric seed called a bump seed.
+`find_program_address`, this method provides an additional seed called a “bump
+seed.” The cryptographic function for deriving a PDA results in a key that lies
+_on_ the Ed25519 curve about 50% of the time. The find*program_address method
+adds a numeric seed called a bump seed that ensures the result \_lies off* on
+the Ed25519 curve. Addresses off the Ed25519 curve lack a secret key.
 
-The function starts by using the value `255` as the bump seed, then checks to
-see if the output is a valid PDA. If the result is not a valid PDA, the function
-decreases the bump seed by 1 and tries again (`255`, `254`, `253`, et cetera).
-Once a valid PDA is found, the function returns both the PDA and the bump that
-was used to derive the PDA.
+The method begins with the bump seed value 255 and checks if the output is a
+valid PDA. If it is not, the method decrements the bump seed by subtracting one
+and tries again (`255`, `254`, `253`, et cetera). When the method finds a valid
+PDA, it returns the PDA and the canonical bump seed that derived it.
 
-#### Under the hood of `find_program_address`
+If the resulting PDA is on the Ed25519 curve, then an error
+`PubkeyError::InvalidSeeds` is returned.
 
-Let's take a look at the source code for `find_program_address`.
+A PDA allows a maximum of `16` seeds, with each seed limited to `32` bytes in
+length. If a seed exceeds this length or the number of seeds surpasses the
+limit, the system returns the error `PubkeyError::MaxSeedLengthExceeded,`
+indicating that the `Length of the seed is too long for address generation`.
+Developers commonly use static strings and public keys as seeds.
+
+The
+[PublicKey](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#)
+type has multiple methods that find a PDA within a Solana program:
+
+1. `find_program_address`
+2. `try_find_program_address`
+3. `create_program_address`
+
+These methods take an optional list of "_seeds_" and a `program ID` as inputs
+and can return the PDA and a bump seed or an error and a PDA.
+
+### 1. find_program_address
+
+The source code for `find_program_address`:
 
 ```rust
- pub fn find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> (Pubkey, u8) {
+pub fn find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> (Pubkey, u8) {
     Self::try_find_program_address(seeds, program_id)
         .unwrap_or_else(|| panic!("Unable to find a viable program address bump seed"))
 }
 ```
 
-Under the hood, the `find_program_address` function passes the input `seeds` and
-`program_id` to the `try_find_program_address` function.
+Under the hood, the `find_program_address` method passes the input `seeds` and
+`program_id` to the `try_find_program_address` method.
 
-The `try_find_program_address` function then introduces the `bump_seed`. The
-`bump_seed` is a `u8` variable with a value ranging between 0 to 255. Iterating
-over a descending range starting from 255, a `bump_seed` is appended to the
-optional input seeds which are then passed to the `create_program_address`
-function. If the output of `create_program_address` is not a valid PDA, then the
-`bump_seed` is decreased by 1 and the loop continues until a valid PDA is found.
+### 2. try_find_program_address
+
+The `try_find_program_address` method then introduces the `bump_seed`. The
+`bump_seed` is a `u8` variable with a value between 0 and 255. Iterating over a
+descending range starting from 255, a `bump_seed` is appended to the optional
+input seeds passed to the `create_program_address` method. If the output of
+`create_program_address` is not a valid PDA, the `bump_seed` is decreased by one
+and continues the loop until it finds a valid PDA.
+
+```rust
+pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<(Pubkey, u8)> {
+    #[cfg(not(target_os = "solana"))]
+    {
+        let mut bump_seed = [u8::MAX];
+        for _ in 0..u8::MAX {
+            {
+                let mut seeds_with_bump = seeds.to_vec();
+                seeds_with_bump.push(&bump_seed);
+                match Self::create_program_address(&seeds_with_bump, program_id) {
+                    Ok(address) => return Some((address, bump_seed[0])),
+                    Err(PubkeyError::InvalidSeeds) => (),
+                    _ => break,
+                }
+            }
+            bump_seed[0] -= 1;
+        }
+        None
+    }
+
+    // ...
+}
+```
+
+We can see that the `try_find_program_address` calls the
+`create_program_address` method.
 
 ```rust
 pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<(Pubkey, u8)> {
 
-    let mut bump_seed = [std::u8::MAX];
+    // ...
     for _ in 0..std::u8::MAX {
         {
-            let mut seeds_with_bump = seeds.to_vec();
-            seeds_with_bump.push(&bump_seed);
+            // `create_program_address` is called here
             match Self::create_program_address(&seeds_with_bump, program_id) {
-                Ok(address) => return Some((address, bump_seed[0])),
-                Err(PubkeyError::InvalidSeeds) => (),
-                _ => break,
+               //...
             }
         }
-        bump_seed[0] -= 1;
+       //...
     }
-    None
 
 }
+
 ```
 
-The `create_program_address` function performs a set of hash operations over the
-seeds and `program_id`. These operations compute a key, then verify if the
-computed key lies on the Ed25519 elliptic curve or not. If a valid PDA is found
-(i.e. an address that is _off_ the curve), then the PDA is returned. Otherwise,
-an error is returned.
+### 3. create_program_address
+
+The `create_program_address` method performs a hashing operation over the seeds
+and `program_id`. These operations compute a key and verify whether it lies on
+the Ed25519 elliptic curve. If a valid PDA is found (i.e., an address that is
+_off_ the curve), then either the PDA or an error is returned.
+
+The source code for `create_program_address`:
 
 ```rust
 pub fn create_program_address(
     seeds: &[&[u8]],
     program_id: &Pubkey,
 ) -> Result<Pubkey, PubkeyError> {
-
-    let mut hasher = crate::hash::Hasher::default();
+    if seeds.len() > MAX_SEEDS {
+        return Err(PubkeyError::MaxSeedLengthExceeded);
+    }
     for seed in seeds.iter() {
-        hasher.hash(seed);
-    }
-    hasher.hashv(&[program_id.as_ref(), PDA_MARKER]);
-    let hash = hasher.result();
-
-    if bytes_are_curve_point(hash) {
-        return Err(PubkeyError::InvalidSeeds);
+        if seed.len() > MAX_SEED_LEN {
+            return Err(PubkeyError::MaxSeedLengthExceeded);
+        }
     }
 
-    Ok(Pubkey::new(hash.as_ref()))
+    #[cfg(not(target_os = "solana"))]
+    {
+        let mut hasher = crate::hash::Hasher::default();
+        for seed in seeds.iter() {
+            hasher.hash(seed);
+        }
+        hasher.hashv(&[program_id.as_ref(), PDA_MARKER]);
+        let hash = hasher.result();
 
+        if bytes_are_curve_point(hash) {
+            return Err(PubkeyError::InvalidSeeds);
+        }
+
+        Ok(Pubkey::from(hash.to_bytes()))
+    }
+
+    // ...
 }
 ```
 
-In summary, the `find_program_address` function passes our input seeds and
-`program_id` to the `try_find_program_address` function. The
-`try_find_program_address` function adds a `bump_seed` (starting from 255) to
-our input seeds, then calls the `create_program_address` function until a valid
-PDA is found. Once found, both the PDA and the `bump_seed` are returned.
+It's crucial to be prepared for potential errors when generating a PDA,
+especially if it's on the Ed25519 curve. When an error occurs during the
+invocation of the `find_program_address` method, it's essential to handle it
+effectively. Though statistically improbable, the system returns the error
+`Unable to find a viable program address bump seed` whenever it finds a PDA that
+lies on the curve. The `try_find_program_address` method is used instead of
+panicking.
 
-Note that for the same input seeds, different valid bumps will generate
-different valid PDAs. The `bump_seed` returned by `find_program_address` will
-always be the first valid PDA found. Because the function starts with a
-`bump_seed` value of 255 and iterates downwards to zero, the `bump_seed` that
-ultimately gets returned will always be the largest valid 8-bit value possible.
-This `bump_seed` is commonly referred to as the "_canonical bump_". To avoid
-confusion, it's recommended to only use the canonical bump, and to _always
-validate every PDA passed into your program._
+Locating a valid PDA off the Ed25519 curve can be time-consuming due to the
+iterations on the canonical bump seed. This operation can consume a variable
+amount of the program’s compute budget. Developers can optimize the performance
+and lower the compute budget of programs by passing the
+`bump_seed (canonical bump)`, the user-supplied seeds as part of the instruction
+data, and then deserialize the seed and canonical bump. These deserialized
+outputs can then be passed to the `create_program_address` method to derive the
+PDA. It's important to note that the `create_program_address` method incurs a
+fixed cost to the compute budget.
 
-One point to emphasize is that the `find_program_address` function only returns
-a Program Derived Address and the bump seed used to derive it. The
-`find_program_address` function does _not_ initialize a new account, nor is any
-PDA returned by the function necessarily associated with an account that stores
-data.
+Address collisions can occur since the seeds are passed as a slice of bytes,
+meaning that the seeds `{abcdef}`, `{abc, def}` and `{ab, cd, ef}` will result
+in the same PDA being generated. A developer must prevent collisions by adding
+separator characters like hyphens.
+
+In summary, the `find_program_address` method passes the input seeds and
+`program_id` to the `try_find_program_address` method. The
+`try_find_program_address` method starts with a `bump_seed` of 255, adds it to
+the input seeds, and then repeatedly calls the `create_program_address` method
+until it finds a valid PDA. Once found, both the PDA and the `bump_seed` are
+returned.
+
+Note that different valid bumps generate different valid PDAs for the same input
+seeds. The `bump_seed` returned by `find_program_address` will always be the
+first valid PDA found.
+
+Using the canonical bump when generating a PDA onchain is crucial. Starting with
+a `bump_seed` value of `255` and iterating downward to `0` ensures that the
+returned seed will always be the most significant valid `8-bit` value possible.
+This `bump_seed` is commonly known as the "_canonical bump_". It's a best
+practice always to use the canonical bump and validate every PDA passed into
+your program to ensure the integrity of the process.
+
+One point to emphasize is that the `find_program_address` method only returns a
+Program-Derived Address and the bump seed used to derive it. The method does not
+initialize a new account, nor is any PDA returned by the method necessarily
+associated with an account that stores data.
 
 ### Use PDA accounts to store data
 
-Since programs themselves are stateless, program state is managed through
-external accounts. Given that you can use seeds for mapping and that programs
-can sign on their behalf, using PDA accounts to store data related to the
-program is an extremely common design choice. While programs can invoke the
-System Program to create non-PDA accounts and use those to store data as well,
-PDAs tend to be the way to go.
+Solana programs are stateless, so they manage their state through external
+accounts. Although programs can use the System Program to create non-PDA
+accounts for data storage, PDAs are the choice for storing program-related data.
+This choice is popular because the seeds and canonical bump directly map to the
+same PDA, and the program specified as the program ID can sign on its behalf.
+
+Program Derived Addresses (PDAs) are account keys only the program can sign on
+its behalf. During cross-program invocations, the program can “sign” for the key
+by calling `invoke_signed` and providing the same seeds used to generate the
+address, along with the calculated bump seed. The runtime then verifies that the
+program associated with the address is the caller and thus authorized to sign.
 
 If you need a refresher on how to store data in PDAs, have a look at the
 [State Management lesson](/content/courses/native-onchain-development/program-state-management).
 
 ### Map to data stored in PDA accounts
 
-Storing data in PDA accounts is only half of the equation. You also need a way
-to retrieve that data. We'll talk about two approaches:
+Storing data in PDA accounts is only half of the equation. Retrieving the data
+is the other half. We'll talk about two approaches:
 
 1. Creating a PDA "map" account that stores the addresses of various accounts
    where data is stored
 2. Strategically using seeds to locate the appropriate PDA accounts and retrieve
    the necessary data
 
-#### Map to data using PDA "map" accounts
+### Map to data using PDA "map" accounts
 
-One approach to organizing data storage is to store clusters of relevant data in
-their own PDAs and then to have a separate PDA account that stores a mapping of
-where all of the data is.
+For example, imagine a note-taking app where the underlying program generates
+PDA accounts using random seeds, with each account storing an individual note.
+Additionally, the program derives a single global PDA account, called the "map"
+account, using a static seed like "GLOBAL_MAPPING." This map account maintains a
+mapping of users' public keys to the list of PDAs where their notes are stored.
 
-For example, you might have a note-taking app whose backing program uses random
-seeds to generate PDA accounts and stores one note in each account. The program
-would also have a single global PDA "map" account that stores a mapping of
-users' public keys to the list of PDAs where their notes are stored. This map
-account would be derived using a static seed, e.g. "GLOBAL_MAPPING".
+To retrieve a user's notes, a lookup of the map account is performed to check
+the list of addresses associated with a user's public key and retrieve the
+account for each address.
 
-When it comes time to retrieve a user's notes, you could then look at the map
-account, see the list of addresses associated with a user's public key, then
-retrieve the account for each of those addresses.
+While such a solution is more approachable for traditional web developers, it
+has some drawbacks that are particular to web3 development. Since the map size
+stored in the map account will grow over time, each time you create a new note,
+you must either allocate more space than necessary when creating the account or
+reallocate space. Additionally, you will eventually reach the account size limit
+of 10 megabytes.
 
-While such a solution is perhaps more approachable for traditional web
-developers, it does come with some drawbacks that are particular to web3
-development. Since the size of the mapping stored in the map account will grow
-over time, you'll either need to allocate more size than necessary to the
-account when you first create it, or you'll need to reallocate space for it
-every time a new note is created. On top of that, you'll eventually reach the
-account size limit of 10 megabytes.
+You can mitigate this issue to a certain degree by creating a separate map
+account for each user. For example, you can construct a PDA map account per user
+rather than having a single PDA map account for the entire program. These map
+accounts are with the user's public key. You can then store the addresses for
+each note inside the corresponding user's map account.
 
-You could mitigate this issue to some degree by creating a separate map account
-for each user. For example, rather than having a single PDA map account for the
-entire program, you would construct a PDA map account per user. Each of these
-map accounts could be derived with the user's public key. The addresses for each
-note could then be stored inside the corresponding user's map account.
-
-This approach reduces the size required for each map account, but ultimately
+This approach reduces the size required for each map account but ultimately
 still adds an unnecessary requirement to the process: having to read the
 information on the map account _before_ being able to find the accounts with the
 relevant note data.
 
-There may be times where using this approach makes sense for your application,
-but we don't recommend it as your "go to" strategy.
+There are instances where this approach is a viable choice for an application,
+but it should be different from the default or recommended strategy.
 
-#### Map to data using PDA derivation
+### Map to data using PDA derivation
 
 If you're strategic about the seeds you use to derive PDAs, you can embed the
-required mappings into the seeds themselves. This is the natural evolution of
-the note-taking app example we just discussed. If you start to use the note
-creator's public key as a seed to create one map account per user, then why not
-use both the creator's public key and some other known piece of information to
-derive a PDA for the note itself?
+required mappings into them. It is the natural evolution of the note-taking app
+example we just discussed. If you start to use the note creator's public key as
+a seed to create one map account per user, then why not use both the creator's
+public key and some other known piece of information to derive a PDA for the
+note?
 
-Now, without talking about it explicitly, we’ve been mapping seeds to accounts
-this entire course. Think about the Movie Review program we've been built in
-previous lessons. This program uses a review creator's public key and the title
-of the movie they're reviewing to find the address that _should_ be used to
-store the review. This approach lets the program create a unique address for
-every new review while also making it easy to locate a review when needed. When
-you want to find a user's review of "Spiderman," you know that it is stored at
-the PDA account whose address can be derived using the user's public key and the
-text "Spiderman" as seeds.
+We've been mapping seeds to accounts this entire course and have yet to discuss
+it explicitly. Think about the Movie Review program we've built in previous
+lessons. This program uses a review creator's public key and the title of the
+movie they're reviewing to find the address that _should_ be used to store the
+review. This approach lets the program create a unique address for every new
+review while making it easy to locate a review when needed. When you want to
+find a user's review of "Spiderman", you can derive the PDA account's address
+using the user's public key and the text "Spiderman" as seeds.
 
 ```rust
 let (pda, bump_seed) = Pubkey::find_program_address(&[
         initializer.key.as_ref(),
         title.as_bytes().as_ref()
     ],
-    program_id)
+    program_id
+);
 ```
 
-#### Associated token account addresses
+### Associated token account addresses
 
-Another practical example of this type of mapping is how associated token
-account (ATA) addresses are determined. Tokens are often held in an ATA whose
-address was derived using a wallet address and the mint address of a specific
-token. The address for an ATA is found using the `get_associated_token_address`
-function which takes a `wallet_address` and `token_mint_address` as inputs.
+Another practical example of this mapping type is determining the associated
+token account (ATA) addresses. An ATA whose address is derived using a wallet
+address and the mint address of a specific token holds tokens. Solana token
+extensions introduced a new
+[token extensions program ID](https://docs.rs/spl-token-2022/latest/spl_token_2022/fn.id.html).
+You can specify how to create tokens using the legacy token or the new token
+extensions program. Use the new token extensions program, now the standard way
+to create tokens on Solana. The
+[get_associated_token_address_with_program_id](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/fn.get_associated_token_address_with_program_id.html)
+function finds the ATA account accepts a `wallet_address`, `token_mint_address`
+and the `token_program_id` as arguments.
+
+```toml
+# ...
+[dependencies]
+spl-token-2022 = "<latest_version_here>"
+spl-associated-token-account = "<latest_version_here>"
+```
 
 ```rust
-let associated_token_address = get_associated_token_address(&wallet_address, &token_mint_address);
+// Get the token extensions program ID
+let token2022_program = spl_token_2022::id();
+let associated_token_address = spl_associated_token_account::get_associated_token_address_with_program_id(&wallet_address, &token_mint_address, &token2022_program);
 ```
 
 Under the hood, the associated token address is a PDA found using the
-`wallet_address`, `token_program_id`, and `token_mint_address` as seeds. This
-provides a deterministic way to find a token account associated with any wallet
+`wallet_address`, `token_program_id`, and `token_mint_address` as seeds,
+providing a deterministic way to find a token account associated with any wallet
 address for a specific token mint.
 
 ```rust
@@ -294,50 +409,55 @@ fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-The mappings between seeds and PDA accounts that you use will be highly
-dependent on your specific program. While this isn't a lesson on system design
-or architecture, it's worth calling out a few guidelines:
+The mappings between seeds and PDA accounts you use will depend highly on your
+specific program. While this isn't a lesson on system design or architecture,
+it's worth calling out a few guidelines:
 
-- Use seeds that will be known at the time of PDA derivation
-- Be thoughtful about what data is grouped together into a single account
+- Use seeds known at the time of PDA derivation
+- Be thoughtful about how you group data into a single account
 - Be thoughtful about the data structure used within each account
 - Simpler is usually better
 
 ## Lab
 
-Let’s practice together with the Movie Review program we've worked on in
-previous lessons. No worries if you’re just jumping into this lesson without
-having done the previous lesson - it should be possible to follow along either
-way.
+Let's practice with the Movie Review program we've worked on in previous
+lessons. No worries if you're jumping into this lesson without doing the last
+lesson - it should be possible to follow along either way.
 
 As a refresher, the Movie Review program lets users create movie reviews. These
-reviews are stored in an account using a PDA derived with the initializer’s
-public key and the title of the movie they are reviewing.
+reviews are stored in an account using a PDA derived from the initializer's
+public key and the movie title they are reviewing.
 
-Previously, we finished implementing the ability to update a movie review in a
-secure manner. In this lab, we'll add the ability for users to comment on a
-movie review. We'll use building this feature as an opportunity to work through
-how to structure the comment storage using PDA accounts.
+Previously, we finished implementing the ability to update a movie review
+securely. In this lab, we'll add the ability for users to comment on a movie
+review. We'll use building this feature as an opportunity to work through how to
+structure the comment storage using PDA accounts.
 
-#### 1. Get the starter code
+### 1. Get the starter code
 
 To begin, you can find
 [the movie program starter code](https://github.com/Unboxed-Software/solana-movie-program/tree/starter)
 on the `starter` branch.
 
 If you've been following along with the Movie Review labs, you'll notice that
-this is the program we’ve built out so far. Previously, we
+this is the program we've built out so far. Previously, we
 used [Solana Playground](https://beta.solpg.io/) to write, build, and deploy our
-code. In this lesson, we’ll build and deploy the program locally.
+code. In this lesson, we'll develop and deploy the program locally. Ensure that
+`solana-test-validator` is running.
 
-Open the folder, then run `cargo-build-bpf` to build the program. The
-`cargo-build-bpf` command will output instruction to deploy the program.
+Open the folder, then run `cargo build-bpf` to build the program. The
+`cargo build-bpf` command will output a shared library for deployment inside the
+`./target/deploy/` path.
+
+The `./target/deploy/` directory contains the shared library in the format
+`<program_name_in_snake_case>.so` and the keypair that includes the public key
+of the program in the format `<program_name_in_snake_case>-keypair.json`.
 
 ```sh
-cargo-build-bpf
+cargo build-bpf
 ```
 
-Deploy the program by copying the output of `cargo-build-bpf` and running the
+Deploy the program by copying the output of `cargo build-bpf` and running the
 `solana program deploy` command.
 
 ```sh
@@ -346,13 +466,13 @@ solana program deploy <PATH>
 
 You can test the program by using the movie review
 [frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-update-reviews)
-and updating the program ID with the one you’ve just deployed. Make sure you use
+and updating the program ID with the one you've just deployed. Make sure you use
 the `solution-update-reviews` branch.
 
-#### 2. Plan out the account structure
+### 2. Plan out the account structure
 
-Adding comments means we need to make a few decisions about how to store the
-data associated with each comment. The criteria for a good structure here are:
+Adding comments means we must make a few decisions about storing the data
+associated with each comment. The criteria for a good structure here are:
 
 - Not overly complicated
 - Data is easily retrievable
@@ -363,28 +483,28 @@ To do this, we'll create two new account types:
 - Comment counter account
 - Comment account
 
-There will be one comment counter account per review and one comment account per
-comment. The comment counter account will be linked to a given review by using a
-review's address as a seed for finding the comment counter PDA. It will also use
-the static string "comment" as a seed.
+There will be one comment counter account per review, and one account linked to
+each comment posted. The comment counter account will be linked to a given
+review by using the review's address as a seed for finding the comment counter
+PDA. It will also use the static string "comment" as a seed.
 
-The comment account will be linked to a review in the same way. However, it will
-not include the "comment" string as a seed and will instead use the _actual
-comment count_ as a seed. That way the client can easily retrieve comments for a
-given review by doing the following:
+Link the comment account to a review in the same way. However, it will not
+include the "comment" string as a seed; instead, it will use the _actual comment
+count_ as a seed. That way, the client can easily retrieve comments for a given
+review by doing the following:
 
 1. Read the data on the comment counter account to determine the number of
    comments on a review.
 2. Where `n` is the total number of comments on the review, loop `n` times. Each
-   iteration of the loop will derive a PDA using the review address and the
-   current number as seeds. The result is `n` number of PDAs, each of which is
-   the address of an account that stores a comment.
-3. Fetch the accounts for each of the `n` PDAs and read the data stored in each.
+   loop iteration will derive a PDA using the review address and the current
+   number as seeds. The result is the `n` number of PDAs, each of which is the
+   address of an account that stores a comment.
+3. Fetch the accounts for each of the `n` PDAs and read the stored data.
 
-This ensures that every one of our accounts can be deterministically retrieved
-using data that is already known ahead of time.
+Every one of our accounts can be deterministically retrieved using data that is
+already known ahead of time.
 
-To implement these changes, we'll need to do the following:
+To implement these changes, do the following:
 
 - Define structs to represent the comment counter and comment accounts
 - Update the existing `MovieAccountState` to contain a discriminator (more on
@@ -394,7 +514,7 @@ To implement these changes, we'll need to do the following:
   include creating the comment counter account
 - Create a new `add_comment` instruction processing function
 
-#### 3. Define `MovieCommentCounter` and `MovieComment` structs
+### 3. Define MovieCommentCounter and MovieComment structs
 
 Recall that the `state.rs` file defines the structs our program uses to populate
 the data field of a new account.
@@ -405,12 +525,11 @@ We’ll need to define two new structs to enable commenting.
    associated with a review
 2. `MovieComment` - to store data associated with each comment
 
-To start, let’s define the structs we’ll be using for our program. Note that we
-are adding a `discriminator` field to each struct, including the existing
-`MovieAccountState`. Since we now have multiple account types, we need a way to
-only fetch the account type we need from the client. This discriminator is a
-string that can be used to filter through accounts when we fetch our program
-accounts.
+Let’s define the structs we’ll be using for our program. We add a
+`discriminator` field to each struct, including the existing
+`MovieAccountState`. Since we now have multiple account types, we only need a
+way to fetch the account type we need from the client. This discriminator is a
+string that will filter through accounts when we fetch our program accounts.
 
 ```rust
 #[derive(BorshSerialize, BorshDeserialize)]
@@ -462,11 +581,10 @@ impl IsInitialized for MovieComment {
 ```
 
 Since we've added a new `discriminator` field to our existing struct, the
-account size calculation needs to change. Let's use this as an opportunity to
-clean up some of our code a bit. We'll add an implementation for each of the
-three structs above that adds a constant `DISCRIMINATOR` and either a constant
-`SIZE` or function `get_account_size` so we can quickly get the size needed when
-initializing an account.
+account size calculation needs to change. Let's clean up some of our code. We'll
+add an implementation for each of the three structs above that adds a constant
+`DISCRIMINATOR` and either a constant `SIZE` or method `get_account_size` to
+quickly get the size needed when initializing an account.
 
 ```rust
 impl MovieAccountState {
@@ -495,15 +613,15 @@ impl MovieComment {
 }
 ```
 
-Now everywhere we need the discriminator or account size we can use this
-implementation and not risk unintentional typos.
+Now, we can use this implementation everywhere we need the discriminator or
+account size and not risk unintentional typos.
 
-#### 4. Create `AddComment` instruction
+### 4. Create AddComment instruction
 
 Recall that the `instruction.rs` file defines the instructions our program will
 accept and how to deserialize the data for each. We need to add a new
 instruction variant for adding comments. Let’s start by adding a new variant
-`AddComment` to the `MovieInstruction` enum.
+`AddComment,` to the `MovieInstruction` enum.
 
 ```rust
 pub enum MovieInstruction {
@@ -526,8 +644,7 @@ pub enum MovieInstruction {
 Next, let's create a `CommentPayload` struct to represent the instruction data
 associated with this new instruction. Most of the data we'll include in the
 account are public keys associated with accounts passed into the program, so the
-only thing we actually need here is a single field to represent the comment
-text.
+only thing we need here is a single field to represent the comment text.
 
 ```rust
 #[derive(BorshDeserialize)]
@@ -536,14 +653,16 @@ struct CommentPayload {
 }
 ```
 
-Now let’s update how we unpack the instruction data. Notice that we’ve moved the
+Now, update the unpacking of the instruction data. Notice that we’ve moved the
 deserialization of instruction data into each matching case using the associated
 payload struct for each instruction.
 
 ```rust
 impl MovieInstruction {
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
-        let (&variant, rest) = input.split_first().ok_or(ProgramError::InvalidInstructionData)?;
+        let (&variant, rest) = input
+            .split_first()
+            .ok_or(ProgramError::InvalidInstructionData)?;
         Ok(match variant {
             0 => {
                 let payload = MovieReviewPayload::try_from_slice(rest).unwrap();
@@ -572,17 +691,17 @@ impl MovieInstruction {
 }
 ```
 
-Lastly, let's update the `process_instruction` function in `processor.rs` to use
-the new instruction variant we've created.
+Lastly, update the `process_instruction` function in `processor.rs` to use our
+new instruction variant.
 
-In `processor.rs`, bring into scope the new structs from `state.rs`.
+In `processor.rs`, import the new structs from `state.rs` into scope.
 
 ```rust
 use crate::state::{MovieAccountState, MovieCommentCounter, MovieComment};
 ```
 
-Then in `process_instruction` let’s match our deserialized `AddComment`
-instruction data to the `add_comment` function we’ll be implementing shortly.
+Then in `process_instruction`, match our deserialized `AddComment` instruction
+data to the `add_comment` function we will be implementing shortly.
 
 ```rust
 pub fn process_instruction(
@@ -593,34 +712,34 @@ pub fn process_instruction(
     let instruction = MovieInstruction::unpack(instruction_data)?;
     match instruction {
         MovieInstruction::AddMovieReview { title, rating, description } => {
-            add_movie_review(program_id, accounts, title, rating, description)
+ 			add_movie_review(program_id, accounts, title, rating, description)
         },
         MovieInstruction::UpdateMovieReview { title, rating, description } => {
-            update_movie_review(program_id, accounts, title, rating, description)
+ 			update_movie_review(program_id, accounts, title, rating, description)
         },
 
         MovieInstruction::AddComment { comment } => {
-            add_comment(program_id, accounts, comment)
+ 			add_comment(program_id, accounts, comment)
         }
     }
 }
 ```
 
-#### 5. Update `add_movie_review` to create comment counter account
+### 5. Update add_movie_review to create a comment counter account.
 
-Before we implement the `add_comment` function, we need to update the
+Before implementing the `add_comment` function, we need to update the
 `add_movie_review` function to create the review's comment counter account.
 
-Remember that this account will keep track of the total number of comments that
-exist for an associated review. It's address will be a PDA derived using the
-movie review address and the word “comment” as seeds. Note that how we store the
-counter is simply a design choice. We could also add a “counter” field to the
-original movie review account.
+Remember that this account will keep track of the total number of comments for
+an associated review. Its address will be a PDA derived using the movie review
+address and the word “comment” as seeds. Note that how we store the counter is
+simply a design choice. We could add a “counter” field to the original movie
+review account.
 
 Within the `add_movie_review` function, let’s add a `pda_counter` to represent
 the new counter account we’ll be initializing along with the movie review
-account. This means we now expect four accounts to be passed into
-the `add_movie_review` function through the `accounts` argument.
+account. Now, expect four accounts passed into the `add_movie_review` function
+through the `accounts` argument.
 
 ```rust
 let account_info_iter = &mut accounts.iter();
@@ -631,7 +750,7 @@ let pda_counter = next_account_info(account_info_iter)?;
 let system_program = next_account_info(account_info_iter)?;
 ```
 
-Next, there's a check to make sure `total_len` is less than 1000 bytes, but
+Next, there's a check to ensure `total_len` is less than 1000 bytes, but
 `total_len` is no longer accurate since we added the discriminator. Let's
 replace `total_len` with a call to `MovieAccountState::get_account_size`:
 
@@ -639,13 +758,13 @@ replace `total_len` with a call to `MovieAccountState::get_account_size`:
 let account_len: usize = 1000;
 
 if MovieAccountState::get_account_size(title.clone(), description.clone()) > account_len {
-    msg!("Data length is larger than 1000 bytes");
+ msg!("Data length is larger than 1000 bytes");
     return Err(ReviewError::InvalidDataLength.into());
 }
 ```
 
-Note that this also needs to be updated in the `update_movie_review` function
-for that instruction to work properly.
+Remember to update the code within the `update_movie_review` function for that
+instruction to work correctly.
 
 Once we’ve initialized the review account, we’ll also need to update the
 `account_data` with the new fields we specified in the `MovieAccountState`
@@ -661,7 +780,7 @@ account_data.is_initialized = true;
 ```
 
 Finally, let’s add the logic to initialize the counter account within the
-`add_movie_review` function. This means:
+`add_movie_review` function by:
 
 1. Calculating the rent exemption amount for the counter account
 2. Deriving the counter PDA using the review address and the string "comment" as
@@ -670,8 +789,8 @@ Finally, let’s add the logic to initialize the counter account within the
 4. Set the starting counter value
 5. Serialize the account data and return from the function
 
-All of this should be added to the end of the `add_movie_review` function before
-the `Ok(())`.
+Add these steps to the end of the `add_movie_review` function before the
+`Ok(())`.
 
 ```rust
 msg!("create comment counter");
@@ -681,7 +800,7 @@ let counter_rent_lamports = rent.minimum_balance(MovieCommentCounter::SIZE);
 let (counter, counter_bump) =
     Pubkey::find_program_address(&[pda.as_ref(), "comment".as_ref()], program_id);
 if counter != *pda_counter.key {
-    msg!("Invalid seeds for PDA");
+ msg!("Invalid seeds for PDA");
     return Err(ProgramError::InvalidArgument);
 }
 
@@ -703,11 +822,11 @@ invoke_signed(
 msg!("comment counter created");
 
 let mut counter_data =
-    try_from_slice_unchecked::<MovieCommentCounter>(&pda_counter.data.borrow()).unwrap();
+ try_from_slice_unchecked::<MovieCommentCounter>(&pda_counter.data.borrow()).unwrap();
 
 msg!("checking if counter account is already initialized");
 if counter_data.is_initialized() {
-    msg!("Account already initialized");
+ msg!("Account already initialized");
     return Err(ProgramError::AccountAlreadyInitialized);
 }
 
@@ -718,24 +837,23 @@ msg!("comment count: {}", counter_data.counter);
 counter_data.serialize(&mut &mut pda_counter.data.borrow_mut()[..])?;
 ```
 
-Now when a new review is created, two accounts are initialized:
+The function initializes two accounts whenever it creates a new review:
 
-1. The first is the review account that stores the contents of the review. This
-   is unchanged from the version of the program we started with.
+1. The first is the review account, which stores the review's contents. This is
+   unchanged from the program's version we started with.
 2. The second account stores the counter for comments
 
-#### 6. Implement `add_comment`
+### 6. Implement add_comment
 
-Finally, let’s implement our `add_comment` function to create new comment
-accounts.
+Finally, implement the `add_comment` function to create new comment accounts.
 
-When a new comment is created for a review, we will increment the count on the
-comment counter PDA account and derive the PDA for the comment account using the
-review address and current count.
+When creating a new comment for a review, the counter will be incremented on the
+comment counter PDA account, and the PDA for the comment account will be derived
+using the review address and current count.
 
-Like in other instruction processing functions, we'll start by iterating through
-accounts passed into the program. Then before we do anything else we need to
-deserialize the counter account so we have access to the current comment count:
+Like other instruction processing functions, we'll start by iterating through
+accounts passed into the program. Then, before we do anything else, we need to
+deserialize the counter account, so we have access to the current comment count:
 
 ```rust
 pub fn add_comment(
@@ -743,8 +861,8 @@ pub fn add_comment(
     accounts: &[AccountInfo],
     comment: String
 ) -> ProgramResult {
-    msg!("Adding Comment...");
-    msg!("Comment: {}", comment);
+ msg!("Adding Comment...");
+ msg!("Comment: {}", comment);
 
     let account_info_iter = &mut accounts.iter();
 
@@ -763,12 +881,12 @@ pub fn add_comment(
 Now that we have access to the counter data, we can continue with the remaining
 steps:
 
-1. Calculate the rent exempt amount for the new comment account
+1. Calculate the rent-exempt amount for the new comment account
 2. Derive the PDA for the comment account using the review address and the
    current comment count as seeds
 3. Invoke the System Program to create the new comment account
 4. Set the appropriate values to the newly created account
-5. Serialize the account data and return from the function
+5. Serialize the account data and return from the method
 
 ```rust
 pub fn add_comment(
@@ -776,8 +894,8 @@ pub fn add_comment(
     accounts: &[AccountInfo],
     comment: String
 ) -> ProgramResult {
-    msg!("Adding Comment...");
-    msg!("Comment: {}", comment);
+ msg!("Adding Comment...");
+ msg!("Comment: {}", comment);
 
     let account_info_iter = &mut accounts.iter();
 
@@ -796,11 +914,11 @@ pub fn add_comment(
 
     let (pda, bump_seed) = Pubkey::find_program_address(&[pda_review.key.as_ref(), counter_data.counter.to_be_bytes().as_ref(),], program_id);
     if pda != *pda_comment.key {
-        msg!("Invalid seeds for PDA");
+ msg!("Invalid seeds for PDA");
         return Err(ReviewError::InvalidPDA.into())
     }
 
-    invoke_signed(
+ invoke_signed(
         &system_instruction::create_account(
         commenter.key,
         pda_comment.key,
@@ -812,13 +930,13 @@ pub fn add_comment(
         &[&[pda_review.key.as_ref(), counter_data.counter.to_be_bytes().as_ref(), &[bump_seed]]],
     )?;
 
-    msg!("Created Comment Account");
+ msg!("Created Comment Account");
 
     let mut comment_data = try_from_slice_unchecked::<MovieComment>(&pda_comment.data.borrow()).unwrap();
 
-    msg!("checking if comment account is already initialized");
+ msg!("checking if comment account is already initialized");
     if comment_data.is_initialized() {
-        msg!("Account already initialized");
+ msg!("Account already initialized");
         return Err(ProgramError::AccountAlreadyInitialized);
     }
 
@@ -829,7 +947,7 @@ pub fn add_comment(
     comment_data.is_initialized = true;
     comment_data.serialize(&mut &mut pda_comment.data.borrow_mut()[..])?;
 
-    msg!("Comment Count: {}", counter_data.counter);
+ msg!("Comment Count: {}", counter_data.counter);
     counter_data.counter += 1;
     counter_data.serialize(&mut &mut pda_counter.data.borrow_mut()[..])?;
 
@@ -837,24 +955,24 @@ pub fn add_comment(
 }
 ```
 
-#### 7. Build and deploy
+### 7. Build and deploy
 
 We're ready to build and deploy our program!
 
-Build the updated program by running `cargo-build-bpf`. Then deploy the program
-by running the `solana program deploy` command printed to the console.
+Build the updated program by running `cargo build-bpf`. Run the command
+`solana program deploy <path-to-the-program>` to deploy the program.
 
-You can test your program by submitting a transaction with the right instruction
-data. You can create your own script or feel free to use
+You can test your program by submitting a transaction with the correct
+instruction data. You can create your script or use
 [this frontend](https://github.com/Unboxed-Software/solana-movie-frontend/tree/solution-add-comments).
 Be sure to use the `solution-add-comments` branch and replace the
-`MOVIE_REVIEW_PROGRAM_ID` in `utils/constants.ts` with your program's ID or the
+`MOVIE_REVIEW_PROGRAM_ID` in `utils/constants.ts` with your program's ID, or the
 frontend won't work with your program.
 
-Keep in mind that we made breaking changes to the review accounts (i.e. adding a
-discriminator). If you were to use the same program ID that you've used
-previously when deploying this program, none of the reviews you created
-previously will show on this frontend due to a data mismatch.
+Remember that we made breaking changes to the review accounts (i.e., adding a
+discriminator). If you were to use the same program ID you've used before adding
+the discriminator when deploying this program, none of the reviews you created
+will show on this frontend due to a data mismatch.
 
 If you need more time with this project to feel comfortable with these concepts,
 have a look at
@@ -868,22 +986,20 @@ Now it’s your turn to build something independently! Go ahead and work with th
 Student Intro program that we've used in past lessons. The Student Intro program
 is a Solana program that lets students introduce themselves. This program takes
 a user's name and a short message as the `instruction_data` and creates an
-account to store the data onchain. For this challenge you should:
+account to store the data onchain. For this challenge, you should:
 
 1. Add an instruction allowing other users to reply to an intro
 2. Build and deploy the program locally
 
 If you haven't been following along with past lessons or haven't saved your work
 from before, feel free to use the starter code on the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-student-intro-program/tree/starter).
+[solana-student-intro-program](https://github.com/Unboxed-Software/solana-student-intro-program/tree/starter).
 
-Try to do this independently if you can! If you get stuck though, feel free to
-reference the
+Try to do this independently! If you get stuck, though, you can reference the
 [solution code](https://github.com/Unboxed-Software/solana-student-intro-program/tree/solution-add-replies).
 Note that the solution code is on the `solution-add-replies` branch and that
 your code may look slightly different.
 
 <Callout type="success" title="Completed the lab?">
-Push your code to GitHub and
-[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=89d367b4-5102-4237-a7f4-4f96050fe57e)!
+Push your code to GitHub and [tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=89d367b4-5102-4237-a7f4-4f96050fe57e)!
 </Callout>


### PR DESCRIPTION
Part of the `superteam-lesson-updates`

### Problem
The lesson on program derived addresses needs some updates to show the uses of the 3 methods on the `Pubkey` that are used to derive  a PDA.

Token Extensions was standardized but not updated in this repository.

The content also contains a lot of grammatical errors.


### Summary of Changes

1. Rewrote  sentences and correct grammatical mistakes found using grammarly
2. The `get_associated_token_address_with_program_id` function is used to show how ATAs are derived using the Token Extensions program ID
3. Informs a user on when to use the methods of `Pubkey` to find ATAs

Fixes #
- Correct the grammatical errors that were found using grammarly

- Inform the user when to use the methods:
  - find_program_address
  - try_find_program_address
  - create_program_address - for perfomant onchain code

- Inform the user on errors encountered by the methods or when a panic can happen

- Inform the user on the maximum number of seeds allowed and number of bytes a seed can contain

- Inform the user on seed collisions

- Avoid repeating the components of a PDA like how seeds are derived

- Replace `get_associated_token_address` with `get_associated_token_address_with_program_id` which is used in the new Token Extensions code

- use Token Extensions program when showcasing the use of `get_associated_token_address_with_program_id`

- Change `private key` to `secret key` in accordance with contributing guidelines

- Remove backticks in headings in accordance with contributing guidelines

- Use h3 instead of h4 markdown tags

https://github.com/Unboxed-Software/solana-movie-program/pull/5  pull request on solana-movie-program updates the dependencies for the starter code referenced in this PR