### PR TITLE
Edit: link: Anchor Multiple Files Template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ yarn prettier
   ask them to run `anchor keys sync`.
 
 - Use the
-  [multiple files template](https://www.anchor-lang.com/docs/release-notes#multiple-files-template)
+  [multiple files template](https://www.anchor-lang.com/release-notes/0.29.0#multiple-files-template)
   to organize very large Anchor projects.
 
 ### Heading styles


### PR DESCRIPTION
Old link is dead, updated with new location.

### Problem

Clicking the existing link for Multiple Files Template in CONTRIBUTING.md leads to a 404 page in Anchor's docs. 

### Summary of Changes

Searched for Multiple Files Template in Anchor's docs, found the only link that seemed to have relevant data, and updated existing CONTRIBUTING.md Anchor Multiple Files Template link with the working link. 

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->