### PR TITLE
 Fix broken links and terminology in mwa-deep-dive.md

### DIFF
--- a/content/courses/mobile/mwa-deep-dive.md
+++ b/content/courses/mobile/mwa-deep-dive.md
@@ -198,7 +198,7 @@ transact(async (wallet: Web3MobileWallet) => {
 Note that the above example does not handle errors or user rejections. In
 production, it's a good idea to wrap the authorization state and methods with a
 custom `useAuthorization` hook. For reference, we built this
-[in the previous lesson](/content/courses/mobile/intro-to-solana-mobile).
+[in the previous lesson](/content/courses/mobile/intro-to-solana-mobile.md).
 
 #### Interact with a wallet
 
@@ -450,7 +450,7 @@ app-wallet relationship.
 Before we start programming our wallet, we need to do some setup. You will need
 a React Native development environment and a Solana dApp to test on. If you have
 completed the
-[Introduction to Solana Mobile lab](/content/courses/mobile/intro-to-solana-mobile),
+[Introduction to Solana Mobile lab](/content/courses/mobile/intro-to-solana-mobile.md),
 both of these requirements should be met and the counter app installed on your
 Android device/emulator.
 
@@ -1625,7 +1625,7 @@ request types: `SignMessagesRequest` and `SignTransactionsRequest`.
 
 Try to do this without help as it's great practice, but if you get stuck, check
 out the
-[solution code on the `solution` branch](https://github.com/solana-developers/react-native-fake-solana-wallet/tree/solution).
+[solution code on the `solution` branch](https://github.com/Unboxed-Software/react-native-fake-solana-wallet/tree/solution).
 
 <Callout type="success" title="Completed the lab?">
 Push your code to GitHub and

--- a/content/courses/mobile/mwa-deep-dive.md
+++ b/content/courses/mobile/mwa-deep-dive.md
@@ -1625,7 +1625,7 @@ request types: `SignMessagesRequest` and `SignTransactionsRequest`.
 
 Try to do this without help as it's great practice, but if you get stuck, check
 out the
-[solution code on the `solution` branch](https://github.com/Unboxed-Software/react-native-fake-solana-wallet/tree/solution).
+[solution code on the repo](https://github.com/solana-developers/react-native-fake-solana-wallet).
 
 <Callout type="success" title="Completed the lab?">
 Push your code to GitHub and

--- a/content/courses/mobile/mwa-deep-dive.md
+++ b/content/courses/mobile/mwa-deep-dive.md
@@ -23,7 +23,7 @@ description:
 ## Lesson
 
 Wallets exist to protect your secret keys. While some applications might have
-app-specific keys, many crypto use cases rely on a single identity used across
+app-specific keys, many blockchain use cases rely on a single identity used across
 multiple apps. In these cases, you very much want to be careful about how you
 expose signing across these apps. You don't want to share your secret key with
 all of them, which means you need a standard for allowing apps to submit

--- a/content/courses/mobile/mwa-deep-dive.md
+++ b/content/courses/mobile/mwa-deep-dive.md
@@ -41,7 +41,7 @@ app-wallet connection differently.
 
 At its core, a wallet app is fairly straightforward. It's a secure wrapper
 around your keypair. External applications can request that the wallet sign
-transactions without ever having access to your private key. Both the web and
+transactions without ever having access to your secret key. Both the web and
 mobile wallet adapters define this interaction for their respective platforms.
 
 #### How does a web wallet work?
@@ -598,7 +598,7 @@ provider should generate and store a keypair. The `WalletProvider` will then
 return its context including the `wallet` and `connection`. The rest of the app
 can access this context using the `useWallet()` hook.
 
-**_AGAIN_**, async storage is not fit to store private keys in production.
+**_AGAIN_**, async storage is not fit to store secret keys in production.
 Please use something like
 [Android's keystore system](https://developer.android.com/privacy-and-security/keystore).
 

--- a/content/courses/mobile/mwa-deep-dive.md
+++ b/content/courses/mobile/mwa-deep-dive.md
@@ -23,10 +23,10 @@ description:
 ## Lesson
 
 Wallets exist to protect your secret keys. While some applications might have
-app-specific keys, many blockchain use cases rely on a single identity used across
-multiple apps. In these cases, you very much want to be careful about how you
-expose signing across these apps. You don't want to share your secret key with
-all of them, which means you need a standard for allowing apps to submit
+app-specific keys, many blockchain use cases rely on a single identity used
+across multiple apps. In these cases, you very much want to be careful about how
+you expose signing across these apps. You don't want to share your secret key
+with all of them, which means you need a standard for allowing apps to submit
 transactions for signature to a secure wallet app that holds your secret key.
 This is where the Mobile Wallet Adapter (MWA) comes in. It's the transport layer
 to connect your mobile dApps to your wallet.
@@ -598,8 +598,8 @@ provider should generate and store a keypair. The `WalletProvider` will then
 return its context including the `wallet` and `connection`. The rest of the app
 can access this context using the `useWallet()` hook.
 
-**_AGAIN_**, async storage is not fit to store secret keys in production.
-Please use something like
+**_AGAIN_**, async storage is not fit to store secret keys in production. Please
+use something like
 [Android's keystore system](https://developer.android.com/privacy-and-security/keystore).
 
 Let's create the `WalletProvider.tsx` within a new directory named `components`:


### PR DESCRIPTION
### Problem

There were broken links and terminology that didn't appear to follow contributing guidelines.

### Summary of Changes

1. Contributing guide recommends using  'secret key' rather than 'private key'
2. Contributing guide recommends 'blockchain' or 'web3' rather than 'crypto'.
3. Added the `.md` file extension to broken links. 

Note: I linked the solution code to the [Unboxed Software](https://github.com/Unboxed-Software/react-native-fake-solana-wallet/tree/solution) repo, though I'm not sure if this was the right link. Let me know if this needs fixing. 


<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->