### PR TITLE
Fix syntax error in UpdateMovieReview struct: Add missing comma after realloc attribute

### DIFF
--- a/content/courses/onchain-development/anchor-pdas.md
+++ b/content/courses/onchain-development/anchor-pdas.md
@@ -5,7 +5,7 @@ objectives:
   - Enable and use the `init_if_needed` constraint
   - Use the `realloc` constraint to reallocate space on an existing account
   - Use the `close` constraint to close an existing account
-description:
+description: 
   "Store arbitrary data on Solana, using PDAs, an inbuilt key-value store."
 ---
 
@@ -674,7 +674,7 @@ pub struct UpdateMovieReview<'info> {
         mut,
         seeds = [title.as_bytes(), initializer.key().as_ref()],
         bump,
-        realloc = DISCRIMINATOR + MovieAccountState::INIT_SPACE
+        realloc = DISCRIMINATOR + MovieAccountState::INIT_SPACE,
         realloc::payer = initializer,
         realloc::zero = true,
     )]


### PR DESCRIPTION
Fix UpdateMovieReview struct: Add missing comma in account attribute

### Problem

The UpdateMovieReview struct in the movie review system contained a syntax error in the #[account] attribute macro. A missing comma after the 'realloc' parameter caused the following compiler error:
```shell
error: expected non-macro attribute, found attribute macro `account`
```
This error prevented the code from compiling and blocked the proper functioning of the movie review update process.


### Summary of Changes
Added a missing comma in the #[account] attribute macro of the UpdateMovieReview struct, specifically after the 'realloc' parameter. This ensures all parameters within the attribute are properly separated.

Fixes 
Resolves the compiler error by correcting the syntax in the #[account] attribute.
-Allows the code to compile successfully.
-Enables the correct reallocation of account space and assignment of the reallocation payer in the UpdateMovieReview struct.
-Restores the intended functionality of the movie review update process in the system.

The corrected code now looks like this:
```rust
#[account(
    mut,
    seeds = [title.as_bytes(), initializer.key().as_ref()],
    bump,
    realloc = DISCRIMINATOR + MovieAccountState::INIT_SPACE,
    realloc::payer = initializer,
    realloc::zero = true,
)]
```
This fix maintains the intended structure and functionality of the UpdateMovieReview struct while resolving the syntax issue.

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->