### PR TITLE
Fix typo: Change "species" to "specifies" in documentation

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -154,7 +154,7 @@ counter program you built previously:
 Inspecting the IDL, you can see the `programId` and the `metadata` object which
 have been added in anchor 0.30.0
 
-This program contains two instructions (`initialize` and `increment`).
+This program contains two instruction handlers, `initialize` and `increment`.
 
 Notice that in addition to specifying the instructions, it specifies the
 accounts and inputs for each instruction. The `initialize` instruction requires

--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -156,7 +156,7 @@ have been added in anchor 0.30.0
 
 This program contains two instructions (`initialize` and `increment`).
 
-Notice that in addition to specifying the instructions, it species the accounts
+Notice that in addition to specifying the instructions, it specifies the accounts
 and inputs for each instruction. The `initialize` instruction requires three
 accounts:
 

--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -156,7 +156,7 @@ have been added in anchor 0.30.0
 
 This program contains two instruction handlers, `initialize` and `increment`.
 
-Notice that in addition to specifying the instructions, it specifies the
+Notice that in addition to specifying the instruction handlers, it specifies the
 accounts and inputs for each instruction. The `initialize` instruction requires
 three accounts:
 

--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -156,9 +156,9 @@ have been added in anchor 0.30.0
 
 This program contains two instructions (`initialize` and `increment`).
 
-Notice that in addition to specifying the instructions, it specifies the accounts
-and inputs for each instruction. The `initialize` instruction requires three
-accounts:
+Notice that in addition to specifying the instructions, it specifies the
+accounts and inputs for each instruction. The `initialize` instruction requires
+three accounts:
 
 1. `counter` - the new account being initialized in the instruction
 2. `user` - the payer for the transaction and initialization


### PR DESCRIPTION
### Problem
There is a typo in the documentation where "species" is used instead of "specifies". This incorrect word usage could lead to confusion for readers.


### Summary of Changes
The word "species" has been changed to "specifies" to correct the typo and improve clarity.


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->