### PR TITLE
Add sol4k to the client-side development section

### DIFF
--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -68,16 +68,16 @@ If you're developing on the client-side, you can work with any programming
 language you're comfortable with. Solana has community-contributed SDKs to help
 developers interact with the Solana network in most popular languages :
 
-| Language   | SDK                                                                                         |
-| ---------- | ------------------------------------------------------------------------------------------- |
-| RUST       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                 |
-| Typescript | [@solana/web3.js](https://github.com/solana-labs/solana-web3.js)                            |
-| Python     | [solders](https://github.com/kevinheavey/solders)                                           |
-| Java       | [solanaj](https://github.com/skynetcap/solanaj)                                             |
-| C++        | [solcpp](https://github.com/mschneider/solcpp)                                              |
-| Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                      |
-| Kotlin     | [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                 |
-| Dart       | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana) |
+| Language   | SDK                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------ |
+| RUST       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                            |
+| Typescript | [@solana/web3.js](https://github.com/solana-labs/solana-web3.js)                                       |
+| Python     | [solders](https://github.com/kevinheavey/solders)                                                      |
+| Java       | [solanaj](https://github.com/skynetcap/solanaj)                                                        |
+| C++        | [solcpp](https://github.com/mschneider/solcpp)                                                         |
+| Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                                 |
+| Kotlin     | [solanaKT](https://github.com/metaplex-foundation/SolanaKT) or [sol4k](https://github.com/sol4k/sol4k) |
+| Dart       | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)            |
 
 You'll also need a connection with an RPC to interact with the network. You can
 either work with a [RPC infrastructure provider](https://solana.com/rpc) or


### PR DESCRIPTION
### Problem

While `solanaKT` is a great library, there are many reasons why we might want to add alternatives. Let me list a couple:
- `sol4k` is a well-maintained library with frequent releases and convenient APIs similar to those of `web3.js`
- it is up to date with the Solana updates (for instance, it supports versioned transactions) 
- widely used in the Kotlin community (projects like [web3auth](https://web3auth.io/docs/connect-blockchain/solana/android) or [Mixin Network](https://github.com/MixinNetwork/android-app) among others)
- it is built not only for Android but also for back-end development with Kotlin or Java (no Android-specific dependencies, no need to import the `jetpack` repository, etc.) 
- it is simplistic and lightweight (no heavy-weight dependencies like `bitcoinj`)

### Summary of Changes

Adds [sol4k](https://github.com/sol4k/sol4k) to the client-side development section for Kotlin.

