### PR TITLE
 add config of link checker

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Check links in Markdown files
         run: |
-          find . -name "*.md" -print0 | xargs -0 markdown-link-check
+          find . -name "*.md" -print0 | xargs -0 markdown-link-check --quiet

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,28 @@
+name: Check Relative Links
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+
+      - name: Install Markdown link checker
+        run: npm install -g markdown-link-check
+
+      - name: Check links in Markdown files
+        run: |
+          find . -name "*.md" -print0 | xargs -0 markdown-link-check


### PR DESCRIPTION
### Summary of Changes

1. use quiet mode, only list invalid links in result;
2. add config, replaces links starting with `/` with `https://solana.com/docs/core/` when check;


https://github.com/solana-foundation/developer-content/pull/370