### PR TITLE
Fix a typo for the 'delete' instruction

### DIFF
--- a/docs/intro/quick-start/program-derived-address.md
+++ b/docs/intro/quick-start/program-derived-address.md
@@ -599,7 +599,7 @@ The `Delete` struct defines the accounts required for the `delete` instruction:
 </AccordionItem>
 </Accordion>
 
-Next, implement the logic for the `update` instruction.
+Next, implement the logic for the `delete` instruction.
 
 ```rs filename="lib.rs"
 pub fn delete(_ctx: Context<Delete>) -> Result<()> {


### PR DESCRIPTION
The description for the delete logic should be: implement the logic for the 'delete' instruction rather than  ...  'update' instruction

### Problem
The description for the delete logic should be modified.


### Summary of Changes
--->> implement the logic for the 'delete' instruction rather than implement the logic for the  'update' instruction


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->