### PR TITLE
Add apostrophe to inanimate possessive object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ In particular:
   have `instruction handlers` that process `instructions`. Do not refer to
   [instruction handlers](https://solana.com/docs/terminology#instruction-handler)
   as instructions! The reason is simple: an instruction cannot process an
-  instruction. The `multiple` template in Anchor also calls the functions
+  instruction. The `multiple` template in Anchor also calls the function's
   `handler`.
 
 ### Code


### PR DESCRIPTION
### Problem

Lines 78 - 80 of CONTRIBUTING.md state: 

 Use apostrophes of possession,
    [including for inanimate objects](https://english.stackexchange.com/questions/1031/is-using-the-possessive-s-correct-in-the-cars-antenna).
    Eg 'the account's balance' is correct.


_But_ lines 87 - 88 seem to be missing the possessive apostrophe for "functions handler."

### Summary of Changes

Add possessive apostrophe for "function's handler," assuming that functions in Anchor are defined in a way that specifies how to handle the instructions sent from clients. However, I am not certain that I am interpreting the documentation accurately, and the existing "functions handler" might be contextually accurate.  

Maybe it would be clearer to say something like, "The `multiple files template` in Anchor also calls each defined function's respective `handler`." 

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->