### PR TITLE
Update intro-to-anchor.md

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor.md
+++ b/content/courses/onchain-development/intro-to-anchor.md
@@ -548,7 +548,7 @@ following:
 ```rust
 use anchor_lang::prelude::*;
 
-declare_id!("your-private-key");
+declare_id!("onchain-program-address");
 
 #[program]
 pub mod anchor_counter {


### PR DESCRIPTION
### Problem

declare_id!("your-private-key");
This is not a private key. It is misleading, because a developer could actually try to add the private key to the code directly, thereby exposing it


### Summary of Changes

declare_id!("your-private-key") -> declare_id!("onchain-program-address");

Fixes #
-