### PR TITLE
Fixing misnamed field in `getRecentPerformanceSamples` return data

### DIFF
--- a/docs/rpc/http/getRecentPerformanceSamples.mdx
+++ b/docs/rpc/http/getRecentPerformanceSamples.mdx
@@ -31,14 +31,14 @@ An array of `RpcPerfSample<object>` with the following fields:
   period
 - `numSlots: <u64>` - Number of slots completed during the sample period
 - `samplePeriodSecs: <u16>` - Number of seconds in a sample window
-- `numNonVoteTransaction: <u64>` - Number of non-vote transactions processed
+- `numNonVoteTransactions: <u64>` - Number of non-vote transactions processed
   during the sample period.
 
 <Callout type={"info"}>
-  `numNonVoteTransaction` is present starting with v1.15. To get a number of
+  `numNonVoteTransactions` is present starting with v1.15. To get a number of
   voting transactions compute:
   <br />
-  `numTransactions - numNonVoteTransaction`
+  `numTransactions - numNonVoteTransactions`
 </Callout>
 
 </DocLeftSide>
@@ -65,28 +65,28 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
     {
       "numSlots": 126,
       "numTransactions": 126,
-      "numNonVoteTransaction": 1,
+      "numNonVoteTransactions": 1,
       "samplePeriodSecs": 60,
       "slot": 348125
     },
     {
       "numSlots": 126,
       "numTransactions": 126,
-      "numNonVoteTransaction": 1,
+      "numNonVoteTransactions": 1,
       "samplePeriodSecs": 60,
       "slot": 347999
     },
     {
       "numSlots": 125,
       "numTransactions": 125,
-      "numNonVoteTransaction": 0,
+      "numNonVoteTransactions": 0,
       "samplePeriodSecs": 60,
       "slot": 347873
     },
     {
       "numSlots": 125,
       "numTransactions": 125,
-      "numNonVoteTransaction": 0,
+      "numNonVoteTransactions": 0,
       "samplePeriodSecs": 60,
       "slot": 347748
     }


### PR DESCRIPTION
### Problem

The docs for the `getRecentPerformanceSamples` method include a return field of `numNonVoteTransaction`. The correct field is `numNonVoteTransactions` (with an "s").

The error also currently exists in the `solana-web3.js` repo, see https://github.com/solana-labs/solana-web3.js/pull/3202

You can confirm the correct fields with:

```sh
curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -s \
   -d '{"jsonrpc":"2.0", "id":1,"method": "getRecentPerformanceSamples","params": [1]}'
```
Returns..

```js
{
  "jsonrpc": "2.0",
  "result": [
    {
      "numNonVoteTransactions": 850,  // <--- 👀
      "numSlots": 163,
      "numTransactions": 2792,
      "samplePeriodSecs": 60,
      "slot": 323584907
    }
  ],
  "id": 1
}
````

### Summary of Changes

Fixing misnamed field in the return data for the `getRecentPerformanceSamples` method.
