### PR TITLE
Fix inconsistency in intro-to-custom-onchain-programs.md

### DIFF
--- a/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
+++ b/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
@@ -21,11 +21,6 @@ In previous chapters, we used:
 
 - The `SystemProgram.transfer()` function from `@solana/web3.js` to make an
   instruction for the System program to transfer SOL.
-- The `mintTo()` and `transfer()` functions from `@solana/spl-token`, to make
-  instructions to the Token program to mint and transfer tokens
-- The `createCreateMetadataAccountV3Instruction()` function from
-  `@metaplex-foundation/mpl-token-metadata@2` to make instructions to Metaplex
-  to create token Metadata.
 
 When working with other programs, however, you'll need to create instructions
 manually. With `@solana/web3.js`, you can create instructions with the

--- a/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
+++ b/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
@@ -17,7 +17,7 @@ invoked in the onchain program.
 
 ### Instructions
 
-In previous chapters, we used the `SystemProgram.transfer()` function from 
+In previous lessons, we used the `SystemProgram.transfer()` function from 
 `@solana/web3.js`, which creates an instruction for the System program to 
 transfer SOL.
 

--- a/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
+++ b/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
@@ -17,10 +17,9 @@ invoked in the onchain program.
 
 ### Instructions
 
-In previous chapters, we used:
-
-- The `SystemProgram.transfer()` function from `@solana/web3.js` to make an
-  instruction for the System program to transfer SOL.
+In previous chapters, we used the `SystemProgram.transfer()` function from 
+`@solana/web3.js`, which creates an instruction for the System program to 
+transfer SOL.
 
 When working with other programs, however, you'll need to create instructions
 manually. With `@solana/web3.js`, you can create instructions with the


### PR DESCRIPTION
### Problem
Here https://solana.com/developers/courses/intro-to-solana/intro-to-custom-onchain-programs#instructions, it's mentioned that in previous chapters, we used the below functions:

- SystemProgram.transfer()
- mintTo() and transfer()
- createCreateMetadataAccountV3Instruction()

This is incorrect. I've read and checked out the previous chapters. Only SystemProgram.transfer() is used. The other two functions haven't been used/introduced yet.



### Summary of Changes
Removed the irrelevant lines that could confuse the reader.


Fixes #545

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->