### PR TITLE
Use ES2020 rather than ES5 (2009!)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "allowJs": true,


### PR DESCRIPTION
ES5 is from 2009 and outputting it creates needlessly complicated JS with lots of extra code for things that didn't exist 14 years ago. ES2020 is supported widely in current browsers. 