### PR TITLE
Fix INIT_SPACE typo

### DIFF
--- a/content/courses/onchain-development/anchor-pdas.md
+++ b/content/courses/onchain-development/anchor-pdas.md
@@ -599,7 +599,7 @@ pub struct AddMovieReview<'info> {
         seeds = [title.as_bytes(), initializer.key().as_ref()],
         bump,
         payer = initializer,
-        space = DISCRIMINATOR + MovieAccountState::INIT_SOACE
+        space = DISCRIMINATOR + MovieAccountState::INIT_SPACE
     )]
     pub movie_review: Account<'info, MovieAccountState>,
     #[account(mut)]
@@ -674,7 +674,7 @@ pub struct UpdateMovieReview<'info> {
         mut,
         seeds = [title.as_bytes(), initializer.key().as_ref()],
         bump,
-        realloc = DISCRIMINATOR + MovieAccountState::INIT_SOACE
+        realloc = DISCRIMINATOR + MovieAccountState::INIT_SPACE
         realloc::payer = initializer,
         realloc::zero = true,
     )]


### PR DESCRIPTION
### Problem
Commit 14155b1ffd7341edd4190a77cfe142b05e7c7b00 introduced a typo in the 
`anchor_movie_review_program` making the code unable to compile.

### Summary of Changes
Replace `MovieAccountState::INIT_SOACE` by `MovieAccountState::INIT_SPACE`