### PR TITLE
[docs/rpc] fix: required field on `getTokenAccountsByOwner`

### DIFF
--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -121,9 +121,9 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
     "id": 1,
     "method": "getTokenAccountsByOwner",
     "params": [
-      "4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F",
+      "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd",
       {
-        "mint": "3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E"
+        "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
       },
       {
         "encoding": "jsonParsed"

--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -137,52 +137,74 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 
 ```json
 {
+  "id": 1,
   "jsonrpc": "2.0",
   "result": {
     "context": {
-      "slot": 1114
+      "apiVersion": "2.0.8",
+      "slot": 329669901
     },
     "value": [
       {
         "account": {
           "data": {
-            "program": "spl-token",
             "parsed": {
-              "accountType": "account",
               "info": {
-                "tokenAmount": {
-                  "amount": "1",
-                  "decimals": 1,
-                  "uiAmount": 0.1,
-                  "uiAmountString": "0.1"
-                },
-                "delegate": "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T",
-                "delegatedAmount": {
-                  "amount": "1",
-                  "decimals": 1,
-                  "uiAmount": 0.1,
-                  "uiAmountString": "0.1"
-                },
-                "state": "initialized",
                 "isNative": false,
-                "mint": "3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E",
-                "owner": "4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"
+                "mint": "BejB75Gmq8btLboHx7yffWcurHVBv5xvKcnY1fBYxnvf",
+                "owner": "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd",
+                "state": "initialized",
+                "tokenAmount": {
+                  "amount": "10000000000000",
+                  "decimals": 9,
+                  "uiAmount": 10000,
+                  "uiAmountString": "10000"
+                }
               },
               "type": "account"
             },
+            "program": "spl-token",
             "space": 165
           },
           "executable": false,
-          "lamports": 1726080,
+          "lamports": 2039280,
           "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "rentEpoch": 4,
+          "rentEpoch": 18446744073709551615,
           "space": 165
         },
-        "pubkey": "C2gJg6tKpQs41PRS1nC8aw3ZKNZK3HQQZGVrDFDup5nx"
+        "pubkey": "5HvuXcy57o41qtGBBJM7dRN9DS6G3jd9KEhHt4eYqJmB"
+      },
+      {
+        "account": {
+          "data": {
+            "parsed": {
+              "info": {
+                "isNative": false,
+                "mint": "FSX34rYUJ4zfdD7z4p3L1Fd1pGiiErusaSNTfgKqhep6",
+                "owner": "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd",
+                "state": "initialized",
+                "tokenAmount": {
+                  "amount": "10000000000000",
+                  "decimals": 9,
+                  "uiAmount": 10000,
+                  "uiAmountString": "10000"
+                }
+              },
+              "type": "account"
+            },
+            "program": "spl-token",
+            "space": 165
+          },
+          "executable": false,
+          "lamports": 2039280,
+          "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "rentEpoch": 18446744073709551615,
+          "space": 165
+        },
+        "pubkey": "HvTGvCP4tg2wVdFtqZCTdMPHDXmkYwNAxaTBCHabqh2X"
       }
     ]
-  },
-  "id": 1
+  }
 }
 ```
 

--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -18,9 +18,9 @@ Returns all SPL Token accounts by token owner.
   Pubkey of account delegate to query, as base-58 encoded string
 </Parameter>
 
-<Parameter type={"object"} optional={true}>
+<Parameter type={"object"} required={true}>
 
-A JSON object with one of the following fields:
+A JSON object with either one of the following fields:
 
 - `mint: <string>` - Pubkey of the specific token Mint to limit accounts to, as
   base-58 encoded string; or


### PR DESCRIPTION
### Problem

https://github.com/solana-foundation/developer-content/issues/520

### Summary of Changes

updated that the second param is also required per the [RPC source](https://github.com/anza-xyz/agave/blob/c7283625a9efa64377597e7e098a0f9965ff259a/rpc/src/rpc.rs#L2490-L2516)

Fixes #520 

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->