### PR TITLE
Updated account-data-matching,  bump-seed-canonicalization

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -13,6 +13,6 @@ solved:
     # Close the discussion
     close: true
     # Set a close reason
-    close-reason: 'resolved'
+    close-reason: "resolved"
     # Lock the discussion
     lock: true

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -13,6 +13,7 @@ solved:
     # Close the discussion
     close: true
     # Set a close reason
-    close-reason: "resolved"
+    close-reason: 'resolved'
     # Lock the discussion
     lock: true
+    

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -23,7 +23,8 @@ description:
       return Err(ProgramError::InvalidAccountData.into());
   }
   ```
-- Use [Anchor constraints](https://www.anchor-lang.com/docs/account-constraints) to simplify the process:
+- Use [Anchor constraints](https://www.anchor-lang.com/docs/account-constraints)
+  to simplify the process:
   - Use `constraint` to evaluate custom expressions
   - Use `has_one` to check that a field on one account matches the key of
     another account

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -46,14 +46,14 @@ attacks:
    gaining access to functionality they shouldn't have
 2. State manipulation: attackers might alter the program's state in unintended  
    ways, compromising its integrity
-3. Fund theft: in programs dealing with tokens or SOL, inadequate checks could  
+3. Fund theft: in programs dealing with tokens, inadequate checks could  
    lead to unauthorized withdrawals
 
 Let's look at an example to illustrate the importance of account data matching.
 
 ### Example: Insecure Admin Update
 
-Consider a program with an `update_admin` instruction that changes the admin of
+Consider a program with an `update_admin` instruction handler that changes the admin of
 a configuration account:
 
 ```rust
@@ -178,7 +178,7 @@ of a withdraw instruction to highlight the difference.
 ### 1. Setup
 
 Clone the starter code from the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-account-data-matching).
+[this repository](https://github.com/solana-developers/solana-account-data-matching).
 
 The starter code includes a program with two instructions and a boilerplate test
 file:
@@ -200,7 +200,7 @@ pub fn insecure_withdraw(ctx: Context<InsecureWithdraw>) -> Result<()> {
     let amount = ctx.accounts.token_account.amount;
 
     let seeds = &[b"vault".as_ref(), &[ctx.bumps.vault]];
-    let signer = [&seeds[..]];
+    let signers = [&seeds[..]];
 
     let cpi_ctx = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
@@ -209,7 +209,7 @@ pub fn insecure_withdraw(ctx: Context<InsecureWithdraw>) -> Result<()> {
             authority: ctx.accounts.vault.to_account_info(),
             to: ctx.accounts.withdraw_destination.to_account_info(),
         },
-        &signer,
+        &signers,
     );
 
     token::transfer(cpi_ctx, amount)?;
@@ -286,7 +286,7 @@ pub fn secure_withdraw(ctx: Context<SecureWithdraw>) -> Result<()> {
     let amount = ctx.accounts.token_account.amount;
 
     let seeds = &[b"vault".as_ref(), &[ctx.bumps.vault]];
-    let signer = [&seeds[..]];
+    let signers = [&seeds[..]];
 
     let cpi_ctx = CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),
@@ -295,7 +295,7 @@ pub fn secure_withdraw(ctx: Context<SecureWithdraw>) -> Result<()> {
             authority: ctx.accounts.vault.to_account_info(),
             to: ctx.accounts.withdraw_destination.to_account_info(),
         },
-        &signer,
+        &signers,
     );
 
     token::transfer(cpi_ctx, amount)?;
@@ -385,6 +385,41 @@ test("Secure withdraw allows authorized access", async () => {
 
 Run `anchor test` again. You should see that the unauthorized withdrawal now
 fails, while the authorized one succeeds.
+
+Run `anchor test` to see that the transaction using an incorrect authority
+account will now return an Anchor Error while the transaction using correct
+accounts completes successfully.
+
+```bash
+'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS invoke [1]',
+'Program log: Instruction: SecureWithdraw',
+'Program log: AnchorError caused by account: vault. Error Code: ConstraintHasOne. Error Number: 2001. Error Message: A has one constraint was violated.',
+'Program log: Left:',
+'Program log: DfLZV18rD7wCQwjYvhTFwuvLh49WSbXFeJFPQb5czifH',
+'Program log: Right:',
+'Program log: 5ovvmG5ntwUC7uhNWfirjBHbZD96fwuXDMGXiyMwPg87',
+'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS consumed 10401 of 200000 compute units',
+'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS failed: custom program error: 0x7d1'
+```
+
+Note that Anchor specifies in the logs the account that causes the error
+(`AnchorError caused by account: vault`).
+
+```bash
+✔ Secure withdraw, expect error (77ms)
+✔ Secure withdraw (10073ms)
+```
+
+And just like that, you've closed up the security loophole. The theme across
+most of these potential exploits is that they're quite simple. However, as your
+programs grow in scope and complexity, it becomse increasingly easy to miss
+possible exploits. It's great to get in a habit of writing tests that send
+instructions that _shouldn't_ work. The more the better. That way you catch
+problems before you deploy.
+
+If you want to take a look at the final solution code you can find it on the
+`solution` branch of
+[the repository](https://github.com/solana-developers/account-data-matching/tree/solution)
 
 ### Conclusion
 

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -53,8 +53,8 @@ Let's look at an example to illustrate the importance of account data matching.
 
 ### Example: Insecure Admin Update
 
-Consider a program with an `update_admin` instruction handler that changes the admin of
-a configuration account:
+Consider a program with an `update_admin` instruction handler that changes the
+admin of a configuration account:
 
 ```rust
 use anchor_lang::prelude::*;

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -133,13 +133,14 @@ This approach allows for more flexibility in your validation logic.
 <Callout type="info">
   Remember to define your custom errors in your program's error enum:
 
-  ```rust
-  #[error_code]
-  pub enum MyError {
-      #[msg("Only the current admin can perform this action")]
-      InvalidAdmin,
-  }
-  ```
+```rust
+#[error_code]
+pub enum MyError {
+    #[msg("Only the current admin can perform this action")]
+    InvalidAdmin,
+}
+```
+
 </Callout>
 
 By implementing these checks, you ensure that only the rightful admin can update the admin_config account, significantly improving your program's security.
@@ -227,14 +228,14 @@ it("Insecure withdraw allows unauthorized access", async () => {
       withdrawDestination: withdrawDestinationFake,
       authority: walletFake.publicKey,
     })
-    .transaction()
+    .transaction();
 
-  await anchor.web3.sendAndConfirmTransaction(connection, tx, [walletFake])
+  await anchor.web3.sendAndConfirmTransaction(connection, tx, [walletFake]);
 
   // Check that the withdrawal succeeded (it shouldn't have!)
-  const balance = await connection.getTokenAccountBalance(tokenPDA)
-  expect(balance.value.uiAmount).to.eq(0)
-})
+  const balance = await connection.getTokenAccountBalance(tokenPDA);
+  expect(balance.value.uiAmount).to.eq(0);
+});
 ```
 
 Run `anchor test` to see that this unauthorized withdrawal succeeds, demonstrating the security flaw.
@@ -309,19 +310,19 @@ it("Secure withdraw prevents unauthorized access", async () => {
         withdrawDestination: withdrawDestinationFake,
         authority: walletFake.publicKey,
       })
-      .rpc()
-    
+      .rpc();
+
     // If we reach here, the test failed
-    assert.fail("Expected an error, but withdrawal succeeded")
+    assert.fail("Expected an error, but withdrawal succeeded");
   } catch (error) {
     // Check that it's the error we expect
-    expect(error.error.errorCode.code).to.equal("ConstraintHasOne")
+    expect(error.error.errorCode.code).to.equal("ConstraintHasOne");
   }
 
   // Check that the balance hasn't changed
-  const balance = await connection.getTokenAccountBalance(tokenPDA)
-  expect(balance.value.uiAmount).to.eq(100) // Assuming 100 tokens were initially minted
-})
+  const balance = await connection.getTokenAccountBalance(tokenPDA);
+  expect(balance.value.uiAmount).to.eq(100); // Assuming 100 tokens were initially minted
+});
 
 it("Secure withdraw allows authorized access", async () => {
   // Perform authorized withdrawal
@@ -333,12 +334,12 @@ it("Secure withdraw allows authorized access", async () => {
       withdrawDestination: withdrawDestination,
       authority: wallet.publicKey,
     })
-    .rpc()
+    .rpc();
 
   // Check that the withdrawal succeeded
-  const balance = await connection.getTokenAccountBalance(tokenPDA)
-  expect(balance.value.uiAmount).to.eq(0)
-})
+  const balance = await connection.getTokenAccountBalance(tokenPDA);
+  expect(balance.value.uiAmount).to.eq(0);
+});
 ```
 
 Run `anchor test` again. You should see that the unauthorized withdrawal now fails, while the authorized one succeeds.
@@ -349,10 +350,10 @@ By implementing proper account data matching, we've significantly improved the s
 
 Remember, as your programs grow in complexity, it becomes increasingly important to implement thorough data validation checks. Always consider what assumptions your program is making about its inputs. Validate these assumptions explicitly.
 
-<Callout type="success" title="Challenge">
-  Now that you've seen how to implement account data matching, take some time to review one of your existing programs. Look for places where you might be making assumptions about account data without explicitly checking it. Implement appropriate checks using the techniques you've learned in this lesson.
+Now that you've seen how to implement account data matching, take some time to review one of your existing programs. Look for places where you might be making assumptions about account data without explicitly checking it. Implement appropriate checks using the techniques you've learned in this lesson.
 
-  Remember, if you find a security vulnerability in someone else's program, responsibly disclose it to the program's maintainers. If you find one in your own program, patch it as soon as possible!
-</Callout>
+Remember, if you find a security vulnerability in someone else's program, responsibly disclose it to the program's maintainers. If you find one in your own program, patch it as soon as possible!
 
 After completing this lab and challenge, you'll have gained practical experience in identifying and fixing security vulnerabilities related to account data matching. This skill is crucial for developing secure Solana programs.
+
+Push your code to GitHub and [tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=a107787e-ad33-42bb-96b3-0592efc1b92f)!

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -253,7 +253,6 @@ test("Insecure withdraw allows unauthorized access", async () => {
   // ... (initialization code here)
 
   // Attempt unauthorized withdrawal
-  // Note: unauthorizedWallet represents an unauthorized wallet trying to withdraw funds
   const tx = await program.methods
     .insecureWithdraw()
     .accounts({

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -1,50 +1,44 @@
 ---
-title: Account Data Matching
+title: Account data matching
 objectives:
   - Explain the security risks associated with missing data validation checks
-  - Implement data validation checks using long-form Rust
+  - Implement data validation checks using native Rust
   - Implement data validation checks using Anchor constraints
-description:
-  "How to check your program's data accounts in both Anchor and Native Rust."
+description: Learn how to properly validate account data in Solana programs to prevent security vulnerabilities.
 ---
+
+# Account Data Matching
 
 ## Summary
 
-- Use **data validation checks** to verify that account data matches an expected
-  value. Without appropriate data validation checks, unexpected accounts may be
-  used in an instruction.
-- To implement data validation checks in Rust, simply compare the data stored on
-  an account to an expected value.
+- **Data validation checks** are crucial for verifying that account data matches expected values. Without proper checks, malicious users could exploit your program using unexpected accounts.
+- In native Rust, implement data validation by comparing account data to expected values:
   ```rust
   if ctx.accounts.user.key() != ctx.accounts.user_data.user {
       return Err(ProgramError::InvalidAccountData.into());
   }
   ```
-- In Anchor, you can use `constraint` to checks whether the given expression
-  evaluates to true. Alternatively, you can use `has_one` to check that a target
-  account field stored on the account matches the key of an account in the
-  `Accounts` struct.
+- Anchor simplifies this process with constraints:
+  - Use `constraint` to evaluate custom expressions
+  - Use `has_one` to check that a field on one account matches the key of another account
 
 ## Lesson
 
-Account data matching refers to data validation checks used to verify the data
-stored on an account matches an expected value. Data validation checks provide a
-way to include additional constraints to ensure the appropriate accounts are
-passed into an instruction.
+Account data matching is a critical security practice in Solana program development. It involves implementing data validation checks to ensure that the data stored on an account matches expected values. These checks are essential for preventing unauthorized access and maintaining the integrity of your program's state.
 
-This can be useful when accounts required by an instruction have dependencies on
-values stored in other accounts or if an instruction is dependent on the data
-stored in an account.
+### Why Account Data Matching Matters
 
-#### Missing data validation check
+Without proper data validation, your program becomes vulnerable to various attacks:
 
-The example below includes an `update_admin` instruction that updates the
-`admin` field stored on an `admin_config` account.
+1. Unauthorized access: Malicious users could pass in unexpected accounts, gaining access to functionality they shouldn't have.
+2. State manipulation: Attackers might alter the program's state in unintended ways, compromising its integrity.
+3. Fund theft: In programs dealing with tokens or SOL, inadequate checks could lead to unauthorized withdrawals.
 
-The instruction is missing a data validation check to verify the `admin` account
-signing the transaction matches the `admin` stored on the `admin_config`
-account. This means any account signing the transaction and passed into the
-instruction as the `admin` account can update the `admin_config` account.
+Let's look at an example to illustrate the importance of account data matching.
+
+### Example: Insecure Admin Update
+
+Consider a program with an `update_admin` instruction that changes the admin of a configuration account:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -52,9 +46,9 @@ use anchor_lang::prelude::*;
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
-pub mod data_validation {
+pub mod insecure_admin {
     use super::*;
-    ...
+
     pub fn update_admin(ctx: Context<UpdateAdmin>) -> Result<()> {
         ctx.accounts.admin_config.admin = ctx.accounts.new_admin.key();
         Ok(())
@@ -65,8 +59,7 @@ pub mod data_validation {
 pub struct UpdateAdmin<'info> {
     #[account(mut)]
     pub admin_config: Account<'info, AdminConfig>,
-    #[account(mut)]
-    pub admin: Signer<'info>,
+    pub current_admin: Signer<'info>,
     pub new_admin: SystemAccount<'info>,
 }
 
@@ -76,214 +69,118 @@ pub struct AdminConfig {
 }
 ```
 
-#### Add data validation check
+This instruction is insecure because it doesn't verify that the `current_admin` signer matches the `admin` stored in the `admin_config` account. Any signer could potentially update the admin!
 
-The basic Rust approach to solve this problem is to simply compare the passed in
-`admin` key to the `admin` key stored in the `admin_config` account, throwing an
-error if they don’t match.
+### Implementing Data Validation Checks
 
-```rust
-if ctx.accounts.admin.key() != ctx.accounts.admin_config.admin {
-    return Err(ProgramError::InvalidAccountData.into());
-}
-```
+Let's secure this instruction using two methods: native Rust and Anchor constraints.
 
-By adding a data validation check, the `update_admin` instruction would only
-process if the `admin` signer of the transaction matched the `admin` stored on
-the `admin_config` account.
+#### Native Rust Approach
+
+In native Rust, we can add a simple comparison:
 
 ```rust
-use anchor_lang::prelude::*;
-
-declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
-
-#[program]
-pub mod data_validation {
-    use super::*;
-    ...
-    pub fn update_admin(ctx: Context<UpdateAdmin>) -> Result<()> {
-      if ctx.accounts.admin.key() != ctx.accounts.admin_config.admin {
-            return Err(ProgramError::InvalidAccountData.into());
-        }
-        ctx.accounts.admin_config.admin = ctx.accounts.new_admin.key();
-        Ok(())
+pub fn update_admin(ctx: Context<UpdateAdmin>) -> Result<()> {
+    if ctx.accounts.current_admin.key() != ctx.accounts.admin_config.admin {
+        return Err(ProgramError::InvalidAccountData.into());
     }
-}
-
-#[derive(Accounts)]
-pub struct UpdateAdmin<'info> {
-    #[account(mut)]
-    pub admin_config: Account<'info, AdminConfig>,
-    #[account(mut)]
-    pub admin: Signer<'info>,
-    pub new_admin: SystemAccount<'info>,
-}
-
-#[account]
-pub struct AdminConfig {
-    admin: Pubkey,
+    ctx.accounts.admin_config.admin = ctx.accounts.new_admin.key();
+    Ok(())
 }
 ```
 
-#### Use Anchor constraints
+This check ensures that only the current admin can update the admin_config account.
 
-Anchor simplifies this with the `has_one` constraint. You can use the `has_one`
-constraint to move the data validation check from the instruction logic to the
-`UpdateAdmin` struct.
+#### Anchor Constraints
 
-In the example below, `has_one = admin` specifies that the `admin` account
-signing the transaction must match the `admin` field stored on the
-`admin_config` account. To use the `has_one` constraint, the naming convention
-of the data field on the account must be consistent with the naming on the
-account validation struct.
-
-```rust
-use anchor_lang::prelude::*;
-
-declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
-
-#[program]
-pub mod data_validation {
-    use super::*;
-    ...
-    pub fn update_admin(ctx: Context<UpdateAdmin>) -> Result<()> {
-        ctx.accounts.admin_config.admin = ctx.accounts.new_admin.key();
-        Ok(())
-    }
-}
-
-#[derive(Accounts)]
-pub struct UpdateAdmin<'info> {
-    #[account(
-        mut,
-        has_one = admin
-    )]
-    pub admin_config: Account<'info, AdminConfig>,
-    #[account(mut)]
-    pub admin: Signer<'info>,
-    pub new_admin: SystemAccount<'info>,
-}
-
-#[account]
-pub struct AdminConfig {
-    admin: Pubkey,
-}
-```
-
-Alternatively, you can use `constraint` to manually add an expression that must
-evaluate to true in order for execution to continue. This is useful when for
-some reason naming can’t be consistent or when you need a more complex
-expression to fully validate the incoming data.
+Anchor provides a more declarative way to implement these checks using constraints:
 
 ```rust
 #[derive(Accounts)]
 pub struct UpdateAdmin<'info> {
     #[account(
         mut,
-        constraint = admin_config.admin == admin.key()
+        has_one = current_admin @ MyError::InvalidAdmin
     )]
     pub admin_config: Account<'info, AdminConfig>,
-    #[account(mut)]
-    pub admin: Signer<'info>,
+    pub current_admin: Signer<'info>,
     pub new_admin: SystemAccount<'info>,
 }
 ```
 
-## Lab
+The `has_one = current_admin` constraint checks that the `current_admin` account's key matches the `admin` field in the `AdminConfig` account. If it doesn't match, Anchor will return the custom `InvalidAdmin` error.
 
-For this lab we’ll create a simple “vault” program similar to the program we
-used in the Signer Authorization lesson and the Owner Check lesson. Similar to
-those labs, we’ll show in this lab how a missing data validation check could
-allow the vault to be drained.
-
-#### 1. Starter
-
-To get started, download the starter code from the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-account-data-matching).
-The starter code includes a program with two instructions and the boilerplate
-setup for the test file.
-
-The `initialize_vault` instruction initializes a new `Vault` account and a new
-`TokenAccount`. The `Vault` account will store the address of a token account,
-the authority of the vault, and a withdraw destination token account.
-
-The authority of the new token account will be set as the `vault`, a PDA of the
-program. This allows the `vault` account to sign for the transfer of tokens from
-the token account.
-
-The `insecure_withdraw` instruction transfers all the tokens in the `vault`
-account’s token account to a `withdraw_destination` token account.
-
-Notice that this instruction \***\*does\*\*** have a signer check for
-`authority` and an owner check for `vault`. However, nowhere in the account
-validation or instruction logic is there code that checks that the `authority`
-account passed into the instruction matches the `authority` account on the
-`vault`.
+Alternatively, you can use the `constraint` attribute for more complex checks:
 
 ```rust
-use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Mint, Token, TokenAccount};
-
-declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
-
-#[program]
-pub mod account_data_matching {
-    use super::*;
-
-    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {
-        ctx.accounts.vault.token_account = ctx.accounts.token_account.key();
-        ctx.accounts.vault.authority = ctx.accounts.authority.key();
-        ctx.accounts.vault.withdraw_destination = ctx.accounts.withdraw_destination.key();
-        Ok(())
-    }
-
-    pub fn insecure_withdraw(ctx: Context<InsecureWithdraw>) -> Result<()> {
-        let amount = ctx.accounts.token_account.amount;
-
-        let seeds = &[b"vault".as_ref(), &[*ctx.bumps.get("vault").unwrap()]];
-        let signer = [&seeds[..]];
-
-        let cpi_ctx = CpiContext::new_with_signer(
-            ctx.accounts.token_program.to_account_info(),
-            token::Transfer {
-                from: ctx.accounts.token_account.to_account_info(),
-                authority: ctx.accounts.vault.to_account_info(),
-                to: ctx.accounts.withdraw_destination.to_account_info(),
-            },
-            &signer,
-        );
-
-        token::transfer(cpi_ctx, amount)?;
-        Ok(())
-    }
-}
-
 #[derive(Accounts)]
-pub struct InitializeVault<'info> {
+pub struct UpdateAdmin<'info> {
     #[account(
-        init,
-        payer = authority,
-        space = 8 + 32 + 32 + 32,
-        seeds = [b"vault"],
-        bump,
+        mut,
+        constraint = admin_config.admin == current_admin.key() @ MyError::InvalidAdmin
     )]
-    pub vault: Account<'info, Vault>,
-    #[account(
-        init,
-        payer = authority,
-        token::mint = mint,
-        token::authority = vault,
-        seeds = [b"token"],
-        bump,
-    )]
-    pub token_account: Account<'info, TokenAccount>,
-    pub withdraw_destination: Account<'info, TokenAccount>,
-    pub mint: Account<'info, Mint>,
-    #[account(mut)]
-    pub authority: Signer<'info>,
-    pub token_program: Program<'info, Token>,
-    pub system_program: Program<'info, System>,
-    pub rent: Sysvar<'info, Rent>,
+    pub admin_config: Account<'info, AdminConfig>,
+    pub current_admin: Signer<'info>,
+    pub new_admin: SystemAccount<'info>,
+}
+```
+
+This approach allows for more flexibility in your validation logic.
+
+<Callout type="info">
+  Remember to define your custom errors in your program's error enum:
+
+  ```rust
+  #[error_code]
+  pub enum MyError {
+      #[msg("Only the current admin can perform this action")]
+      InvalidAdmin,
+  }
+  ```
+</Callout>
+
+By implementing these checks, you ensure that only the rightful admin can update the admin_config account, significantly improving your program's security.
+
+## Lab: Securing a Vault Program
+
+In this lab, we'll create a simple "vault" program to demonstrate the importance of account data matching. We'll implement both an insecure and a secure version of a withdraw instruction to highlight the difference.
+
+### 1. Setup
+
+Clone the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-account-data-matching).
+
+The starter code includes a program with two instructions and a boilerplate test file:
+
+1. `initialize_vault`: Creates a new `Vault` account and associated `TokenAccount`.
+2. `insecure_withdraw`: Transfers tokens from the vault's token account to a destination account.
+
+<Callout type="warning">
+  The `insecure_withdraw` instruction has a critical flaw. Can you spot it before we implement the fix?
+</Callout>
+
+### 2. Understand the Insecure Withdraw Instruction
+
+Let's examine the `insecure_withdraw` instruction:
+
+```rust
+pub fn insecure_withdraw(ctx: Context<InsecureWithdraw>) -> Result<()> {
+    let amount = ctx.accounts.token_account.amount;
+
+    let seeds = &[b"vault".as_ref(), &[*ctx.bumps.get("vault").unwrap()]];
+    let signer = [&seeds[..]];
+
+    let cpi_ctx = CpiContext::new_with_signer(
+        ctx.accounts.token_program.to_account_info(),
+        token::Transfer {
+            from: ctx.accounts.token_account.to_account_info(),
+            authority: ctx.accounts.vault.to_account_info(),
+            to: ctx.accounts.withdraw_destination.to_account_info(),
+        },
+        &signer,
+    );
+
+    token::transfer(cpi_ctx, amount)?;
+    Ok(())
 }
 
 #[derive(Accounts)]
@@ -304,103 +201,63 @@ pub struct InsecureWithdraw<'info> {
     pub token_program: Program<'info, Token>,
     pub authority: Signer<'info>,
 }
-
-#[account]
-pub struct Vault {
-    token_account: Pubkey,
-    authority: Pubkey,
-    withdraw_destination: Pubkey,
-}
 ```
 
-#### 2. Test `insecure_withdraw` instruction
+The critical flaw here is that while the instruction requires an `authority` signer, it doesn't verify whether the `authority` account passed to the instruction matches the `authority` stored in the `Vault` account. This means that any signer could potentially withdraw funds from the vault, even if they're not the authorized user.
 
-To prove that this is a problem, let’s write a test where an account other than
-the vault’s `authority` tries to withdraw from the vault.
+### 3. Test the Insecure Withdraw Instruction
 
-The test file includes the code to invoke the `initialize_vault` instruction
-using the provider wallet as the `authority` and then mints 100 tokens to the
-`vault` token account.
-
-Add a test to invoke the `insecure_withdraw` instruction. Use
-`withdrawDestinationFake` as the `withdrawDestination` account and `walletFake`
-as the `authority`. Then send the transaction using `walletFake`.
-
-Since there are no checks the verify the `authority` account passed into the
-instruction matches the values stored on the `vault` account initialized in the
-first test, the instruction will process successfully and the tokens will be
-transferred to the `withdrawDestinationFake` account.
+Let's write a test to demonstrate this vulnerability. Add the following test to your `tests/account-data-matching.ts` file:
 
 ```typescript
-describe("account-data-matching", () => {
-  ...
-  it("Insecure withdraw", async () => {
-    const tx = await program.methods
-      .insecureWithdraw()
-      .accounts({
-        vault: vaultPDA,
-        tokenAccount: tokenPDA,
-        withdrawDestination: withdrawDestinationFake,
-        authority: walletFake.publicKey,
-      })
-      .transaction()
+it("Insecure withdraw allows unauthorized access", async () => {
+  // Setup: Initialize vault and mint some tokens to it
+  // ... (initialization code here)
 
-    await anchor.web3.sendAndConfirmTransaction(connection, tx, [walletFake])
+  // Attempt unauthorized withdrawal
+  const tx = await program.methods
+    .insecureWithdraw()
+    .accounts({
+      vault: vaultPDA,
+      tokenAccount: tokenPDA,
+      withdrawDestination: withdrawDestinationFake,
+      authority: walletFake.publicKey,
+    })
+    .transaction()
 
-    const balance = await connection.getTokenAccountBalance(tokenPDA)
-    expect(balance.value.uiAmount).to.eq(0)
-  })
+  await anchor.web3.sendAndConfirmTransaction(connection, tx, [walletFake])
+
+  // Check that the withdrawal succeeded (it shouldn't have!)
+  const balance = await connection.getTokenAccountBalance(tokenPDA)
+  expect(balance.value.uiAmount).to.eq(0)
 })
 ```
 
-Run `anchor test` to see that both transactions will complete successfully.
+Run `anchor test` to see that this unauthorized withdrawal succeeds, demonstrating the security flaw.
 
-```bash
-account-data-matching
-  ✔ Initialize Vault (811ms)
-  ✔ Insecure withdraw (403ms)
-```
+### 4. Implement a Secure Withdraw Instruction
 
-#### 3. Add `secure_withdraw` instruction
-
-Let’s go implement a secure version of this instruction called
-`secure_withdraw`.
-
-This instruction will be identical to the `insecure_withdraw` instruction,
-except we’ll use the `has_one` constraint in the account validation struct
-(`SecureWithdraw`) to check that the `authority` account passed into the
-instruction matches the `authority` account on the `vault` account. That way
-only the correct authority account can withdraw the vault’s tokens.
+Now, let's implement a secure version of the withdraw instruction:
 
 ```rust
-use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Mint, Token, TokenAccount};
+pub fn secure_withdraw(ctx: Context<SecureWithdraw>) -> Result<()> {
+    let amount = ctx.accounts.token_account.amount;
 
-declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+    let seeds = &[b"vault".as_ref(), &[*ctx.bumps.get("vault").unwrap()]];
+    let signer = [&seeds[..]];
 
-#[program]
-pub mod account_data_matching {
-    use super::*;
-    ...
-    pub fn secure_withdraw(ctx: Context<SecureWithdraw>) -> Result<()> {
-        let amount = ctx.accounts.token_account.amount;
+    let cpi_ctx = CpiContext::new_with_signer(
+        ctx.accounts.token_program.to_account_info(),
+        token::Transfer {
+            from: ctx.accounts.token_account.to_account_info(),
+            authority: ctx.accounts.vault.to_account_info(),
+            to: ctx.accounts.withdraw_destination.to_account_info(),
+        },
+        &signer,
+    );
 
-        let seeds = &[b"vault".as_ref(), &[*ctx.bumps.get("vault").unwrap()]];
-        let signer = [&seeds[..]];
-
-        let cpi_ctx = CpiContext::new_with_signer(
-            ctx.accounts.token_program.to_account_info(),
-            token::Transfer {
-                from: ctx.accounts.token_account.to_account_info(),
-                authority: ctx.accounts.vault.to_account_info(),
-                to: ctx.accounts.withdraw_destination.to_account_info(),
-            },
-            &signer,
-        );
-
-        token::transfer(cpi_ctx, amount)?;
-        Ok(())
-    }
+    token::transfer(cpi_ctx, amount)?;
+    Ok(())
 }
 
 #[derive(Accounts)]
@@ -408,10 +265,9 @@ pub struct SecureWithdraw<'info> {
     #[account(
         seeds = [b"vault"],
         bump,
-        has_one = token_account,
         has_one = authority,
+        has_one = token_account,
         has_one = withdraw_destination,
-
     )]
     pub vault: Account<'info, Vault>,
     #[account(
@@ -427,107 +283,71 @@ pub struct SecureWithdraw<'info> {
 }
 ```
 
-#### 4. Test `secure_withdraw` instruction
+The key difference here is the use of `has_one` constraints in the `SecureWithdraw` struct. These ensure that the `authority`, `token_account`, and `withdraw_destination` passed to the instruction match those stored in the `Vault` account.
 
-Now let’s test the `secure_withdraw` instruction with two tests: one that uses
-`walletFake` as the authority and one that uses `wallet` as the authority. We
-expect the first invocation to return an error and the second to succeed.
+### 5. Test the Secure Withdraw Instruction
+
+Now, let's test our secure instruction:
 
 ```typescript
-describe("account-data-matching", () => {
-  ...
-  it("Secure withdraw, expect error", async () => {
-    try {
-      const tx = await program.methods
-        .secureWithdraw()
-        .accounts({
-          vault: vaultPDA,
-          tokenAccount: tokenPDA,
-          withdrawDestination: withdrawDestinationFake,
-          authority: walletFake.publicKey,
-        })
-        .transaction()
+it("Secure withdraw prevents unauthorized access", async () => {
+  // Setup: Initialize vault and mint some tokens to it
+  // ... (initialization code here)
 
-      await anchor.web3.sendAndConfirmTransaction(connection, tx, [walletFake])
-    } catch (err) {
-      expect(err)
-      console.log(err)
-    }
-  })
-
-  it("Secure withdraw", async () => {
-    await spl.mintTo(
-      connection,
-      wallet.payer,
-      mint,
-      tokenPDA,
-      wallet.payer,
-      100
-    )
-
+  // Attempt unauthorized withdrawal
+  try {
     await program.methods
       .secureWithdraw()
       .accounts({
         vault: vaultPDA,
         tokenAccount: tokenPDA,
-        withdrawDestination: withdrawDestination,
-        authority: wallet.publicKey,
+        withdrawDestination: withdrawDestinationFake,
+        authority: walletFake.publicKey,
       })
       .rpc()
+    
+    // If we reach here, the test failed
+    assert.fail("Expected an error, but withdrawal succeeded")
+  } catch (error) {
+    // Check that it's the error we expect
+    expect(error.error.errorCode.code).to.equal("ConstraintHasOne")
+  }
 
-    const balance = await connection.getTokenAccountBalance(tokenPDA)
-    expect(balance.value.uiAmount).to.eq(0)
-  })
+  // Check that the balance hasn't changed
+  const balance = await connection.getTokenAccountBalance(tokenPDA)
+  expect(balance.value.uiAmount).to.eq(100) // Assuming 100 tokens were initially minted
+})
+
+it("Secure withdraw allows authorized access", async () => {
+  // Perform authorized withdrawal
+  await program.methods
+    .secureWithdraw()
+    .accounts({
+      vault: vaultPDA,
+      tokenAccount: tokenPDA,
+      withdrawDestination: withdrawDestination,
+      authority: wallet.publicKey,
+    })
+    .rpc()
+
+  // Check that the withdrawal succeeded
+  const balance = await connection.getTokenAccountBalance(tokenPDA)
+  expect(balance.value.uiAmount).to.eq(0)
 })
 ```
 
-Run `anchor test` to see that the transaction using an incorrect authority
-account will now return an Anchor Error while the transaction using correct
-accounts completes successfully.
+Run `anchor test` again. You should see that the unauthorized withdrawal now fails, while the authorized one succeeds.
 
-```bash
-'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS invoke [1]',
-'Program log: Instruction: SecureWithdraw',
-'Program log: AnchorError caused by account: vault. Error Code: ConstraintHasOne. Error Number: 2001. Error Message: A has one constraint was violated.',
-'Program log: Left:',
-'Program log: DfLZV18rD7wCQwjYvhTFwuvLh49WSbXFeJFPQb5czifH',
-'Program log: Right:',
-'Program log: 5ovvmG5ntwUC7uhNWfirjBHbZD96fwuXDMGXiyMwPg87',
-'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS consumed 10401 of 200000 compute units',
-'Program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS failed: custom program error: 0x7d1'
-```
+### Conclusion
 
-Note that Anchor specifies in the logs the account that causes the error
-(`AnchorError caused by account: vault`).
+By implementing proper account data matching, we've significantly improved the security of our vault program. The secure version ensures that only the authorized user can withdraw funds, preventing potential exploits.
 
-```bash
-✔ Secure withdraw, expect error (77ms)
-✔ Secure withdraw (10073ms)
-```
+Remember, as your programs grow in complexity, it becomes increasingly important to implement thorough data validation checks. Always consider what assumptions your program is making about its inputs and validate them explicitly.
 
-And just like that, you've closed up the security loophole. The theme across
-most of these potential exploits is that they're quite simple. However, as your
-programs grow in scope and complexity, it becomse increasingly easy to miss
-possible exploits. It's great to get in a habit of writing tests that send
-instructions that _shouldn't_ work. The more the better. That way you catch
-problems before you deploy.
+<Callout type="success" title="Challenge">
+  Now that you've seen how to implement account data matching, take some time to review one of your existing programs. Look for places where you might be making assumptions about account data without explicitly checking it. Implement appropriate checks using the techniques you've learned in this lesson.
 
-If you want to take a look at the final solution code you can find it on the
-`solution` branch of
-[the repository](https://github.com/Unboxed-Software/solana-account-data-matching/tree/solution).
-
-## Challenge
-
-Just as with other lessons in this unit, your opportunity to practice avoiding
-this security exploit lies in auditing your own or other programs.
-
-Take some time to review at least one program and ensure that proper data checks
-are in place to avoid security exploits.
-
-Remember, if you find a bug or exploit in somebody else's program, please alert
-them! If you find one in your own program, be sure to patch it right away.
-
-<Callout type="success" title="Completed the lab?">
-Push your code to GitHub and
-[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=a107787e-ad33-42bb-96b3-0592efc1b92f)!
+  Remember, if you find a security vulnerability in someone else's program, responsibly disclose it to the program's maintainers. If you find one in your own program, patch it as soon as possible!
 </Callout>
+
+After completing this lab and challenge, you'll have gained practical experience in identifying and fixing security vulnerabilities related to account data matching. This skill is crucial for developing secure Solana programs.

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -30,9 +30,11 @@ description:
 
 ## Lesson
 
-Account data matching involves implementing data validation checks to ensure that the  
-data stored on an account matches expected values. This is essential for preventing 
-unauthorized access and maintaining the integrity of your program's state.  
+Account data matching involves implementing data validation checks to ensure
+that the  
+data stored on an account matches expected values. This is essential for
+preventing unauthorized access and maintaining the integrity of your program's
+state.
 
 ### Why Account Data Matching Matters
 
@@ -40,11 +42,11 @@ Without proper data validation, your program becomes vulnerable to various
 attacks:
 
 1. Unauthorized access: malicious users could pass in unexpected accounts,  
-   gaining access to functionality they shouldn't have  
+   gaining access to functionality they shouldn't have
 2. State manipulation: attackers might alter the program's state in unintended  
-   ways, compromising its integrity  
+   ways, compromising its integrity
 3. Fund theft: in programs dealing with tokens or SOL, inadequate checks could  
-   lead to unauthorized withdrawals 
+   lead to unauthorized withdrawals
 
 Let's look at an example to illustrate the importance of account data matching.
 
@@ -180,8 +182,7 @@ Clone the starter code from the `starter` branch of
 The starter code includes a program with two instructions and a boilerplate test
 file:
 
-1. `initialize_vault`: Creates a new `Vault` account and a
-   `tokenAccount`.
+1. `initialize_vault`: Creates a new `Vault` account and a `tokenAccount`.
 2. `insecure_withdraw`: Transfers tokens from the vault's token account to a
    destination account.
 
@@ -262,7 +263,9 @@ test("Insecure withdraw allows unauthorized access", async () => {
     })
     .transaction();
 
-  await anchor.web3.sendAndConfirmTransaction(connection, tx, [unauthorizedWallet]);
+  await anchor.web3.sendAndConfirmTransaction(connection, tx, [
+    unauthorizedWallet,
+  ]);
 
   // Check that the withdrawal succeeded (it shouldn't have!)
   const balance = await connection.getTokenAccountBalance(tokenPDA);
@@ -321,8 +324,11 @@ pub struct SecureWithdraw<'info> {
 }
 ```
 
-The key difference here is the use of a [`has_one` constraint](https://www.anchor-lang.com/docs/account-constraints) in the `SecureWithdraw` struct. These ensure that the `authority`, `token_account`, and `withdraw_destination` passed to the instruction match those stored in the `Vault` account.
-
+The key difference here is the use of a
+[`has_one` constraint](https://www.anchor-lang.com/docs/account-constraints) in
+the `SecureWithdraw` struct. These ensure that the `authority`, `token_account`,
+and `withdraw_destination` passed to the instruction match those stored in the
+`Vault` account.
 
 ### 5. Test the Secure Withdraw Instruction
 
@@ -396,7 +402,8 @@ appropriate checks using the techniques you've learned in this lesson.
 
 Remember, if you find a security vulnerability in someone else's program,  
 [responsibly disclose](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure)  
-it to the program's maintainers. If you find one in your own program, patch it as soon as possible!
+it to the program's maintainers. If you find one in your own program, patch it
+as soon as possible!
 
 After completing this lab and challenge, you'll have gained practical experience
 in identifying and fixing security vulnerabilities related to account data

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -4,15 +4,20 @@ objectives:
   - Explain the security risks associated with missing data validation checks
   - Implement data validation checks using native Rust
   - Implement data validation checks using Anchor constraints
-description: Learn how to properly validate account data in Solana programs to prevent security vulnerabilities.
+description:
+  Learn how to properly validate account data in Solana programs to prevent
+  security vulnerabilities.
 ---
 
 # Account Data Matching
 
 ## Summary
 
-- **Data validation checks** are crucial for verifying that account data matches expected values. Without proper checks, malicious users could exploit your program using unexpected accounts.
-- Implement data validation in native Rust by comparing account data to expected values:
+- **Data validation checks** are crucial for verifying that account data matches
+  expected values. Without proper checks, malicious users could exploit your
+  program using unexpected accounts.
+- Implement data validation in native Rust by comparing account data to expected
+  values:
   ```rust
   if ctx.accounts.user.key() != ctx.accounts.user_data.user {
       return Err(ProgramError::InvalidAccountData.into());
@@ -20,25 +25,35 @@ description: Learn how to properly validate account data in Solana programs to p
   ```
 - Use Anchor constraints to simplify the process:
   - Use `constraint` to evaluate custom expressions
-  - Use `has_one` to check that a field on one account matches the key of another account
+  - Use `has_one` to check that a field on one account matches the key of
+    another account
 
 ## Lesson
 
-Account data matching is a critical security practice in Solana program development. It involves implementing data validation checks to ensure that the data stored on an account matches expected values. These checks are essential for preventing unauthorized access and maintaining the integrity of your program's state.
+Account data matching is a critical security practice in Solana program
+development. It involves implementing data validation checks to ensure that the
+data stored on an account matches expected values. These checks are essential
+for preventing unauthorized access and maintaining the integrity of your
+program's state.
 
 ### Why Account Data Matching Matters
 
-Without proper data validation, your program becomes vulnerable to various attacks:
+Without proper data validation, your program becomes vulnerable to various
+attacks:
 
-1. Unauthorized access: Malicious users could pass in unexpected accounts, gaining access to functionality they shouldn't have
-2. State manipulation: Attackers might alter the program's state in unintended ways, compromising its integrity
-3. Fund theft: In programs dealing with tokens or SOL, inadequate checks could lead to unauthorized withdrawals
+1. Unauthorized access: Malicious users could pass in unexpected accounts,
+   gaining access to functionality they shouldn't have
+2. State manipulation: Attackers might alter the program's state in unintended
+   ways, compromising its integrity
+3. Fund theft: In programs dealing with tokens or SOL, inadequate checks could
+   lead to unauthorized withdrawals
 
 Let's look at an example to illustrate the importance of account data matching.
 
 ### Example: Insecure Admin Update
 
-Consider a program with an `update_admin` instruction that changes the admin of a configuration account:
+Consider a program with an `update_admin` instruction that changes the admin of
+a configuration account:
 
 ```rust
 use anchor_lang::prelude::*;
@@ -70,11 +85,14 @@ pub struct AdminConfig {
 }
 ```
 
-This instruction is insecure because it doesn't verify that the `current_admin` signer matches the `admin` stored in the `admin_config` account. Any signer could potentially update the admin!
+This instruction is insecure because it doesn't verify that the `current_admin`
+signer matches the `admin` stored in the `admin_config` account. Any signer
+could potentially update the admin!
 
 ### Implementing Data Validation Checks
 
-Let's secure this instruction using two methods: native Rust and Anchor constraints.
+Let's secure this instruction using two methods: native Rust and Anchor
+constraints.
 
 #### Native Rust Approach
 
@@ -90,11 +108,13 @@ pub fn update_admin(ctx: Context<UpdateAdmin>) -> Result<()> {
 }
 ```
 
-This check ensures that only the current admin can update the admin_config account.
+This check ensures that only the current admin can update the admin_config
+account.
 
 #### Anchor Constraints
 
-Anchor provides a more declarative way to implement these checks using constraints:
+Anchor provides a more declarative way to implement these checks using
+constraints:
 
 ```rust
 #[derive(Accounts)]
@@ -110,7 +130,9 @@ pub struct UpdateAdmin<'info> {
 }
 ```
 
-The `has_one = current_admin` constraint checks that the `current_admin` account's key matches the `admin` field in the `AdminConfig` account. If it doesn't match, Anchor will return the custom `InvalidAdmin` error.
+The `has_one = current_admin` constraint checks that the `current_admin`
+account's key matches the `admin` field in the `AdminConfig` account. If it
+doesn't match, Anchor will return the custom `InvalidAdmin` error.
 
 Alternatively, you can use the `constraint` attribute for more complex checks:
 
@@ -143,20 +165,27 @@ pub enum MyError {
 
 </Callout>
 
-By implementing these checks, you ensure that only the rightful admin can update the admin_config account, significantly improving your program's security.
+By implementing these checks, you ensure that only the rightful admin can update
+the admin_config account, significantly improving your program's security.
 
 ## Lab: Securing a Vault Program
 
-In this lab, we'll create a simple "vault" program to demonstrate the importance of account data matching. We'll implement both an insecure and a secure version of a withdraw instruction to highlight the difference.
+In this lab, we'll create a simple "vault" program to demonstrate the importance
+of account data matching. We'll implement both an insecure and a secure version
+of a withdraw instruction to highlight the difference.
 
 ### 1. Setup
 
-Clone the starter code from the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-account-data-matching).
+Clone the starter code from the `starter` branch of
+[this repository](https://github.com/Unboxed-Software/solana-account-data-matching).
 
-The starter code includes a program with two instructions and a boilerplate test file:
+The starter code includes a program with two instructions and a boilerplate test
+file:
 
-1. `initialize_vault`: Creates a new `Vault` account and associated `TokenAccount`.
-2. `insecure_withdraw`: Transfers tokens from the vault's token account to a destination account.
+1. `initialize_vault`: Creates a new `Vault` account and associated
+   `TokenAccount`.
+2. `insecure_withdraw`: Transfers tokens from the vault's token account to a
+   destination account.
 
 <Callout type="warning">
   The `insecure_withdraw` instruction has a critical flaw. Can you spot it before we implement the fix?
@@ -207,11 +236,16 @@ pub struct InsecureWithdraw<'info> {
 }
 ```
 
-The critical flaw here is that while the instruction requires an `authority` signer, it doesn't verify whether the `authority` account passed to the instruction matches the `authority` stored in the `Vault` account. This means that any signer could potentially withdraw funds from the vault, even if they're not the authorized user.
+The critical flaw here is that while the instruction requires an `authority`
+signer, it doesn't verify whether the `authority` account passed to the
+instruction matches the `authority` stored in the `Vault` account. This means
+that any signer could potentially withdraw funds from the vault, even if they're
+not the authorized user.
 
 ### 3. Test the Insecure Withdraw Instruction
 
-Let's write a test to demonstrate this vulnerability. Add the following test to your `tests/account-data-matching.ts` file:
+Let's write a test to demonstrate this vulnerability. Add the following test to
+your `tests/account-data-matching.ts` file:
 
 ```typescript
 it("Insecure withdraw allows unauthorized access", async () => {
@@ -238,7 +272,8 @@ it("Insecure withdraw allows unauthorized access", async () => {
 });
 ```
 
-Run `anchor test` to see that this unauthorized withdrawal succeeds, demonstrating the security flaw.
+Run `anchor test` to see that this unauthorized withdrawal succeeds,
+demonstrating the security flaw.
 
 ### 4. Implement a Secure Withdraw Instruction
 
@@ -288,7 +323,10 @@ pub struct SecureWithdraw<'info> {
 }
 ```
 
-The key difference here is the use of `has_one` constraints in the `SecureWithdraw` struct. These ensure that the `authority`, `token_account`, and `withdraw_destination` passed to the instruction match those stored in the `Vault` account.
+The key difference here is the use of `has_one` constraints in the
+`SecureWithdraw` struct. These ensure that the `authority`, `token_account`, and
+`withdraw_destination` passed to the instruction match those stored in the
+`Vault` account.
 
 ### 5. Test the Secure Withdraw Instruction
 
@@ -342,18 +380,31 @@ it("Secure withdraw allows authorized access", async () => {
 });
 ```
 
-Run `anchor test` again. You should see that the unauthorized withdrawal now fails, while the authorized one succeeds.
+Run `anchor test` again. You should see that the unauthorized withdrawal now
+fails, while the authorized one succeeds.
 
 ### Conclusion
 
-By implementing proper account data matching, we've significantly improved the security of our vault program. The secure version ensures that only the authorized user can withdraw funds, preventing potential exploits.
+By implementing proper account data matching, we've significantly improved the
+security of our vault program. The secure version ensures that only the
+authorized user can withdraw funds, preventing potential exploits.
 
-Remember, as your programs grow in complexity, it becomes increasingly important to implement thorough data validation checks. Always consider what assumptions your program is making about its inputs. Validate these assumptions explicitly.
+Remember, as your programs grow in complexity, it becomes increasingly important
+to implement thorough data validation checks. Always consider what assumptions
+your program is making about its inputs. Validate these assumptions explicitly.
 
-Now that you've seen how to implement account data matching, take some time to review one of your existing programs. Look for places where you might be making assumptions about account data without explicitly checking it. Implement appropriate checks using the techniques you've learned in this lesson.
+Now that you've seen how to implement account data matching, take some time to
+review one of your existing programs. Look for places where you might be making
+assumptions about account data without explicitly checking it. Implement
+appropriate checks using the techniques you've learned in this lesson.
 
-Remember, if you find a security vulnerability in someone else's program, responsibly disclose it to the program's maintainers. If you find one in your own program, patch it as soon as possible!
+Remember, if you find a security vulnerability in someone else's program,
+responsibly disclose it to the program's maintainers. If you find one in your
+own program, patch it as soon as possible!
 
-After completing this lab and challenge, you'll have gained practical experience in identifying and fixing security vulnerabilities related to account data matching. This skill is crucial for developing secure Solana programs.
+After completing this lab and challenge, you'll have gained practical experience
+in identifying and fixing security vulnerabilities related to account data
+matching. This skill is crucial for developing secure Solana programs.
 
-Push your code to GitHub and [tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=a107787e-ad33-42bb-96b3-0592efc1b92f)!
+Push your code to GitHub and
+[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=a107787e-ad33-42bb-96b3-0592efc1b92f)!

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -23,7 +23,7 @@ description:
       return Err(ProgramError::InvalidAccountData.into());
   }
   ```
-- Use Anchor constraints to simplify the process:
+- Use [Anchor constraints](https://www.anchor-lang.com/docs/account-constraints) to simplify the process:
   - Use `constraint` to evaluate custom expressions
   - Use `has_one` to check that a field on one account matches the key of
     another account

--- a/content/courses/program-security/account-data-matching.md
+++ b/content/courses/program-security/account-data-matching.md
@@ -30,23 +30,21 @@ description:
 
 ## Lesson
 
-Account data matching is a critical security practice in Solana program
-development. It involves implementing data validation checks to ensure that the
-data stored on an account matches expected values. These checks are essential
-for preventing unauthorized access and maintaining the integrity of your
-program's state.
+Account data matching involves implementing data validation checks to ensure that the  
+data stored on an account matches expected values. This is essential for preventing 
+unauthorized access and maintaining the integrity of your program's state.  
 
 ### Why Account Data Matching Matters
 
 Without proper data validation, your program becomes vulnerable to various
 attacks:
 
-1. Unauthorized access: Malicious users could pass in unexpected accounts,
-   gaining access to functionality they shouldn't have
-2. State manipulation: Attackers might alter the program's state in unintended
-   ways, compromising its integrity
-3. Fund theft: In programs dealing with tokens or SOL, inadequate checks could
-   lead to unauthorized withdrawals
+1. Unauthorized access: malicious users could pass in unexpected accounts,  
+   gaining access to functionality they shouldn't have  
+2. State manipulation: attackers might alter the program's state in unintended  
+   ways, compromising its integrity  
+3. Fund theft: in programs dealing with tokens or SOL, inadequate checks could  
+   lead to unauthorized withdrawals 
 
 Let's look at an example to illustrate the importance of account data matching.
 
@@ -114,7 +112,7 @@ account.
 #### Anchor Constraints
 
 Anchor provides a more declarative way to implement these checks using
-constraints:
+[account constraints](https://www.anchor-lang.com/docs/account-constraints):
 
 ```rust
 #[derive(Accounts)]
@@ -166,7 +164,7 @@ pub enum MyError {
 </Callout>
 
 By implementing these checks, you ensure that only the rightful admin can update
-the admin_config account, significantly improving your program's security.
+the 'admin_config' account, significantly improving your program's security.
 
 ## Lab: Securing a Vault Program
 
@@ -182,8 +180,8 @@ Clone the starter code from the `starter` branch of
 The starter code includes a program with two instructions and a boilerplate test
 file:
 
-1. `initialize_vault`: Creates a new `Vault` account and associated
-   `TokenAccount`.
+1. `initialize_vault`: Creates a new `Vault` account and a
+   `tokenAccount`.
 2. `insecure_withdraw`: Transfers tokens from the vault's token account to a
    destination account.
 
@@ -248,23 +246,23 @@ Let's write a test to demonstrate this vulnerability. Add the following test to
 your `tests/account-data-matching.ts` file:
 
 ```typescript
-it("Insecure withdraw allows unauthorized access", async () => {
+test("Insecure withdraw allows unauthorized access", async () => {
   // Setup: Initialize vault and mint some tokens to it
   // ... (initialization code here)
 
   // Attempt unauthorized withdrawal
-  // Note: walletFake represents an unauthorized wallet trying to withdraw funds
+  // Note: unauthorizedWallet represents an unauthorized wallet trying to withdraw funds
   const tx = await program.methods
     .insecureWithdraw()
     .accounts({
       vault: vaultPDA,
       tokenAccount: tokenPDA,
-      withdrawDestination: withdrawDestinationFake,
-      authority: walletFake.publicKey,
+      withdrawDestination: unauthorizedWalletWithdrawDestination,
+      authority: unauthorizedWallet.publicKey,
     })
     .transaction();
 
-  await anchor.web3.sendAndConfirmTransaction(connection, tx, [walletFake]);
+  await anchor.web3.sendAndConfirmTransaction(connection, tx, [unauthorizedWallet]);
 
   // Check that the withdrawal succeeded (it shouldn't have!)
   const balance = await connection.getTokenAccountBalance(tokenPDA);
@@ -323,30 +321,28 @@ pub struct SecureWithdraw<'info> {
 }
 ```
 
-The key difference here is the use of `has_one` constraints in the
-`SecureWithdraw` struct. These ensure that the `authority`, `token_account`, and
-`withdraw_destination` passed to the instruction match those stored in the
-`Vault` account.
+The key difference here is the use of a [`has_one` constraint](https://www.anchor-lang.com/docs/account-constraints) in the `SecureWithdraw` struct. These ensure that the `authority`, `token_account`, and `withdraw_destination` passed to the instruction match those stored in the `Vault` account.
+
 
 ### 5. Test the Secure Withdraw Instruction
 
 Now, let's test our secure instruction:
 
 ```typescript
-it("Secure withdraw prevents unauthorized access", async () => {
+test("Secure withdraw prevents unauthorized access", async () => {
   // Setup: Initialize vault and mint some tokens to it
   // ... (initialization code here)
 
   // Attempt unauthorized withdrawal
-  // Note: walletFake represents an unauthorized wallet trying to withdraw funds
+  // Note: unauthorizedWallet represents an unauthorized wallet trying to withdraw funds
   try {
     await program.methods
       .secureWithdraw()
       .accounts({
         vault: vaultPDA,
         tokenAccount: tokenPDA,
-        withdrawDestination: withdrawDestinationFake,
-        authority: walletFake.publicKey,
+        withdrawDestination: unauthorizedWalletWithdrawDestination,
+        authority: unauthorizedWallet.publicKey,
       })
       .rpc();
 
@@ -362,7 +358,7 @@ it("Secure withdraw prevents unauthorized access", async () => {
   expect(balance.value.uiAmount).to.eq(100); // Assuming 100 tokens were initially minted
 });
 
-it("Secure withdraw allows authorized access", async () => {
+test("Secure withdraw allows authorized access", async () => {
   // Perform authorized withdrawal
   await program.methods
     .secureWithdraw()
@@ -398,9 +394,9 @@ review one of your existing programs. Look for places where you might be making
 assumptions about account data without explicitly checking it. Implement
 appropriate checks using the techniques you've learned in this lesson.
 
-Remember, if you find a security vulnerability in someone else's program,
-responsibly disclose it to the program's maintainers. If you find one in your
-own program, patch it as soon as possible!
+Remember, if you find a security vulnerability in someone else's program,  
+[responsibly disclose](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure)  
+it to the program's maintainers. If you find one in your own program, patch it as soon as possible!
 
 After completing this lab and challenge, you'll have gained practical experience
 in identifying and fixing security vulnerabilities related to account data

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -17,9 +17,11 @@ description: "How to safely invoke Solana programs from other Solana programs."
   program should check for incorrect or unexpected programs.
 - Perform program checks in native programs by comparing the public key of the
   passed-in program to the program you expected.
-- If a program is written in Anchor, it may have a publicly available CPI
-  module for making cross-program invocations. This makes invoking the program from another Anchor program simple and secure. The Anchor CPI module automatically checks that the address of the
-  program passed in matches the address of the program stored in the module.
+- If a program is written in Anchor, it may have a publicly available CPI module
+  for making cross-program invocations. This makes invoking the program from
+  another Anchor program simple and secure. The Anchor CPI module automatically
+  checks that the address of the program passed in matches the address of the
+  program stored in the module.
 
 ## Lesson
 
@@ -127,10 +129,11 @@ crate provides the address of the SPL Token Program.
 ### Use an Anchor CPI Module
 
 A simpler way to manage program checks is to use Anchor CPI modules. We learned
-in a [previous lesson](https://github.com/solana-foundation/developer-content/blob/main/content/courses/onchain-development/anchor-cpi.md) that Anchor can automatically
-generate CPI modules to make CPIs into the program simpler. These modules also
-enhance security by verifying the public key of the program that's passed into
-one of its public instructions using
+in a
+[previous lesson](https://github.com/solana-foundation/developer-content/blob/main/content/courses/onchain-development/anchor-cpi.md)
+that Anchor can automatically generate CPI modules to make CPIs into the program
+simpler. These modules also enhance security by verifying the public key of the
+program that's passed into one of its public instructions using
 [account constraints](https://www.anchor-lang.com/docs/account-constraints).
 
 Every Anchor program uses the `declare_id()` macro to define the address of the

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -3,8 +3,8 @@ title: Arbitrary CPI
 objectives:
   - Explain the security risks associated with invoking a CPI to an unknown
     program
-  - Showcase how Anchor’s CPI module prevents this from happening when making a
-    CPI from one Anchor program to another
+  - Showcase how Anchor's CPI module prevents this from happening when making
+    a CPI from one Anchor program to another
   - Safely and securely make a CPI from an Anchor program to an arbitrary
     non-anchor program
 description: "How to safely invoke Solana programs from other Solana programs."
@@ -13,34 +13,35 @@ description: "How to safely invoke Solana programs from other Solana programs."
 ## Summary
 
 - To generate a CPI, the target program must be passed into the invoking
-  instruction as an account. This means that any target program could be passed
+  instruction as an account. This means any target program could be passed
   into the instruction. Your program should check for incorrect or unexpected
   programs.
-- Perform program checks in native programs by simply comparing the public key
-  of the passed-in program to the progam you expected.
-- If a program is written in Anchor, then it may have a publicly available CPI
-  module. This makes invoking the program from another Anchor program simple and
-  secure. The Anchor CPI module automatically checks that the address of the
-  program passed in matches the address of the program stored in the module.
+- Perform program checks in native programs by comparing the public key of the
+  passed-in program to the program you expected.
+- If a program is written in Anchor, it may have a publicly available CPI
+  module. This makes invoking the program from another Anchor program simple
+  and secure. The Anchor CPI module automatically checks that the address of
+  the program passed in matches the address of the program stored in the
+  module.
 
 ## Lesson
 
-A cross program invocation (CPI) is when one program invokes an instruction on
-another program. An “arbitrary CPI” is when a program is structured to issue a
-CPI to whatever program is passed into the instruction rather than expecting to
-perform a CPI to one specific program. Given that the callers of your program's
-instruction can pass any program they'd like into the instruction's list of
-accounts, failing to verify the address of a passed-in program results in your
-program performing CPIs to arbitrary programs.
+A cross-program invocation (CPI) is when one program invokes an instruction on
+another program. An "arbitrary CPI" is when a program is structured to issue a
+CPI to whatever program is passed into the instruction rather than expecting
+to perform a CPI to one specific program. Given that the callers of your
+program's instruction can pass any program they'd like into the instruction's
+list of accounts, failing to verify the address of a passed-in program results
+in your program performing CPIs to arbitrary programs.
 
-This lack of program checks creates an opportunity for a malicious user to pass
-in a different program than expected, causing the original program to call an
-instruction on this mystery program. There’s no telling what the consequences of
-this CPI could be. It depends on the program logic (both that of the original
-program and the unexpected program), as well as what other accounts are passed
-into the original instruction.
+This lack of program checks creates an opportunity for a malicious user to
+pass in a different program than expected, causing the original program to
+call an instruction on this mystery program. There's no telling what the
+consequences of this CPI could be. It depends on the program logic (both that
+of the original program and the unexpected program), as well as what other
+accounts are passed into the original instruction.
 
-### Missing program checks
+### Missing Program Checks
 
 Take the following program as an example. The `cpi` instruction invokes the
 `transfer` instruction on `token_program`, but there is no code that checks
@@ -57,20 +58,20 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 pub mod arbitrary_cpi_insecure {
     use super::*;
 
-    pub fn cpi(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
+    pub fn cpi(ctx: Context<Cpi>, amount: u64) -> Result<()> {
         solana_program::program::invoke(
             &spl_token::instruction::transfer(
-                ctx.accounts.token_program.key,
-                ctx.accounts.source.key,
-                ctx.accounts.destination.key,
-                ctx.accounts.authority.key,
+                ctx.accounts.token_program.key(),
+                ctx.accounts.source.key(),
+                ctx.accounts.destination.key(),
+                ctx.accounts.authority.key(),
                 &[],
                 amount,
             )?,
             &[
-                ctx.accounts.source.clone(),
-                ctx.accounts.destination.clone(),
-                ctx.accounts.authority.clone(),
+                ctx.accounts.source.to_account_info(),
+                ctx.accounts.destination.to_account_info(),
+                ctx.accounts.authority.to_account_info(),
             ],
         )
     }
@@ -80,7 +81,7 @@ pub mod arbitrary_cpi_insecure {
 pub struct Cpi<'info> {
     source: UncheckedAccount<'info>,
     destination: UncheckedAccount<'info>,
-    authority: UncheckedAccount<'info>,
+    authority: Signer<'info>,
     token_program: UncheckedAccount<'info>,
 }
 ```
@@ -88,60 +89,61 @@ pub struct Cpi<'info> {
 An attacker could easily call this instruction and pass in a duplicate token
 program that they created and control.
 
-### Add program checks
+### Add Program Checks
 
-It's possible to fix this vulnerabilty by simply adding a few lines to the `cpi`
-instruction to check whether or not `token_program`'s public key is that of the
-SPL Token Program.
+It's possible to fix this vulnerability by simply adding a few lines to the
+`cpi` instruction to check whether or not `token_program`'s public key is that
+of the SPL Token Program.
 
 ```rust
-pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
-    if &spl_token::ID != ctx.accounts.token_program.key {
-        return Err(ProgramError::IncorrectProgramId);
+pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> Result<()> {
+    if ctx.accounts.token_program.key() != spl_token::ID {
+        return Err(ProgramError::IncorrectProgramId.into());
     }
     solana_program::program::invoke(
         &spl_token::instruction::transfer(
-            ctx.accounts.token_program.key,
-            ctx.accounts.source.key,
-            ctx.accounts.destination.key,
-            ctx.accounts.authority.key,
+            ctx.accounts.token_program.key(),
+            ctx.accounts.source.key(),
+            ctx.accounts.destination.key(),
+            ctx.accounts.authority.key(),
             &[],
             amount,
         )?,
         &[
-            ctx.accounts.source.clone(),
-            ctx.accounts.destination.clone(),
-            ctx.accounts.authority.clone(),
+            ctx.accounts.source.to_account_info(),
+            ctx.accounts.destination.to_account_info(),
+            ctx.accounts.authority.to_account_info(),
         ],
-    )
+    )?;
+    Ok(())
 }
 ```
 
 Now, if an attacker passes in a different token program, the instruction will
 return the `ProgramError::IncorrectProgramId` error.
 
-Depending on the program you’re invoking with your CPI, you can either hard code
-the address of the expected program ID or use the program’s Rust crate to get
-the address of the program, if available. In the example above, the `spl_token`
-crate provides the address of the SPL Token Program.
+Depending on the program you're invoking with your CPI, you can either hard
+code the address of the expected program ID or use the program's Rust crate to
+get the address of the program, if available. In the example above, the
+`spl_token` crate provides the address of the SPL Token Program.
 
-### Use an Anchor CPI module
+### Use an Anchor CPI Module
 
-A simpler way to manage program checks is to use Anchor CPI modules. We learned
-in a
-[previous lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/anchor-cpi)
-that Anchor can automatically generate CPI modules to make CPIs into the program
-simpler. These modules also enhance security by verifying the public key of the
-program that’s passed into one of its public instructions.
+A simpler way to manage program checks is to use Anchor CPI modules. We
+learned in a [previous lesson](../anchor-cpi/README.md) that Anchor can
+automatically generate CPI modules to make CPIs into the program simpler.
+These modules also enhance security by verifying the public key of the program
+that's passed into one of its public instructions.
 
-Every Anchor program uses the `declare_id()` macro to define the address of the
-program. When a CPI module is generated for a specific program, it uses the
-address passed into this macro as the "source of truth" and will automatically
-verify that all CPIs made using its CPI module target this program id.
+Every Anchor program uses the `declare_id()` macro to define the address of
+the program. When a CPI module is generated for a specific program, it uses
+the address passed into this macro as the "source of truth" and will
+automatically verify that all CPIs made using its CPI module target this
+program id.
 
 While at the core no different than manual program checks, using CPI modules
-avoids the possibility of forgetting to perform a program check or accidentally
-typing in the wrong program ID when hard-coding it.
+avoids the possibility of forgetting to perform a program check or
+accidentally typing in the wrong program ID when hard-coding it.
 
 The program below shows an example of using a CPI module for the SPL Token
 Program to perform the transfer shown in the previous examples.
@@ -156,17 +158,19 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 pub mod arbitrary_cpi_recommended {
     use super::*;
 
-    pub fn cpi(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
+    pub fn cpi(ctx: Context<Cpi>, amount: u64) -> Result<()> {
         token::transfer(ctx.accounts.transfer_ctx(), amount)
     }
 }
 
 #[derive(Accounts)]
 pub struct Cpi<'info> {
-    source: Account<'info, TokenAccount>,
-    destination: Account<'info, TokenAccount>,
-    authority: Signer<'info>,
-    token_program: Program<'info, Token>,
+    #[account(mut)]
+    pub source: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub destination: Account<'info, TokenAccount>,
+    pub authority: Signer<'info>,
+    pub token_program: Program<'info, Token>,
 }
 
 impl<'info> Cpi<'info> {
@@ -186,20 +190,21 @@ Note that, like the example above, Anchor has created a few
 [wrappers for popular native programs](https://github.com/coral-xyz/anchor/tree/master/spl/src)
 that allow you to issue CPIs into them as if they were Anchor programs.
 
-Additionally and depending on the program you’re making the CPI to, you may be
-able to use Anchor’s
+Additionally and depending on the program you're making the CPI to, you may be
+able to use Anchor's
 [`Program` account type](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/program/struct.Program.html)
 to validate the passed-in program in your account validation struct. Between
-the [`anchor_lang`](https://docs.rs/anchor-lang/latest/anchor_lang) and [`anchor_spl`](https://docs.rs/anchor_spl/latest/) crates,
-the following `Program` types are provided out of the box:
+the [anchor_lang](https://docs.rs/anchor-lang/latest/anchor_lang) and
+[anchor_spl](https://docs.rs/anchor_spl/latest/) crates, the following
+`Program` types are provided out of the box:
 
 - [`System`](https://docs.rs/anchor-lang/latest/anchor_lang/system_program/struct.System.html)
 - [`AssociatedToken`](https://docs.rs/anchor-spl/latest/anchor_spl/associated_token/struct.AssociatedToken.html)
 - [`Token`](https://docs.rs/anchor-spl/latest/anchor_spl/token/struct.Token.html)
 
 If you have access to an Anchor program's CPI module, you typically can import
-its program type with the following, replacing the program name with the name of
-the actual program:
+its program type with the following, replacing the program name with the name
+of the actual program:
 
 ```rust
 use other_program::program::OtherProgram;
@@ -207,18 +212,18 @@ use other_program::program::OtherProgram;
 
 ## Lab
 
-To show the importance of checking with program you use for CPIs, we're going to
-work with a simplified and somewhat contrived game. This game represents
+To show the importance of checking which program you use for CPIs, we're going
+to work with a simplified and somewhat contrived game. This game represents
 characters with PDA accounts, and uses a separate "metadata" program to manage
 character metadata and attributes like health and power.
 
 While this example is somewhat contrived, it's actually almost identical
-architecture to how NFTs on Solana work: the SPL Token Program manages the token
-mints, distribution, and transfers, and a separate metadata program is used to
-assign metadata to tokens. So the vulnerability we go through here could also be
-applied to real tokens.
+architecture to how NFTs on Solana work: the SPL Token Program manages the
+token mints, distribution, and transfers, and a separate metadata program is
+used to assign metadata to tokens. So the vulnerability we go through here
+could also be applied to real tokens.
 
-#### 1. Setup
+### 1. Setup
 
 We'll start with the `starter` branch of
 [this repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/starter).
@@ -237,23 +242,23 @@ look at the program. It has two instructions:
 
 1. `create_character_insecure` - creates a new character and CPI's into the
    metadata program to set up the character's initial attributes
-2. `battle_insecure` - pits two characters against each other, assigning a "win"
-   to the character with the highest attributes
+2. `battle_insecure` - pits two characters against each other, assigning a
+   "win" to the character with the highest attributes
 
-The second program, `character-metadata`, is meant to be the "approved" program
-for handling character metadata. Have a look at this program. It has a single
-instruction for `create_metadata` that creates a new PDA and assigns a
+The second program, `character-metadata`, is meant to be the "approved"
+program for handling character metadata. Have a look at this program. It has a
+single instruction for `create_metadata` that creates a new PDA and assigns a
 pseudo-random value between 0 and 20 for the character's health and power.
 
 The last program, `fake-metadata` is a "fake" metadata program meant to
 illustrate what an attacker might make to exploit our `gameplay` program. This
-program is almost identical to the `character-metadata` program, only it assigns
-a character's initial health and power to be the max allowed: 255.
+program is almost identical to the `character-metadata` program, only it
+assigns a character's initial health and power to be the max allowed: 255.
 
-#### 2. Test `create_character_insecure` instruction
+### 2. Test `create_character_insecure` Instruction
 
-There is already a test in the `tests` directory for this. It's long, but take a
-minute to look at it before we talk through it together:
+There is already a test in the `tests` directory for this. It's long, but take
+a minute to look at it before we talk through it together:
 
 ```typescript
 it("Insecure instructions allow attacker to win every time", async () => {
@@ -306,32 +311,32 @@ it("Insecure instructions allow attacker to win every time", async () => {
 });
 ```
 
-This test walks through the scenario where a regular player and an attacker both
-create their characters. Only the attacker passes in the program ID of the fake
-metadata program rather than the actual metadata program. And since the
-`create_character_insecure` instruction has no program checks, it still
+This test walks through the scenario where a regular player and an attacker
+both create their characters. Only the attacker passes in the program ID of
+the fake metadata program rather than the actual metadata program. And since
+the `create_character_insecure` instruction has no program checks, it still
 executes.
 
 The result is that the regular character has the appropriate amount of health
 and power: each a value between 0 and 20. But the attacker's health and power
 are each 255, making the attacker unbeatable.
 
-If you haven't already, run `anchor test` to see that this test in fact behaves
-as described.
+If you haven't already, run `anchor test` to see that this test in fact
+behaves as described.
 
-#### 3. Create a `create_character_secure` instruction
+### 3. Create a `create_character_secure` Instruction
 
 Let's fix this by creating a secure instruction for creating a new character.
 This instruction should implement proper program checks and use the
-`character-metadata` program's `cpi` crate to do the CPI rather than just using
-`invoke`.
+`character-metadata` program's `cpi` crate to do the CPI rather than just
+using `invoke`.
 
 If you want to test out your skills, try this on your own before moving ahead.
 
 We'll start by updating our `use` statement at the top of the `gameplay`
-programs `lib.rs` file. We're giving ourselves access to the program's type for
-account validation, and the helper function for issuing the `create_metadata`
-CPI.
+programs `lib.rs` file. We're giving ourselves access to the program's type
+for account validation, and the helper function for issuing the
+`create_metadata` CPI.
 
 ```rust
 use character_metadata::{
@@ -342,7 +347,8 @@ use character_metadata::{
 ```
 
 Next let's create a new account validation struct called
-`CreateCharacterSecure`. This time, we make `metadata_program` a `Program` type:
+`CreateCharacterSecure`. This time, we make `metadata_program` a `Program`
+type:
 
 ```rust
 #[derive(Accounts)]
@@ -370,8 +376,8 @@ pub struct CreateCharacterSecure<'info> {
 }
 ```
 
-Lastly, we add the `create_character_secure` instruction. It will be the same as
-before but will use the full functionality of Anchor CPIs rather than using
+Lastly, we add the `create_character_secure` instruction. It will be the same
+as before but will use the full functionality of Anchor CPIs rather than using
 `invoke` directly:
 
 ```rust
@@ -397,7 +403,7 @@ pub fn create_character_secure(ctx: Context<CreateCharacterSecure>) -> Result<()
 }
 ```
 
-#### 4. Test `create_character_secure`
+### 4. Test `create_character_secure`
 
 Now that we have a secure way of initializing a new character, let's create a
 new test. This test just needs to attempt to initialize the attacker's character

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -462,5 +462,5 @@ as soon as possible!
 
 <Callout type="success" title="Completed the lab?">
 Push your code to GitHub and
-[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=5bcaf062-c356-4b58-80a0-12cca99c29b0)!
+[tell us what you thought of this lesson]("https://form.typeform.com/to/IPH0UGz7#answers-lesson=5bcaf062-c356-4b58-80a0-12cca99c29b0")!
 </Callout>

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -227,7 +227,6 @@ applied to real tokens.
 
 We'll start with the
 [`starter` branch of this repository](https://github.com/solana-developers/arbitrary-cpi/tree/starter).
-
 Clone the repository and then open it on the `starter` branch.
 
 Notice that there are three programs:

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -13,9 +13,9 @@ description: "How to safely invoke Solana programs from other Solana programs."
 ## Summary
 
 - To generate a CPI, the target program must be passed into the invoking
-  instruction as an account. This means that any target program could be passed
-  into the instruction. Your program should check for incorrect or unexpected
-  programs.
+  instruction handler as an account. This means that any target program could be
+  passed into the instruction handler. Your program should check for incorrect
+  or unexpected programs.
 - Perform program checks in native programs by simply comparing the public key
   of the passed-in program to the progam you expected.
 - If a program is written in Anchor, then it may have a publicly available CPI
@@ -25,27 +25,27 @@ description: "How to safely invoke Solana programs from other Solana programs."
 
 ## Lesson
 
-A cross program invocation (CPI) is when one program invokes an instruction on
-another program. An “arbitrary CPI” is when a program is structured to issue a
-CPI to whatever program is passed into the instruction rather than expecting to
-perform a CPI to one specific program. Given that the callers of your program's
-instruction can pass any program they'd like into the instruction's list of
-accounts, failing to verify the address of a passed-in program results in your
-program performing CPIs to arbitrary programs.
+A cross program invocation (CPI) is when one program invokes an instruction
+handler on another program. An “arbitrary CPI” is when a program is structured
+to issue a CPI to whatever program is passed into the instruction handler rather
+than expecting to perform a CPI to one specific program. Given that the callers
+of your program's instruction handler can pass any program they'd like into the
+instruction's list of accounts, failing to verify the address of a passed-in
+program results in your program performing CPIs to arbitrary programs.
 
 This lack of program checks creates an opportunity for a malicious user to pass
 in a different program than expected, causing the original program to call an
-instruction on this mystery program. There's no telling what the consequences of
-this CPI could be. It depends on the program logic (both that of the original
-program and the unexpected program), as well as what other accounts are passed
-into the original instruction.
+instruction handler on this mystery program. There’s no telling what the
+consequences of this CPI could be. It depends on the program logic (both that of
+the original program and the unexpected program), as well as what other accounts
+are passed into the original instruction handler.
 
-### Missing program checks
+### Missing Program Checks
 
-Take the following program as an example. The `cpi` instruction invokes the
-`transfer` instruction on `token_program`, but there is no code that checks
-whether or not the `token_program` account passed into the instruction is, in
-fact, the SPL Token Program.
+Take the following program as an example. The `cpi` instruction handler invokes
+the `transfer` instruction handler on `token_program`, but there is no code that
+checks whether or not the `token_program` account passed into the instruction
+handler is, in fact, the SPL Token Program.
 
 ```rust
 use anchor_lang::prelude::*;
@@ -85,14 +85,14 @@ pub struct Cpi<'info> {
 }
 ```
 
-An attacker could easily call this instruction and pass in a duplicate token
-program that they created and control.
+An attacker could easily call this instruction handler and pass in a duplicate
+token program that they created and control.
 
-### Add program checks
+### Add Program Checks
 
 It's possible to fix this vulnerabilty by simply adding a few lines to the `cpi`
-instruction to check whether or not `token_program`'s public key is that of the
-SPL Token Program.
+instruction handler to check whether or not `token_program`'s public key is that
+of the SPL Token Program.
 
 ```rust
 pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
@@ -117,19 +117,20 @@ pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
 }
 ```
 
-Now, if an attacker passes in a different token program, the instruction will
-return the `ProgramError::IncorrectProgramId` error.
+Now, if an attacker passes in a different token program, the instruction handler
+will return the `ProgramError::IncorrectProgramId` error.
 
 Depending on the program you're invoking with your CPI, you can either hard code
 the address of the expected program ID or use the program's Rust crate to get
 the address of the program, if available. In the example above, the `spl_token`
 crate provides the address of the SPL Token Program.
 
-### Use an Anchor CPI module
+### Use an Anchor CPI Module
 
-A simpler way to manage program checks is to use Anchor CPI modules. We learned
-in a
-[previous lesson](https://github.com/solana-foundation/developer-content/blob/3c1633ee07205dc5788e72a0d2a0b7255e6d9f7d/content/courses/onchain-development/anchor-cpi.md#L4)
+A simpler way to manage program checks is to use
+[Anchor CPI](https://book.anchor-lang.com/anchor_in_depth/CPIs.html) module. We
+learned in a
+[previous lesson of Anchor CPI](/content/courses/onchain-development/anchor-cpi.md)
 that Anchor can automatically generate CPI modules to make CPIs into the program
 simpler. These modules also enhance security by verifying the public key of the
 program that's passed into one of its public instructions using
@@ -183,9 +184,12 @@ impl<'info> Cpi<'info> {
 }
 ```
 
-Note that, like the example above, Anchor has created a few
+<Callout>
+
+Like the example above, Anchor has created a few
 [wrappers for popular native programs](https://github.com/coral-xyz/anchor/tree/master/spl/src)
 that allow you to issue CPIs into them as if they were Anchor programs.
+</Callout>
 
 Additionally and depending on the program you're making the CPI to, you may be
 able to use Anchor's
@@ -219,10 +223,11 @@ mints, distribution, and transfers, and a separate metadata program is used to
 assign metadata to tokens. So the vulnerability we go through here could also be
 applied to real tokens.
 
-#### 1. Setup
+### 1. Setup
 
-We'll start with the `starter` branch of
-[this repository](https://github.com/solana-developers/arbitrary-cpi/tree/starter).
+We'll start with the
+[`starter` branch of this repository](https://github.com/solana-developers/arbitrary-cpi/tree/starter).
+
 Clone the repository and then open it on the `starter` branch.
 
 Notice that there are three programs:
@@ -243,7 +248,7 @@ look at the program. It has two instructions:
 
 The second program, `character-metadata`, is meant to be the "approved" program
 for handling character metadata. Have a look at this program. It has a single
-instruction for `create_metadata` that creates a new PDA and assigns a
+instruction handler for `create_metadata` that creates a new PDA and assigns a
 pseudo-random value between 0 and 20 for the character's health and power.
 
 The last program, `fake-metadata` is a "fake" metadata program meant to
@@ -251,59 +256,63 @@ illustrate what an attacker might make to exploit our `gameplay` program. This
 program is almost identical to the `character-metadata` program, only it assigns
 a character's initial health and power to be the max allowed: 255.
 
-#### 2. Test `create_character_insecure` instruction
+### 2. Test create_character_insecure Instruction Handler
 
 There is already a test in the `tests` directory for this. It's long, but take a
 minute to look at it before we talk through it together:
 
 ```typescript
-it("Insecure instructions allow attacker to win every time", async () => {
-  // Initialize player one with real metadata program
-  await gameplayProgram.methods
-    .createCharacterInsecure()
-    .accounts({
-      metadataProgram: metadataProgram.programId,
-      authority: playerOne.publicKey,
-    })
-    .signers([playerOne])
-    .rpc();
+it("Insecure instructions allow attacker to win every time successfully", async () => {
+  try {
+    // Initialize player one with real metadata program
+    await gameplayProgram.methods
+      .createCharacterInsecure()
+      .accounts({
+        metadataProgram: metadataProgram.programId,
+        authority: playerOne.publicKey,
+      })
+      .signers([playerOne])
+      .rpc();
 
-  // Initialize attacker with fake metadata program
-  await gameplayProgram.methods
-    .createCharacterInsecure()
-    .accounts({
-      metadataProgram: fakeMetadataProgram.programId,
-      authority: attacker.publicKey,
-    })
-    .signers([attacker])
-    .rpc();
+    // Initialize attacker with fake metadata program
+    await gameplayProgram.methods
+      .createCharacterInsecure()
+      .accounts({
+        metadataProgram: fakeMetadataProgram.programId,
+        authority: attacker.publicKey,
+      })
+      .signers([attacker])
+      .rpc();
 
-  // Fetch both player's metadata accounts
-  const [playerOneMetadataKey] = getMetadataKey(
-    playerOne.publicKey,
-    gameplayProgram.programId,
-    metadataProgram.programId,
-  );
+    // Fetch both player's metadata accounts
+    const [playerOneMetadataKey] = getMetadataKey(
+      playerOne.publicKey,
+      gameplayProgram.programId,
+      metadataProgram.programId,
+    );
 
-  const [attackerMetadataKey] = getMetadataKey(
-    attacker.publicKey,
-    gameplayProgram.programId,
-    fakeMetadataProgram.programId,
-  );
+    const [attackerMetadataKey] = getMetadataKey(
+      attacker.publicKey,
+      gameplayProgram.programId,
+      fakeMetadataProgram.programId,
+    );
 
-  const playerOneMetadata =
-    await metadataProgram.account.metadata.fetch(playerOneMetadataKey);
+    const playerOneMetadata =
+      await metadataProgram.account.metadata.fetch(playerOneMetadataKey);
 
-  const attackerMetadata =
-    await fakeMetadataProgram.account.metadata.fetch(attackerMetadataKey);
+    const attackerMetadata =
+      await fakeMetadataProgram.account.metadata.fetch(attackerMetadataKey);
+    // The regular player should have health and power between 0 and 20
+    expect(playerOneMetadata.health).to.be.lessThan(20);
+    expect(playerOneMetadata.power).to.be.lessThan(20);
 
-  // The regular player should have health and power between 0 and 20
-  expect(playerOneMetadata.health).to.be.lessThan(20);
-  expect(playerOneMetadata.power).to.be.lessThan(20);
-
-  // The attacker will have health and power of 255
-  expect(attackerMetadata.health).to.equal(255);
-  expect(attackerMetadata.power).to.equal(255);
+    // The attacker will have health and power of 255
+    expect(attackerMetadata.health).to.equal(255);
+    expect(attackerMetadata.power).to.equal(255);
+  } catch (error) {
+    console.error("Test failed:", error);
+    throw error;
+  }
 });
 ```
 
@@ -320,12 +329,12 @@ are each 255, making the attacker unbeatable.
 If you haven't already, run `anchor test` to see that this test in fact behaves
 as described.
 
-#### 3. Create a `create_character_secure` instruction
+### 3. Create a create_character_secure Instruction Handler
 
-Let's fix this by creating a secure instruction for creating a new character.
-This instruction should implement proper program checks and use the
-`character-metadata` program's `cpi` crate to do the CPI rather than just using
-`invoke`.
+Let's fix this by creating a secure instruction handler for creating a new
+character. This instruction handler should implement proper program checks and
+use the `character-metadata` program's `cpi` crate to do the CPI rather than
+just using `invoke`.
 
 If you want to test out your skills, try this on your own before moving ahead.
 
@@ -353,7 +362,7 @@ pub struct CreateCharacterSecure<'info> {
     #[account(
         init,
         payer = authority,
-        space = 8 + 32 + 32 + 64,
+        space = DISCRIMINATOR_SIZE + Character::INIT_SPACE,
         seeds = [authority.key().as_ref()],
         bump
     )]
@@ -364,25 +373,27 @@ pub struct CreateCharacterSecure<'info> {
         seeds::program = metadata_program.key(),
         bump,
     )]
-    /// CHECK: manual checks
+    /// CHECK: This account will not be checked by anchor
     pub metadata_account: AccountInfo<'info>,
     pub metadata_program: Program<'info, CharacterMetadata>,
     pub system_program: Program<'info, System>,
 }
 ```
 
-Lastly, we add the `create_character_secure` instruction. It will be the same as
-before but will use the full functionality of Anchor CPIs rather than using
-`invoke` directly:
+Lastly, we add the `create_character_secure` instruction handler. It will be the
+same as before but will use the full functionality of Anchor CPIs rather than
+using `invoke` directly:
 
 ```rust
 pub fn create_character_secure(ctx: Context<CreateCharacterSecure>) -> Result<()> {
+    // Initialize character data
     let character = &mut ctx.accounts.character;
     character.metadata = ctx.accounts.metadata_account.key();
-    character.auth = ctx.accounts.authority.key();
+    character.authority = ctx.accounts.authority.key();
     character.wins = 0;
 
-    let context = CpiContext::new(
+    // Prepare CPI context
+    let cpi_context = CpiContext::new(
         ctx.accounts.metadata_program.to_account_info(),
         CreateMetadata {
             character: ctx.accounts.character.to_account_info(),
@@ -392,20 +403,21 @@ pub fn create_character_secure(ctx: Context<CreateCharacterSecure>) -> Result<()
         },
     );
 
-    create_metadata(context)?;
+    // Perform CPI to create metadata
+    create_metadata(cpi_context)?;
 
     Ok(())
 }
 ```
 
-#### 4. Test `create_character_secure`
+### 4. Test create_character_secure Instruction Handler
 
 Now that we have a secure way of initializing a new character, let's create a
 new test. This test just needs to attempt to initialize the attacker's character
 and expect an error to be thrown.
 
 ```typescript
-it("Secure character creation doesn't allow fake program", async () => {
+it("prevents secure character creation with fake program", async () => {
   try {
     await gameplayProgram.methods
       .createCharacterSecure()
@@ -415,23 +427,25 @@ it("Secure character creation doesn't allow fake program", async () => {
       })
       .signers([attacker])
       .rpc();
+
+    throw new Error("Expected createCharacterSecure to throw an error");
   } catch (error) {
-    expect(error);
+    expect(error).to.be.instanceOf(Error);
     console.log(error);
   }
 });
 ```
 
 Run `anchor test` if you haven't already. Notice that an error was thrown as
-expected, detailing that the program ID passed into the instruction is not the
-expected program ID:
+expected, detailing that the program ID passed into the instruction handler is
+not the expected program ID:
 
 ```bash
 'Program log: AnchorError caused by account: metadata_program. Error Code: InvalidProgramId. Error Number: 3008. Error Message: Program ID was not as expected.',
 'Program log: Left:',
-'Program log: FKBWhshzcQa29cCyaXc1vfkZ5U985gD5YsqfCzJYUBr',
+'Program log: HQqG7PxftCD5BB9WUWcYksrjDLUwCmbV8Smh1W8CEgQm',
 'Program log: Right:',
-'Program log: D4hPnYEsAx4u3EQMrKEXsY3MkfLndXbBKTEYTwwm25TE'
+'Program log: 4FgVd2dgsFnXbSHz8fj9twNbfx8KWcBJkHa6APicU6KS'
 ```
 
 That's all you need to do to protect against arbitrary CPIs!
@@ -441,8 +455,7 @@ certainly won't stop you from architecting the program you need, but please take
 every precaution possible to ensure no vulnerabilities in your program.
 
 If you want to take a look at the final solution code you can find it on the
-`solution` branch of
-[the same repository](https://github.com/solana-developers/arbitrary-cpi/tree/solution).
+[`solution` branch of the same repository](https://github.com/solana-developers/arbitrary-cpi/tree/solution).
 
 ## Challenge
 
@@ -450,13 +463,14 @@ Just as with other lessons in this unit, your opportunity to practice avoiding
 this security exploit lies in auditing your own or other programs.
 
 Take some time to review at least one program and ensure that program checks are
-in place for every program passed into the instructions, particularly those that
-are invoked via CPI.
+in place for every program passed into the instruction handlers, particularly
+those that are invoked via CPI.
 
 Remember, if you find a bug or exploit in somebody else's program, please alert
 them! If you find one in your own program, be sure to patch it right away.
 
 <Callout type="success" title="Completed the lab?">
+
 Push your code to GitHub and
 [tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=5bcaf062-c356-4b58-80a0-12cca99c29b0)!
 </Callout>

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -462,5 +462,5 @@ as soon as possible!
 
 <Callout type="success" title="Completed the lab?">
 Push your code to GitHub and
-[tell us what you thought of this lesson]("https://form.typeform.com/to/IPH0UGz7#answers-lesson=5bcaf062-c356-4b58-80a0-12cca99c29b0")!
+[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=5bcaf062-c356-4b58-80a0-12cca99c29b0)!
 </Callout>

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -128,9 +128,11 @@ crate provides the address of the SPL Token Program.
 ### Use an Anchor CPI module
 
 A simpler way to manage program checks is to use Anchor CPI modules. We learned
-in a [previous lesson](https://github.com/solana-foundation/developer-content/blob/3c1633ee07205dc5788e72a0d2a0b7255e6d9f7d/content/courses/onchain-development/anchor-cpi.md#L4) that Anchor can automatically generate CPI modules to make CPIs into the program simpler. These modules also
-enhance security by verifying the public key of the program that's passed into
-one of its public instructions using
+in a
+[previous lesson](https://github.com/solana-foundation/developer-content/blob/3c1633ee07205dc5788e72a0d2a0b7255e6d9f7d/content/courses/onchain-development/anchor-cpi.md#L4)
+that Anchor can automatically generate CPI modules to make CPIs into the program
+simpler. These modules also enhance security by verifying the public key of the
+program that's passed into one of its public instructions using
 [account constraints](https://www.anchor-lang.com/docs/account-constraints).
 
 Every Anchor program uses the `declare_id()` macro to define the address of the
@@ -206,8 +208,8 @@ use other_program::program::OtherProgram;
 
 ## Lab
 
-To show the importance of checking with program you use for CPIs, we're going to
-work with a simplified and somewhat contrived game. This game represents
+To show the importance of checking the program ID you use for CPIs, we're going
+to work with a simplified and somewhat contrived game. This game represents
 characters with PDA accounts, and uses a separate "metadata" program to manage
 character metadata and attributes like health and power.
 

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -18,8 +18,7 @@ description: "How to safely invoke Solana programs from other Solana programs."
 - Perform program checks in native programs by comparing the public key of the
   passed-in program to the program you expected.
 - If a program is written in Anchor, it may have a publicly available CPI
-  module. This makes invoking the program from another Anchor program simple and
-  secure. The Anchor CPI module automatically checks that the address of the
+  module for making cross-program invocations. This makes invoking the program from another Anchor program simple and secure. The Anchor CPI module automatically checks that the address of the
   program passed in matches the address of the program stored in the module.
 
 ## Lesson
@@ -128,7 +127,7 @@ crate provides the address of the SPL Token Program.
 ### Use an Anchor CPI Module
 
 A simpler way to manage program checks is to use Anchor CPI modules. We learned
-in a [previous lesson](../anchor-cpi/README.md) that Anchor can automatically
+in a [previous lesson](https://github.com/solana-foundation/developer-content/blob/main/content/courses/onchain-development/anchor-cpi.md) that Anchor can automatically
 generate CPI modules to make CPIs into the program simpler. These modules also
 enhance security by verifying the public key of the program that's passed into
 one of its public instructions using
@@ -224,7 +223,7 @@ applied to real tokens.
 ### 1. Setup
 
 We'll start with the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/starter).
+[this repository](https://github.com/solana-developers/arbitrary-cpi/tree/starter).
 Clone the repository and then open it on the `starter` branch.
 
 Notice that there are three programs:

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -3,8 +3,8 @@ title: Arbitrary CPI
 objectives:
   - Explain the security risks associated with invoking a CPI to an unknown
     program
-  - Showcase how Anchor's CPI module prevents this from happening when making
-    a CPI from one Anchor program to another
+  - Showcase how Anchor's CPI module prevents this from happening when making a
+    CPI from one Anchor program to another
   - Safely and securely make a CPI from an Anchor program to an arbitrary
     non-anchor program
 description: "How to safely invoke Solana programs from other Solana programs."
@@ -13,33 +13,32 @@ description: "How to safely invoke Solana programs from other Solana programs."
 ## Summary
 
 - To generate a CPI, the target program must be passed into the invoking
-  instruction as an account. This means any target program could be passed
-  into the instruction. Your program should check for incorrect or unexpected
+  instruction as an account. This means any target program could be passed into
+  the instruction. Your program should check for incorrect or unexpected
   programs.
 - Perform program checks in native programs by comparing the public key of the
   passed-in program to the program you expected.
 - If a program is written in Anchor, it may have a publicly available CPI
-  module. This makes invoking the program from another Anchor program simple
-  and secure. The Anchor CPI module automatically checks that the address of
-  the program passed in matches the address of the program stored in the
-  module.
+  module. This makes invoking the program from another Anchor program simple and
+  secure. The Anchor CPI module automatically checks that the address of the
+  program passed in matches the address of the program stored in the module.
 
 ## Lesson
 
 A cross-program invocation (CPI) is when one program invokes an instruction on
 another program. An "arbitrary CPI" is when a program is structured to issue a
-CPI to whatever program is passed into the instruction rather than expecting
-to perform a CPI to one specific program. Given that the callers of your
-program's instruction can pass any program they'd like into the instruction's
-list of accounts, failing to verify the address of a passed-in program results
-in your program performing CPIs to arbitrary programs.
+CPI to whatever program is passed into the instruction rather than expecting to
+perform a CPI to one specific program. Given that the callers of your program's
+instruction can pass any program they'd like into the instruction's list of
+accounts, failing to verify the address of a passed-in program results in your
+program performing CPIs to arbitrary programs.
 
-This lack of program checks creates an opportunity for a malicious user to
-pass in a different program than expected, causing the original program to
-call an instruction on this mystery program. There's no telling what the
-consequences of this CPI could be. It depends on the program logic (both that
-of the original program and the unexpected program), as well as what other
-accounts are passed into the original instruction.
+This lack of program checks creates an opportunity for a malicious user to pass
+in a different program than expected, causing the original program to call an
+instruction on this mystery program. There's no telling what the consequences of
+this CPI could be. It depends on the program logic (both that of the original
+program and the unexpected program), as well as what other accounts are passed
+into the original instruction.
 
 ### Missing Program Checks
 
@@ -122,28 +121,27 @@ pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> Result<()> {
 Now, if an attacker passes in a different token program, the instruction will
 return the `ProgramError::IncorrectProgramId` error.
 
-Depending on the program you're invoking with your CPI, you can either hard
-code the address of the expected program ID or use the program's Rust crate to
-get the address of the program, if available. In the example above, the
-`spl_token` crate provides the address of the SPL Token Program.
+Depending on the program you're invoking with your CPI, you can either hard code
+the address of the expected program ID or use the program's Rust crate to get
+the address of the program, if available. In the example above, the `spl_token`
+crate provides the address of the SPL Token Program.
 
 ### Use an Anchor CPI Module
 
-A simpler way to manage program checks is to use Anchor CPI modules. We
-learned in a [previous lesson](../anchor-cpi/README.md) that Anchor can
-automatically generate CPI modules to make CPIs into the program simpler.
-These modules also enhance security by verifying the public key of the program
-that's passed into one of its public instructions.
+A simpler way to manage program checks is to use Anchor CPI modules. We learned
+in a [previous lesson](../anchor-cpi/README.md) that Anchor can automatically
+generate CPI modules to make CPIs into the program simpler. These modules also
+enhance security by verifying the public key of the program that's passed into
+one of its public instructions.
 
-Every Anchor program uses the `declare_id()` macro to define the address of
-the program. When a CPI module is generated for a specific program, it uses
-the address passed into this macro as the "source of truth" and will
-automatically verify that all CPIs made using its CPI module target this
-program id.
+Every Anchor program uses the `declare_id()` macro to define the address of the
+program. When a CPI module is generated for a specific program, it uses the
+address passed into this macro as the "source of truth" and will automatically
+verify that all CPIs made using its CPI module target this program id.
 
 While at the core no different than manual program checks, using CPI modules
-avoids the possibility of forgetting to perform a program check or
-accidentally typing in the wrong program ID when hard-coding it.
+avoids the possibility of forgetting to perform a program check or accidentally
+typing in the wrong program ID when hard-coding it.
 
 The program below shows an example of using a CPI module for the SPL Token
 Program to perform the transfer shown in the previous examples.
@@ -193,18 +191,18 @@ that allow you to issue CPIs into them as if they were Anchor programs.
 Additionally and depending on the program you're making the CPI to, you may be
 able to use Anchor's
 [`Program` account type](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/program/struct.Program.html)
-to validate the passed-in program in your account validation struct. Between
-the [anchor_lang](https://docs.rs/anchor-lang/latest/anchor_lang) and
-[anchor_spl](https://docs.rs/anchor_spl/latest/) crates, the following
-`Program` types are provided out of the box:
+to validate the passed-in program in your account validation struct. Between the
+[anchor_lang](https://docs.rs/anchor-lang/latest/anchor_lang) and
+[anchor_spl](https://docs.rs/anchor_spl/latest/) crates, the following `Program`
+types are provided out of the box:
 
 - [`System`](https://docs.rs/anchor-lang/latest/anchor_lang/system_program/struct.System.html)
 - [`AssociatedToken`](https://docs.rs/anchor-spl/latest/anchor_spl/associated_token/struct.AssociatedToken.html)
 - [`Token`](https://docs.rs/anchor-spl/latest/anchor_spl/token/struct.Token.html)
 
 If you have access to an Anchor program's CPI module, you typically can import
-its program type with the following, replacing the program name with the name
-of the actual program:
+its program type with the following, replacing the program name with the name of
+the actual program:
 
 ```rust
 use other_program::program::OtherProgram;
@@ -218,10 +216,10 @@ characters with PDA accounts, and uses a separate "metadata" program to manage
 character metadata and attributes like health and power.
 
 While this example is somewhat contrived, it's actually almost identical
-architecture to how NFTs on Solana work: the SPL Token Program manages the
-token mints, distribution, and transfers, and a separate metadata program is
-used to assign metadata to tokens. So the vulnerability we go through here
-could also be applied to real tokens.
+architecture to how NFTs on Solana work: the SPL Token Program manages the token
+mints, distribution, and transfers, and a separate metadata program is used to
+assign metadata to tokens. So the vulnerability we go through here could also be
+applied to real tokens.
 
 ### 1. Setup
 
@@ -242,23 +240,23 @@ look at the program. It has two instructions:
 
 1. `create_character_insecure` - creates a new character and CPI's into the
    metadata program to set up the character's initial attributes
-2. `battle_insecure` - pits two characters against each other, assigning a
-   "win" to the character with the highest attributes
+2. `battle_insecure` - pits two characters against each other, assigning a "win"
+   to the character with the highest attributes
 
-The second program, `character-metadata`, is meant to be the "approved"
-program for handling character metadata. Have a look at this program. It has a
-single instruction for `create_metadata` that creates a new PDA and assigns a
+The second program, `character-metadata`, is meant to be the "approved" program
+for handling character metadata. Have a look at this program. It has a single
+instruction for `create_metadata` that creates a new PDA and assigns a
 pseudo-random value between 0 and 20 for the character's health and power.
 
 The last program, `fake-metadata` is a "fake" metadata program meant to
 illustrate what an attacker might make to exploit our `gameplay` program. This
-program is almost identical to the `character-metadata` program, only it
-assigns a character's initial health and power to be the max allowed: 255.
+program is almost identical to the `character-metadata` program, only it assigns
+a character's initial health and power to be the max allowed: 255.
 
 ### 2. Test `create_character_insecure` Instruction
 
-There is already a test in the `tests` directory for this. It's long, but take
-a minute to look at it before we talk through it together:
+There is already a test in the `tests` directory for this. It's long, but take a
+minute to look at it before we talk through it together:
 
 ```typescript
 it("Insecure instructions allow attacker to win every time", async () => {
@@ -311,32 +309,32 @@ it("Insecure instructions allow attacker to win every time", async () => {
 });
 ```
 
-This test walks through the scenario where a regular player and an attacker
-both create their characters. Only the attacker passes in the program ID of
-the fake metadata program rather than the actual metadata program. And since
-the `create_character_insecure` instruction has no program checks, it still
+This test walks through the scenario where a regular player and an attacker both
+create their characters. Only the attacker passes in the program ID of the fake
+metadata program rather than the actual metadata program. And since the
+`create_character_insecure` instruction has no program checks, it still
 executes.
 
 The result is that the regular character has the appropriate amount of health
 and power: each a value between 0 and 20. But the attacker's health and power
 are each 255, making the attacker unbeatable.
 
-If you haven't already, run `anchor test` to see that this test in fact
-behaves as described.
+If you haven't already, run `anchor test` to see that this test in fact behaves
+as described.
 
 ### 3. Create a `create_character_secure` Instruction
 
 Let's fix this by creating a secure instruction for creating a new character.
 This instruction should implement proper program checks and use the
-`character-metadata` program's `cpi` crate to do the CPI rather than just
-using `invoke`.
+`character-metadata` program's `cpi` crate to do the CPI rather than just using
+`invoke`.
 
 If you want to test out your skills, try this on your own before moving ahead.
 
 We'll start by updating our `use` statement at the top of the `gameplay`
-programs `lib.rs` file. We're giving ourselves access to the program's type
-for account validation, and the helper function for issuing the
-`create_metadata` CPI.
+programs `lib.rs` file. We're giving ourselves access to the program's type for
+account validation, and the helper function for issuing the `create_metadata`
+CPI.
 
 ```rust
 use character_metadata::{
@@ -347,8 +345,7 @@ use character_metadata::{
 ```
 
 Next let's create a new account validation struct called
-`CreateCharacterSecure`. This time, we make `metadata_program` a `Program`
-type:
+`CreateCharacterSecure`. This time, we make `metadata_program` a `Program` type:
 
 ```rust
 #[derive(Accounts)]
@@ -376,8 +373,8 @@ pub struct CreateCharacterSecure<'info> {
 }
 ```
 
-Lastly, we add the `create_character_secure` instruction. It will be the same
-as before but will use the full functionality of Anchor CPIs rather than using
+Lastly, we add the `create_character_secure` instruction. It will be the same as
+before but will use the full functionality of Anchor CPIs rather than using
 `invoke` directly:
 
 ```rust

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -3,7 +3,7 @@ title: Arbitrary CPI
 objectives:
   - Explain the security risks associated with invoking a CPI to an unknown
     program
-  - Showcase how Anchor’s CPI module prevents this from happening when making a
+  - Showcase how Anchor's CPI module prevents this from happening when making a
     CPI from one Anchor program to another
   - Safely and securely make a CPI from an Anchor program to an arbitrary
     non-anchor program
@@ -35,7 +35,7 @@ program performing CPIs to arbitrary programs.
 
 This lack of program checks creates an opportunity for a malicious user to pass
 in a different program than expected, causing the original program to call an
-instruction on this mystery program. There’s no telling what the consequences of
+instruction on this mystery program. There's no telling what the consequences of
 this CPI could be. It depends on the program logic (both that of the original
 program and the unexpected program), as well as what other accounts are passed
 into the original instruction.
@@ -120,19 +120,18 @@ pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
 Now, if an attacker passes in a different token program, the instruction will
 return the `ProgramError::IncorrectProgramId` error.
 
-Depending on the program you’re invoking with your CPI, you can either hard code
-the address of the expected program ID or use the program’s Rust crate to get
+Depending on the program you're invoking with your CPI, you can either hard code
+the address of the expected program ID or use the program's Rust crate to get
 the address of the program, if available. In the example above, the `spl_token`
 crate provides the address of the SPL Token Program.
 
 ### Use an Anchor CPI module
 
 A simpler way to manage program checks is to use Anchor CPI modules. We learned
-in a
-[previous lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/anchor-cpi)
-that Anchor can automatically generate CPI modules to make CPIs into the program
-simpler. These modules also enhance security by verifying the public key of the
-program that’s passed into one of its public instructions.
+in a [previous lesson](https://github.com/solana-foundation/developer-content/blob/3c1633ee07205dc5788e72a0d2a0b7255e6d9f7d/content/courses/onchain-development/anchor-cpi.md#L4) that Anchor can automatically generate CPI modules to make CPIs into the program simpler. These modules also
+enhance security by verifying the public key of the program that's passed into
+one of its public instructions using
+[account constraints](https://www.anchor-lang.com/docs/account-constraints).
 
 Every Anchor program uses the `declare_id()` macro to define the address of the
 program. When a CPI module is generated for a specific program, it uses the
@@ -186,8 +185,8 @@ Note that, like the example above, Anchor has created a few
 [wrappers for popular native programs](https://github.com/coral-xyz/anchor/tree/master/spl/src)
 that allow you to issue CPIs into them as if they were Anchor programs.
 
-Additionally and depending on the program you’re making the CPI to, you may be
-able to use Anchor’s
+Additionally and depending on the program you're making the CPI to, you may be
+able to use Anchor's
 [`Program` account type](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/program/struct.Program.html)
 to validate the passed-in program in your account validation struct. Between
 the [`anchor_lang`](https://docs.rs/anchor-lang/latest/anchor_lang) and [`anchor_spl`](https://docs.rs/anchor_spl/latest/) crates,
@@ -221,7 +220,7 @@ applied to real tokens.
 #### 1. Setup
 
 We'll start with the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/starter).
+[this repository](https://github.com/solana-developers/arbitrary-cpi/tree/starter).
 Clone the repository and then open it on the `starter` branch.
 
 Notice that there are three programs:
@@ -441,7 +440,7 @@ every precaution possible to ensure no vulnerabilities in your program.
 
 If you want to take a look at the final solution code you can find it on the
 `solution` branch of
-[the same repository](https://github.com/Unboxed-Software/solana-arbitrary-cpi/tree/solution).
+[the same repository](https://github.com/solana-developers/arbitrary-cpi/tree/solution).
 
 ## Challenge
 

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -13,9 +13,8 @@ description: "How to safely invoke Solana programs from other Solana programs."
 ## Summary
 
 - To generate a CPI, the target program must be passed into the invoking
-  instruction as an account. This means any target program could be passed into
-  the instruction. Your program should check for incorrect or unexpected
-  programs.
+  instruction as an account. Any target program could be passed in, so your
+  program should check for incorrect or unexpected programs.
 - Perform program checks in native programs by comparing the public key of the
   passed-in program to the program you expected.
 - If a program is written in Anchor, it may have a publicly available CPI
@@ -132,7 +131,8 @@ A simpler way to manage program checks is to use Anchor CPI modules. We learned
 in a [previous lesson](../anchor-cpi/README.md) that Anchor can automatically
 generate CPI modules to make CPIs into the program simpler. These modules also
 enhance security by verifying the public key of the program that's passed into
-one of its public instructions.
+one of its public instructions using
+[account constraints](https://www.anchor-lang.com/docs/account-constraints).
 
 Every Anchor program uses the `declare_id()` macro to define the address of the
 program. When a CPI module is generated for a specific program, it uses the
@@ -259,7 +259,7 @@ There is already a test in the `tests` directory for this. It's long, but take a
 minute to look at it before we talk through it together:
 
 ```typescript
-test("Insecure instructions allow attacker to win every time", async () => {
+it("Insecure instructions allow attacker to win every time", async () => {
   // Initialize player one with real metadata program
   await gameplayProgram.methods
     .createCharacterInsecure()
@@ -407,15 +407,15 @@ new test. This test just needs to attempt to initialize the attacker's character
 and expect an error to be thrown.
 
 ```typescript
-test("Secure character creation doesn't allow fake program", async () => {
+it("Secure character creation doesn't allow unauthorized program", async () => {
   try {
     await gameplayProgram.methods
       .createCharacterSecure()
       .accounts({
-        metadataProgram: fakeMetadataProgram.programId,
-        authority: attacker.publicKey,
+        metadataProgram: unauthorizedMetadataProgram.programId,
+        authority: unauthorizedWallet.publicKey,
       })
-      .signers([attacker])
+      .signers([unauthorizedWallet])
       .rpc();
   } catch (error) {
     expect(error);
@@ -455,8 +455,10 @@ Take some time to review at least one program and ensure that program checks are
 in place for every program passed into the instructions, particularly those that
 are invoked via CPI.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert
-them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program,
+[responsibly disclose](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure)
+it to the program's maintainers. If you find one in your own program, patch it
+as soon as possible!
 
 <Callout type="success" title="Completed the lab?">
 Push your code to GitHub and

--- a/content/courses/program-security/arbitrary-cpi.md
+++ b/content/courses/program-security/arbitrary-cpi.md
@@ -259,7 +259,7 @@ There is already a test in the `tests` directory for this. It's long, but take a
 minute to look at it before we talk through it together:
 
 ```typescript
-it("Insecure instructions allow attacker to win every time", async () => {
+test("Insecure instructions allow attacker to win every time", async () => {
   // Initialize player one with real metadata program
   await gameplayProgram.methods
     .createCharacterInsecure()
@@ -407,7 +407,7 @@ new test. This test just needs to attempt to initialize the attacker's character
 and expect an error to be thrown.
 
 ```typescript
-it("Secure character creation doesn't allow fake program", async () => {
+test("Secure character creation doesn't allow fake program", async () => {
   try {
     await gameplayProgram.methods
       .createCharacterSecure()

--- a/content/courses/program-security/bump-seed-canonicalization.md
+++ b/content/courses/program-security/bump-seed-canonicalization.md
@@ -18,7 +18,6 @@ tags:
 
 ## Summary
 
-
 - The
   [**`create_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address)
   function derives a PDA without searching for the **canonical bump**. This

--- a/content/courses/program-security/bump-seed-canonicalization.md
+++ b/content/courses/program-security/bump-seed-canonicalization.md
@@ -302,7 +302,7 @@ rewards on time.
 #### 1. Setup
 
 Start by getting the code on the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/starter).
+[this repository](https://github.com/solana-developers/solana-bump-seed-canonicalization/tree/starter).
 
 Notice that there are two instructions on the program and a single test in the
 `tests` directory.
@@ -600,7 +600,7 @@ careful to design your program to explicitly use the canonical bump!
 
 If you want to take a look at the final solution code you can find it on the
 `solution` branch of
-[the same repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/solution).
+[the same repository](https://github.com/solana-developers/solana-bump-seed-canonicalization/tree/solution).
 
 ## Challenge
 

--- a/content/courses/program-security/bump-seed-canonicalization.md
+++ b/content/courses/program-security/bump-seed-canonicalization.md
@@ -1,77 +1,37 @@
 ---
 title: Bump Seed Canonicalization
-objectives:
-  - Explain the vulnerabilities associated with using PDAs derived without the
-    canonical bump
-  - Initialize a PDA using Anchor’s `seeds` and `bump` constraints to
-    automatically use the canonical bump
-  - Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is
-    always used in future instructions when deriving a PDA
-description:
-  "Understand the need for consistent PDA calculation by storing and reusuing
-  the canonical bump."
+description: Learn how to properly use canonical bump seeds when deriving and verifying PDAs to ensure security and consistency in your Solana programs.
+keywords:
+  - canonical bump
+  - PDA
+  - program derived address
+  - Anchor
+  - find_program_address
+  - create_program_address
+tags:
+  - security
+  - pdas
+  - anchor
 ---
 
 ## Summary
 
-- The
-  [**`create_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address)
-  function derives a PDA without searching for the **canonical bump**. This
-  means there are multiple valid bumps, all of which will produce different
-  addresses.
-- Using
-  [**`find_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address)
-  ensures that the highest valid bump, or canonical bump, is used for the
-  derivation, thus creating a deterministic way to find an address given
-  specific seeds.
-- Upon initialization, you can use Anchor's `seeds` and `bump` constraint to
-  ensure that PDA derivations in the account validation struct always use the
-  canonical bump
-- Anchor allows you to **specify a bump** with the `bump = <some_bump>`
-  constraint when verifying the address of a PDA
-- Because `find_program_address` can be expensive, best practice is to store the
-  derived bump in an account’s data field to be referenced later on when
-  re-deriving the address for verification
-  ```rust
-  #[derive(Accounts)]
-  pub struct VerifyAddress<'info> {
-  	#[account(
-      	seeds = [DATA_PDA_SEED.as_bytes()],
-  	    bump = data.bump
-  	)]
-  	data: Account<'info, Data>,
-  }
-  ```
+- The `create_program_address` function derives a PDA without using the canonical bump, potentially leading to security vulnerabilities.
+- Always use `find_program_address` to ensure the canonical bump is used for PDA derivation.
+- Anchor's `seeds` and `bump` constraints can automatically handle canonical bump usage for PDA initialization and verification.
+- Store the canonical bump in the account's data for efficient re-derivation in future instructions.
 
 ## Lesson
 
-Bump seeds are a number between 0 and 255, inclusive, used to ensure that an
-address derived using
-[`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address)
-is a valid PDA. The **canonical bump** is the highest bump value that produces a
-valid PDA. The standard in Solana is to _always use the canonical bump_ when
-deriving PDAs, both for security and convenience.
+Bump seeds are numbers between 0 and 255 used to ensure that an address derived using `create_program_address` is a valid PDA. The canonical bump is the highest valid bump value that produces a valid PDA. For security and consistency, always use the canonical bump when deriving PDAs.
 
-### Insecure PDA derivation using `create_program_address`
+### Insecure PDA derivation
 
-Given a set of seeds, the `create_program_address` function will produce a valid
-PDA about 50% of the time. The bump seed is an additional byte added as a seed
-to "bump" the derived address into valid territory. Since there are 256 possible
-bump seeds and the function produces valid PDAs approximately 50% of the time,
-there are many valid bumps for a given set of input seeds.
+The `create_program_address` function produces a valid PDA about 50% of the time. Multiple valid bumps can exist for a given set of input seeds, potentially causing security issues.
 
-You can imagine that this could cause confusion for locating accounts when using
-seeds as a way of mapping between known pieces of information to accounts. Using
-the canonical bump as the standard ensures that you can always find the right
-account. More importantly, it avoids security exploits caused by the open-ended
-nature of allowing multiple bumps.
+Here's an example of an insecure implementation:
 
-In the example below, the `set_value` instruction uses a `bump` that was passed
-in as instruction data to derive a PDA. The instruction then derives the PDA
-using `create_program_address` function and checks that the `address` matches
-the public key of the `data` account.
-
-```rust
+```
 use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
@@ -104,32 +64,19 @@ pub struct Data {
 }
 ```
 
-While the instruction derives the PDA and checks the passed-in account, which is
-good, it allows the caller to pass in an arbitrary bump. Depending on the
-context of your program, this could result in undesired behavior or potential
-exploit.
+While the instruction derives the PDA and checks the passed-in account, which is good, it allows the caller to pass in an arbitrary bump. Depending on the context of your program, this could result in undesired behavior or potential exploit.
 
-If the seed mapping was meant to enforce a one-to-one relationship between PDA
-and user, for example, this program would not properly enforce that. A user
-could call the program multiple times with many valid bumps, each producing a
-different PDA.
+If the seed mapping was meant to enforce a one-to-one relationship between PDA and user, for example, this program would not properly enforce that. A user could call the program multiple times with many valid bumps, each producing a different PDA.
 
 ### Recommended derivation using `find_program_address`
 
-A simple way around this problem is to have the program expect only the
-canonical bump and use `find_program_address` to derive the PDA.
+A simple way around this problem is to have the program expect only the canonical bump and use `find_program_address` to derive the PDA.
 
-The
-[`find_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address)
-_always uses the canonical bump_. This function iterates through calling
-`create_program_address`, starting with a bump of 255 and decrementing the bump
-by one with each iteration. As soon as a valid address is found, the function
-returns both the derived PDA and the canonical bump used to derive it.
+The `find_program_address` function always uses the canonical bump. It iterates through calling `create_program_address`, starting with a bump of 255 and decrementing the bump by one with each iteration. As soon as a valid address is found, the function returns both the derived PDA and the canonical bump used to derive it.
 
-This ensures a one-to-one mapping between your input seeds and the address they
-produce.
+This ensures a one-to-one mapping between your input seeds and the address they produce.
 
-```rust
+```
 pub fn set_value_secure(
     ctx: Context<BumpSeed>,
     key: u64,
@@ -151,17 +98,11 @@ pub fn set_value_secure(
 }
 ```
 
-### Use Anchor’s `seeds` and `bump` constraints
+### Use Anchor's `seeds` and `bump` constraints
 
-Anchor provides a convenient way to derive PDAs in the account validation struct
-using the `seeds` and `bump` constraints. These can even be combined with the
-`init` constraint to initialize the account at the intended address. To protect
-the program from the vulnerability we’ve been discussing throughout this lesson,
-Anchor does not even allow you to initialize an account at a PDA using anything
-but the canonical bump. Instead, it uses `find_program_address` to derive the
-PDA and subsequently performs the initialization.
+Anchor provides a convenient way to derive PDAs in the account validation struct using the `seeds` and `bump` constraints. These can even be combined with the `init` constraint to initialize the account at the intended address. To protect the program from the vulnerability we've been discussing throughout this lesson, Anchor does not even allow you to initialize an account at a PDA using anything but the canonical bump. Instead, it uses `find_program_address` to derive the PDA and subsequently performs the initialization.
 
-```rust
+```
 use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
@@ -200,24 +141,13 @@ pub struct Data {
 }
 ```
 
-If you aren't initializing an account, you can still validate PDAs with the
-`seeds` and `bump` constraints. This simply rederives the PDA and compares the
-derived address with the address of the account passed in.
+If you aren't initializing an account, you can still validate PDAs with the `seeds` and `bump` constraints. This simply rederives the PDA and compares the derived address with the address of the account passed in.
 
-In this scenario, Anchor _does_ allow you to specify the bump to use to derive
-the PDA with `bump = <some_bump>`. The intent here is not for you to use
-arbitrary bumps, but rather to let you optimize your program. The iterative
-nature of `find_program_address` makes it expensive, so best practice is to
-store the canonical bump in the PDA account's data upon initializing a PDA,
-allowing you to reference the bump stored when validating the PDA in subsequent
-instructions.
+In this scenario, Anchor _does_ allow you to specify the bump to use to derive the PDA with `bump = <some_bump>`. The intent here is not for you to use arbitrary bumps, but rather to let you optimize your program. The iterative nature of `find_program_address` makes it expensive, so best practice is to store the canonical bump in the PDA account's data upon initializing a PDA, allowing you to reference the bump stored when validating the PDA in subsequent instructions.
 
-When you specify the bump to use, Anchor uses `create_program_address` with the
-provided bump instead of `find_program_address`. This pattern of storing the
-bump in the account data ensures that your program always uses the canonical
-bump without degrading performance.
+When you specify the bump to use, Anchor uses `create_program_address` with the provided bump instead of `find_program_address`. This pattern of storing the bump in the account data ensures that your program always uses the canonical bump without degrading performance.
 
-```rust
+```
 use anchor_lang::prelude::*;
 
 declare_id!("CVwV9RoebTbmzsGg1uqU1s4a3LvTKseewZKmaNLSxTqc");
@@ -276,61 +206,40 @@ pub struct Data {
 }
 ```
 
-If you don't specify the bump on the `bump` constraint, Anchor will still use
-`find_program_address` to derive the PDA using the canonical bump. As a
-consequence, your instruction will incur a variable amount of compute budget.
-Programs that are already at risk of exceeding their compute budget should use
-this with care since there is a chance that the program’s budget may be
-occasionally and unpredictably exceeded.
+If you don't specify the bump on the `bump` constraint, Anchor will still use `find_program_address` to derive the PDA using the canonical bump. As a consequence, your instruction will incur a variable amount of compute budget. Programs that are already at risk of exceeding their compute budget should use this with care since there is a chance that the program's budget may be occasionally and unpredictably exceeded.
 
-On the other hand, if you only need to verify the address of a PDA passed in
-without initializing an account, you'll be forced to either let Anchor derive
-the canonical bump or expose your program to unecessary risks. In that case,
-please use the canonical bump despite the slight mark against performance.
+On the other hand, if you only need to verify the address of a PDA passed in without initializing an account, you'll be forced to either let Anchor derive the canonical bump or expose your program to unecessary risks. In that case, please use the canonical bump despite the slight mark against performance.
 
 ## Lab
 
-To demonstrate the security exploits possible when you don't check for the
-canonical bump, let's work with a program that lets each program user "claim"
-rewards on time.
+To demonstrate the security exploits possible when you don't check for the canonical bump, let's work with a program that lets each program user "claim" rewards on time.
 
 #### 1. Setup
 
-Start by getting the code on the `starter` branch of
-[this repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/starter).
+Start by getting the code on the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/starter).
 
-Notice that there are two instructions on the program and a single test in the
-`tests` directory.
+Notice that there are two instructions on the program and a single test in the `tests` directory.
 
 The instructions on the program are:
 
 1. `create_user_insecure`
 2. `claim_insecure`
 
-The `create_user_insecure` instruction simply creates a new account at a PDA
-derived using the signer's public key and a passed-in bump.
+The `create_user_insecure` instruction simply creates a new account at a PDA derived using the signer's public key and a passed-in bump.
 
-The `claim_insecure` instruction mints 10 tokens to the user and then marks the
-account's rewards as claimed so that they can't claim again.
+The `claim_insecure` instruction mints 10 tokens to the user and then marks the account's rewards as claimed so that they can't claim again.
 
-However, the program doesn't explicitly check that the PDAs in question are
-using the canonical bump.
+However, the program doesn't explicitly check that the PDAs in question are using the canonical bump.
 
 Have a look at the program to understand what it does before proceeding.
 
 #### 2. Test insecure instructions
 
-Since the instructions don't explicitly require the `user` PDA to use the
-canonical bump, an attacker can create multiple accounts per wallet and claim
-more rewards than should be allowed.
+Since the instructions don't explicitly require the `user` PDA to use the canonical bump, an attacker can create multiple accounts per wallet and claim more rewards than should be allowed.
 
-The test in the `tests` directory creates a new keypair called `attacker` to
-represent an attacker. It then loops through all possible bumps and calls
-`create_user_insecure` and `claim_insecure`. By the end, the test expects that
-the attacker has been able to claim rewards multiple times and has earned more
-than the 10 tokens allotted per user.
+The test in the `tests` directory creates a new keypair called `attacker` to represent an attacker. It then loops through all possible bumps and calls `create_user_insecure` and `claim_insecure`. By the end, the test expects that the attacker has been able to claim rewards multiple times and has earned more than the 10 tokens allotted per user.
 
-```typescript
+```
 it("Attacker can claim more than reward limit with insecure instructions", async () => {
   const attacker = Keypair.generate();
   await safeAirdrop(attacker.publicKey, provider.connection);
@@ -382,11 +291,9 @@ it("Attacker can claim more than reward limit with insecure instructions", async
 });
 ```
 
-Run `anchor test` to see that this test passes, showing that the attacker is
-successful. Since the test calles the instructions for every valid bump, it
-takes a bit to run, so be patient.
+Run `anchor test` to see that this test passes, showing that the attacker is successful. Since the test calles the instructions for every valid bump, it takes a bit to run, so be patient.
 
-```bash
+```
   bump-seed-canonicalization
 Attacker claimed 129 times and got 1290 tokens
     ✔ Attacker can claim more than reward limit with insecure instructions (133840ms)
@@ -399,11 +306,9 @@ Let's demonstrate patching the vulnerability by creating two new instructions:
 1. `create_user_secure`
 2. `claim_secure`
 
-Before we write the account validation or instruction logic, let's create a new
-user type, `UserSecure`. This new type will add the canonical bump as a field on
-the struct.
+Before we write the account validation or instruction logic, let's create a new user type, `UserSecure`. This new type will add the canonical bump as a field on the struct.
 
-```rust
+```
 #[account]
 pub struct UserSecure {
     auth: Pubkey,
@@ -412,11 +317,9 @@ pub struct UserSecure {
 }
 ```
 
-Next, let's create account validation structs for each of the new instructions.
-They'll be very similar to the insecure versions but will let Anchor handle the
-derivation and deserialization of the PDAs.
+Next, let's create account validation structs for each of the new instructions. They'll be very similar to the insecure versions but will let Anchor handle the derivation and deserialization of the PDAs.
 
-```rust
+```
 #[derive(Accounts)]
 pub struct CreateUserSecure<'info> {
     #[account(mut)]
@@ -463,11 +366,9 @@ pub struct SecureClaim<'info> {
 }
 ```
 
-Finally, let's implement the instruction logic for the two new instructions. The
-`create_user_secure` instruction simply needs to set the `auth`, `bump` and
-`rewards_claimed` fields on the `user` account data.
+Finally, let's implement the instruction logic for the two new instructions. The `create_user_secure` instruction simply needs to set the `auth`, `bump` and `rewards_claimed` fields on the `user` account data.
 
-```rust
+```
 pub fn create_user_secure(ctx: Context<CreateUserSecure>) -> Result<()> {
     ctx.accounts.user.auth = ctx.accounts.payer.key();
     ctx.accounts.user.bump = *ctx.bumps.get("user").unwrap();
@@ -476,10 +377,9 @@ pub fn create_user_secure(ctx: Context<CreateUserSecure>) -> Result<()> {
 }
 ```
 
-The `claim_secure` instruction needs to mint 10 tokens to the user and set the
-`user` account's `rewards_claimed` field to `true`.
+The `claim_secure` instruction needs to mint 10 tokens to the user and set the `user` account's `rewards_claimed` field to `true`.
 
-```rust
+```
 pub fn claim_secure(ctx: Context<SecureClaim>) -> Result<()> {
     token::mint_to(
         CpiContext::new_with_signer(
@@ -505,16 +405,11 @@ pub fn claim_secure(ctx: Context<SecureClaim>) -> Result<()> {
 
 #### 4. Test secure instructions
 
-Let's go ahead and write a test to show that the attacker can no longer claim
-more than once using the new instructions.
+Let's go ahead and write a test to show that the attacker can no longer claim more than once using the new instructions.
 
-Notice that if you start to loop through using multiple PDAs like the old test,
-you can't even pass the non-canonical bump to the instructions. However, you can
-still loop through using the various PDAs and at the end check that only 1 claim
-happened for a total of 10 tokens. Your final test will look something like
-this:
+Notice that if you start to loop through using multiple PDAs like the old test, you can't even pass the non-canonical bump to the instructions. However, you can still loop through using the various PDAs and at the end check that only 1 claim happened for a total of 10 tokens. Your final test will look something like this:
 
-```typescript
+```
 it.only("Attacker can only claim once with secure instructions", async () => {
   const attacker = Keypair.generate();
   await safeAirdrop(attacker.publicKey, provider.connection);
@@ -582,33 +477,25 @@ it.only("Attacker can only claim once with secure instructions", async () => {
 });
 ```
 
-```bash
+```
   bump-seed-canonicalization
 Attacker claimed 119 times and got 1190 tokens
     ✔ Attacker can claim more than reward limit with insecure instructions (128493ms)
     ✔ Attacker can only claim once with secure instructions (1448ms)
 ```
 
-If you use Anchor for all of the PDA derivations, this particular exploit is
-pretty simple to avoid. However, if you end up doing anything "non-standard," be
-careful to design your program to explicitly use the canonical bump!
+If you use Anchor for all of the PDA derivations, this particular exploit is pretty simple to avoid. However, if you end up doing anything "non-standard," be careful to design your program to explicitly use the canonical bump!
 
-If you want to take a look at the final solution code you can find it on the
-`solution` branch of
-[the same repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/solution).
+If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/solution).
 
 ## Challenge
 
-Just as with other lessons in this unit, your opportunity to practice avoiding
-this security exploit lies in auditing your own or other programs.
+Just as with other lessons in this unit, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
 
-Take some time to review at least one program and ensure that all PDA
-derivations and checks are using the canonical bump.
+Take some time to review at least one program and ensure that all PDA derivations and checks are using the canonical bump.
 
-Remember, if you find a bug or exploit in somebody else's program, please alert
-them! If you find one in your own program, be sure to patch it right away.
+Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.
 
 <Callout type="success" title="Completed the lab?">
-Push your code to GitHub and
-[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=d3f6ca7a-11c8-421f-b7a3-d6c08ef1aa8b)!
+Push your code to GitHub and [tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=d3f6ca7a-11c8-421f-b7a3-d6c08ef1aa8b)!
 </Callout>

--- a/content/courses/program-security/bump-seed-canonicalization.md
+++ b/content/courses/program-security/bump-seed-canonicalization.md
@@ -34,7 +34,7 @@ tags:
 - Anchor allows you to **specify a bump** with the `bump = <some_bump>`
   constraint when verifying the address of a PDA
 - Because `find_program_address` can be expensive, best practice is to store the
-  derived bump in an account’s data field to be referenced later on when
+  derived bump in an account's data field to be referenced later on when
   re-deriving the address for verification
   ```rust
   #[derive(Accounts)]

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -229,8 +229,7 @@ library.
 ### Install Node.js
 
 To use node in WSL2 on Windows, please follow this  
-[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl) to
-install node.
+[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl).
 
 ```shell
 sudo apt-get install curl

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -229,7 +229,8 @@ library.
 ### Install Node.js
 
 To use node in WSL2 on Windows, please follow this  
-[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl) to install node.
+[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl) to
+install node.
 
 ```shell
 sudo apt-get install curl

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -229,8 +229,7 @@ library.
 ### Install Node.js
 
 To use node in WSL2 on Windows, please follow this  
-[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl) to
-install node.
+[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl) to install node.
 
 ```shell
 sudo apt-get install curl

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -229,8 +229,8 @@ library.
 ### Install Node.js
 
 To use node in WSL2 on Windows, please follow this  
-[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl)
-to install node.
+[guide to installing node in WSL2](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl) to
+install node.
 
 ```shell
 sudo apt-get install curl

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -37,8 +37,7 @@ with README files that explain you how to run the different examples. Most
 examples are self-contained and are available in native Rust (ie, with no
 framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
-that we would love to
-[see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
+that we would love to [see as contributions].
 
 Within the repo you will find the following subfolder, each with assorted
 example programs within them:

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -37,7 +37,8 @@ with README files that explain you how to run the different examples. Most
 examples are self-contained and are available in native Rust (ie, with no
 framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
-that we would love to [see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see). 
+that we would love to
+[see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
 
 Within the repo you will find the following subfolder, each with assorted
 example programs within them:

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -37,8 +37,7 @@ with README files that explain you how to run the different examples. Most
 examples are self-contained and are available in native Rust (ie, with no
 framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
-that we would love to
-[see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
+that we would love to [see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
 
 Within the repo you will find the following subfolder, each with assorted
 example programs within them:

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -26,7 +26,8 @@ keywords:
   - anchor
 ---
 
-The "[Solana Program Examples](https://github.com/solana-developers/program-examples)"
+The
+"[Solana Program Examples](https://github.com/solana-developers/program-examples)"
 repository on GitHub offers several subfolders, each containing code examples
 for different Solana programming paradigms and languages, designed to help
 developers learn and experiment with Solana blockchain development.
@@ -37,9 +38,10 @@ examples are self-contained and are available in native Rust (ie, with no
 framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
 that we would love to
-[see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).  
+[see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
 
-Within the repo you will find the following subfolder, each with assorted example programs within them:
+Within the repo you will find the following subfolder, each with assorted
+example programs within them:
 
 - [Basics](#basics)
 - [Compression](#compression)

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -37,7 +37,8 @@ with README files that explain you how to run the different examples. Most
 examples are self-contained and are available in native Rust (ie, with no
 framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
-that we would love to [see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
+that we would love to
+[see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).
 
 Within the repo you will find the following subfolder, each with assorted
 example programs within them:

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -39,8 +39,9 @@ framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
 that we would love to
 [see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).  
-Within the repo you will find the following subfolder, each with assorted
-example programs within them:
+Within
+the repo you will find the following subfolder, each with assorted example
+programs within them:
 
 - [Basics](#basics)
 - [Compression](#compression)

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -37,7 +37,7 @@ with README files that explain you how to run the different examples. Most
 examples are self-contained and are available in native Rust (ie, with no
 framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
-that we would love to [see as contributions].
+that we would love to [see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see). 
 
 Within the repo you will find the following subfolder, each with assorted
 example programs within them:

--- a/docs/programs/examples.md
+++ b/docs/programs/examples.md
@@ -26,8 +26,7 @@ keywords:
   - anchor
 ---
 
-The
-"[Solana Program Examples](https://github.com/solana-developers/program-examples)"
+The "[Solana Program Examples](https://github.com/solana-developers/program-examples)"
 repository on GitHub offers several subfolders, each containing code examples
 for different Solana programming paradigms and languages, designed to help
 developers learn and experiment with Solana blockchain development.
@@ -39,9 +38,8 @@ framework), [Anchor](https://www.anchor-lang.com/docs/installation),
 [Seahorse](https://seahorse-lang.org/) and it also contains a list of examples
 that we would love to
 [see as contributions](https://github.com/solana-developers/program-examples?tab=readme-ov-file#examples-wed-love-to-see).  
-Within
-the repo you will find the following subfolder, each with assorted example
-programs within them:
+
+Within the repo you will find the following subfolder, each with assorted example programs within them:
 
 - [Basics](#basics)
 - [Compression](#compression)


### PR DESCRIPTION
# Summary of Changes: Bump Seed Canonicalization

## Frontmatter
- **Added** `keywords` and `tags` fields in the new version.
- **Removed** `objectives` field in the new version.

## Summary Section
- **Updated** the summary to be more concise and focused on the key points.

## Lesson Section
- **Expanded** explanation of bump seeds and canonical bumps.
- **Added** detailed examples of insecure and secure PDA derivation.
- **Included** code examples for both insecure and secure implementations.
- **Added** explanation of using Anchor's `seeds` and `bump` constraints.

## Code Examples
- **Added** code examples for:
  - Insecure PDA derivation using `create_program_address`.
  - Secure PDA derivation using `find_program_address`.
  - Using Anchor's `seeds` and `bump` constraints.

## Test Section
- **Added** a detailed test example to show how the secure implementation prevents multiple claims.

## Challenge Section
- **Added** a challenge section encouraging users to audit their own or others' programs for proper PDA derivation.

## Callout Section
- **Added** a callout section prompting users to push their code to GitHub and provide feedback.