### PR TITLE
fix and improve program-configuration course

### DIFF
--- a/content/courses/tokens-and-nfts/token-program.md
+++ b/content/courses/tokens-and-nfts/token-program.md
@@ -28,7 +28,7 @@ description:
 - Creating Token Mints and Token Accounts requires allocating **rent** in SOL.
   The rent for a Token Account can be refunded when the account is closed.
   Additionally, tokens created with the
-  [Token Extensions Program](/developers/courses/token-extensions-for-mints/close-mint)
+  [Token Extensions Program](/content/courses/token-extensions/close-mint)
   can also close Token Mints.
 
 ### Lesson

--- a/content/courses/tokens-and-nfts/token-program.md
+++ b/content/courses/tokens-and-nfts/token-program.md
@@ -28,7 +28,7 @@ description:
 - Creating Token Mints and Token Accounts requires allocating **rent** in SOL.
   The rent for a Token Account can be refunded when the account is closed.
   Additionally, tokens created with the
-  [Token Extensions Program](/content/courses/token-extensions/close-mint)
+  [Token Extensions Program](/developers/courses/token-extensions-for-mints/close-mint)
   can also close Token Mints.
 
 ### Lesson


### PR DESCRIPTION
### Problem

The error message is not expected in the section "Run the existing test" section.
The "--skip-deploy" option for the test command anchor test is required as the deploy function is found in the typescript. anchor test will deploy the program with program_data's upgrade_authority_address set to system program (11111111111111111111111111111111), which results in an error while running the test case "Initialize Admin config should be successfully" . Deploying the program by the typescript function deploy will set the program_data's upgrade_authority_address to the wallet used.
The course has included the challenging content.

### Summary of Changes

Update the correct error message in the section "Run the existing test".
Add “--skip-deploy” to the test command.
Delete an unnecessary setup in the section "Adding a `local-testing` feature".
Remove the challenge section.

**Also, I made a [PR](https://github.com/Unboxed-Software/solana-admin-instructions/pull/1) for [solana-admin-instructions](https://github.com/Unboxed-Software/solana-admin-instructions/tree/starter) starter branch and a [PR](https://github.com/Unboxed-Software/solana-admin-instructions/pull/2) for [solana-admin-instructions](https://github.com/Unboxed-Software/solana-admin-instructions/tree/solution) solution branch
which must be synced with this PR.**

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->