### PR TITLE
Update installation page to include solution to common install error

### DIFF
--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -306,6 +306,42 @@ You should see output similar to the following:
 anchor-cli 0.30.1
 ```
 
+If you encounter the error `type annotations needed for Box<_>` when installing
+the Anchor CLI, try changing your Rust version to 1.79.0 and attempt the
+installation again.
+
+<Accordion>
+<AccordionItem title="error[E0282]: type annotations needed for `Box<_>`">
+
+```
+   Compiling time v0.3.29
+error[E0282]: type annotations needed for `Box<_>`
+  --> /home/x/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.29/src/format_description/parse/mod.rs:83:9
+   |
+83 |     let items = format_items
+   |         ^^^^^
+...
+86 |     Ok(items.into())
+   |              ---- type must be known at this point
+   |
+help: consider giving `items` an explicit type, where the placeholders `_` are specified
+   |
+83 |     let items: Box<_> = format_items
+   |              ++++++++
+```
+
+You can find more context regarding this error
+[here](https://github.com/coral-xyz/anchor/pull/3143)
+
+</AccordionItem>
+</Accordion>
+
+Run the following command to install Rust 1.79.0:
+
+```shell
+rustup default 1.79.0
+```
+
 When installing the Anchor CLI on Linux or WSL, you may encounter this error:
 
 ```
@@ -382,6 +418,29 @@ You should the following output:
 
 </AccordionItem>
 </Accordion>
+
+When running `anchor build`, if you encounter `error: not a directory` similar
+following:
+
+```
+error: not a directory: '.../solana-release/bin/sdk/sbf/dependencies/platform-tools/rust/lib'
+```
+
+Try these solutions:
+
+1. Force install using the following command:
+
+```shell
+cargo build-sbf --force-tools-install
+```
+
+2. If the above doesn't work, clear the Solana cache:
+
+```shell
+rm -rf ~/.cache/solana/*
+```
+
+After applying either solution, attempt to run `anchor build` again.
 
 If you are on Linux or WSL and encounter the following errors when running
 `anchor test` after creating a new Anchor project, it's may be due to missing


### PR DESCRIPTION
- Add recommendation to change rust version to <1.80 if encounter `error[E0282]: type annotations needed for Box<_>`
https://github.com/coral-xyz/anchor/pull/3143
- Add recommended solution if solana platform tool installation fails and causes `error: not a directory:`
 https://solana.stackexchange.com/questions/13174/anchor-build-fail-due-to-no-platform-tools-rust-lib