### PR TITLE
Fix typo in code reference: missing  an other '='.

### DIFF
--- a/content/guides/dapps/cash-app.md
+++ b/content/guides/dapps/cash-app.md
@@ -400,7 +400,7 @@ Since we are directly manipulating the lamports in an account, we want to ensure
 that the signer of the instruction is the same as the owner of the account so
 that only the owner can call this instruction. This is why the following
 validation check was implemented:
-`require!(cash_account.owner = ctx.accounts.signer, ErrorCode::InvalidSigner)`.
+`require!(cash_account.owner == ctx.accounts.signer, ErrorCode::InvalidSigner)`.
 
 For error handling. the `#[error_code]` Anchor macro is used, which generates
 `Error` and `type Result<T> = Result<T, Error> ` types to be used as return


### PR DESCRIPTION
This commit corrects a typo in a code reference where a single '=' was  used instead of '==':

`require!(cash_account.owner = ctx.accounts.signer, ErrorCode::InvalidSigner);`

Contrary to the actual code implementation:

`require!(cash_account.owner == ctx.accounts.signer.key(), ErrorCode::InvalidSigner);`

This fix ensures the example or documentation accurately reflects the intended comparison logic, avoiding confusion for developers referencing this code.

### Problem



### Summary of Changes



Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->