### PR TITLE
Fix a single typo

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -196,7 +196,7 @@ import idl from "./idl.json";
 
 You would _ideally_ also require types for the IDL which would make it easier to
 interact with the program. The types can be found at `/target/types` folder
-after you have build your program. Here are the types for the above IDL which
+after you have built your program. Here are the types for the above IDL which
 when you notice has the exact same structure as the IDL but are just as type
 helper.
 


### PR DESCRIPTION
### Problem

"build" is the command to build a project, but the correct tense in the context of that sentence would be "built"

### Summary of Changes

replace "build" with "built" for grammatical clarity. 

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->