### PR TITLE
Remove deprecated link to nonexistent VSCode Grammarly extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,7 @@ In particular:
   and save the person reviewing your PR some time. We recommend
   [Grammarly](https://grammarly.com/). In
   [your Grammarly dictionary](https://account.grammarly.com/customize), you may
-  wish to add Solana-specific words like `lamport`, `blockhash`, etc. For VScode
-  users, there is a
-  [VScode extension for Grammarly](https://marketplace.visualstudio.com/items?itemName=znck.grammarly).
+  wish to add Solana-specific words like `lamport`, `blockhash`, etc.
 - Use US English rather than British English. Grammarly will catch this for you.
 - Use 'onchain' (not on-chain, definitely not smart contract) when referring to
   onchain apps. This comes from the Solana Foundation style guide, and is


### PR DESCRIPTION
### Problem

the link no longer works; further research shows LTex is a sub-par alternative users don't enjoy, but I'm not sure if there are any other options for VSCode users. 

https://www.reddit.com/r/vscode/comments/1crtdg8/grammarly_extension_removed/

### Summary of Changes

Remove dead link.

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->