### PR TITLE
Fix typo: Change "species" to "specifies" in intro-to-anchor-frontend.md 

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -156,7 +156,7 @@ have been added in anchor 0.30.0
 
 This program contains two instructions (`initialize` and `increment`).
 
-Notice that in addition to specifying the instructions, it species the accounts
+Notice that in addition to specifying the instructions, it specifies the accounts
 and inputs for each instruction. The `initialize` instruction requires three
 accounts:
 


### PR DESCRIPTION


### Problem
There is a typo in the documentation where "species" is used instead of "specifies". This incorrect word usage could lead to confusion for readers.


### Summary of Changes
Replace "species" with "specifies"


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->