### PR TITLE
Replace "secret key" with "private key" for web3.js ecosystem cohesion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,14 +58,12 @@ In particular:
 - Use the terms 'blockchain' or 'web3' rather than 'crypto'.
 - Use 'SOL' rather than 'Sol' to refer to Solana's native token. Don't call the
   native token 'Solana'!
-- Use 'secret key' rather than 'private key' to be consistent with web3.js.
-  **Note**: this will change in a future version of web3.js, but right now the
-  ecosystem uses 'secret key'.
-- Use 'wallet app' for software. 'wallet' for the address that holds value, to
+- Use 'private key' rather than 'secret key' to be consistent with the current web3.js ecosystem.
+- Use 'wallet app' for software, and 'wallet' for the address that holds value, to
   avoid confusion between these two concepts.
 - PDAs are not public keys. It is not possible to have a public key without a
-  secret key. A public key is derived from a secret key, and it is not possible
-  to generate a public key without first generating a secret key.
+  private key. A public key is derived from a private key, and it is not possible
+  to generate a public key without first generating a private key.
 - Be careful about the term 'token account'. A
   ['token account' is any account formatted to hold tokens](https://solana.stackexchange.com/questions/7507/what-is-the-difference-between-a-token-account-and-an-associated-token-account),
   and being specific (rather than, for example, swapping between 'associated


### PR DESCRIPTION
### Problem

My apologies if this is an unwarranted PR. 

I checked this link: https://web3js.readthedocs.io/en/v1.10.0/search.html?q=private&check_keywords=yes&area=default

It seems there are no references to "secret keys" in the ecosystem anymore, so would it make sense to update these docs as well? Or not, because https://solana-labs.github.io/solana-web3.js/classes/Keypair.html @solana/web3.js still uses secretKey?

In that case, should I revert the changes to "secret key", and instead specify the ecosystem as @solana/web3.js? I realize that it's obviously referring to the Solana ecosystem, but it feels a little ambiguous since there's the Ethereum web3.js that could also be considered as part of the ecosystem. 

### Summary of Changes

1. Replace references to "secret key" with "private key". 
2. Adjust punctuation in following sentence to avoid fragments. 

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->