### PR TITLE
Update local-setup.md

### DIFF
--- a/content/courses/onchain-development/local-setup.md
+++ b/content/courses/onchain-development/local-setup.md
@@ -144,7 +144,8 @@ re-run `anchor test`.
 If you are running `solana-test-validator`, you may encounter the error
 `Error: Your configured rpc port: 8899 is already in use` when running
 `anchor test`. To resolve this, stop the `solana-test-validator` before running
-`anchor test`.
+`anchor test`or if you are unable to find solana-test-validator just run folllowing command 
+in your linux terminal to stop service running on that port `sudo kill -9 $(sudo lsof -t -i :port_number)`.
 
 #### All done?
 


### PR DESCRIPTION
Added a troubleshooting step for users who are unable to find 'solana-test-validator' .  This will help free up the port if it's already in use, allowing the Solana test validator to run successfully.

### Problem
some users are not able to find the services to killthem


### Summary of Changes



Fixes #
it find servies on port by lsof and end them by kill command.

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->