### PR TITLE
Updated fromPubkey to use PublicKey in the transfer instruction

### DIFF
--- a/content/courses/solana-pay/solana-pay.md
+++ b/content/courses/solana-pay/solana-pay.md
@@ -235,11 +235,15 @@ async function post(req: PublicKey, res: PublicKey) {
     feePayer: account,
   });
 
-  const instruction = SystemProgram.transfer({
-    fromPubkey: account,
+    const instruction = SystemProgram.transfer({
+   -  fromPubkey: account,
+   +  fromPubkey: new PublicKey(account),
     toPubkey: Keypair.generate().publicKey,
     lamports: 0.001 * LAMPORTS_PER_SOL,
-  });
+    });
+
+
+  
 
   transaction.add(instruction);
 

--- a/content/courses/solana-pay/solana-pay.md
+++ b/content/courses/solana-pay/solana-pay.md
@@ -235,7 +235,7 @@ async function post(req: PublicKey, res: PublicKey) {
     feePayer: account,
   });
 
-    const instruction = SystemProgram.transfer({
+  const instruction = SystemProgram.transfer({
     fromPubkey: new PublicKey(account),
     toPubkey: Keypair.generate().publicKey,
     lamports: 0.001 * LAMPORTS_PER_SOL,

--- a/content/courses/solana-pay/solana-pay.md
+++ b/content/courses/solana-pay/solana-pay.md
@@ -239,10 +239,7 @@ async function post(req: PublicKey, res: PublicKey) {
     fromPubkey: new PublicKey(account),
     toPubkey: Keypair.generate().publicKey,
     lamports: 0.001 * LAMPORTS_PER_SOL,
-    });
-
-
-  
+  }); 
 
   transaction.add(instruction);
 

--- a/content/courses/solana-pay/solana-pay.md
+++ b/content/courses/solana-pay/solana-pay.md
@@ -236,8 +236,7 @@ async function post(req: PublicKey, res: PublicKey) {
   });
 
     const instruction = SystemProgram.transfer({
-   -  fromPubkey: account,
-   +  fromPubkey: new PublicKey(account),
+    fromPubkey: new PublicKey(account),
     toPubkey: Keypair.generate().publicKey,
     lamports: 0.001 * LAMPORTS_PER_SOL,
     });


### PR DESCRIPTION
### Changes Made
- Changed `fromPubkey: account` to `fromPubkey: new PublicKey(account)` to ensure proper handling of the public key.

### Reason for Change
Using `new PublicKey(account)` ensures that the account variable is properly converted to a PublicKey instance, preventing potential issues with the transfer instruction.