### PR TITLE
fix: wrong parameter for revoke instruction

### DIFF
--- a/content/courses/tokens-and-nfts/token-program-advanced.md
+++ b/content/courses/tokens-and-nfts/token-program-advanced.md
@@ -250,7 +250,7 @@ All we will need for this function is the token account and user. After the
 const revokeTransactionSignature = await revoke(
   connection,
   user,
-  delegate,
+  sourceTokenAccount.address,
   user.publicKey,
 );
 


### PR DESCRIPTION
### Problem
spl-token revoke instruction requires tokenAccount address which was confused with delegate address
```console
Revoke approval for the transfer of tokens from an account

@param connection — Connection to use

@param payer — Payer of the transaction fees

@param account — Address of the token account

@param owner — Owner of the account
```
### Summary of Changes
i have replaced **delegate address** with  **sourceTokenAccount.address**


Fixes #
provided right tokenAccount address
<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->