### PR TITLE
Fix a typo in anchor-pdas.md

### DIFF
--- a/content/courses/onchain-development/anchor-pdas.md
+++ b/content/courses/onchain-development/anchor-pdas.md
@@ -35,7 +35,7 @@ handle PDAs, reallocate space, and close accounts.
 
 ### PDAs with Anchor
 
-PDAs store data, at addressed specified by the onchain programmer, using a list
+PDAs store data, at addresses specified by the onchain programmer, using a list
 of seeds, a bump seed, and a program ID.
 
 Anchor provides a convenient way to validate a PDA with the `seeds` and `bump`


### PR DESCRIPTION
### Problem

PDAs store data, at addressed specified by the onchain programmer, using a list of seeds, a bump seed, and a program ID.

Addressed should instead be "addresses".


### Summary of Changes

Changed "addressed" to "addresses"

