### PR TITLE
Fix broken links in solana-mobile-dapps-with-expo.md

### DIFF
--- a/content/courses/mobile/intro-to-solana-mobile.md
+++ b/content/courses/mobile/intro-to-solana-mobile.md
@@ -372,7 +372,6 @@ environment if you didn't already. This
 Remember that this step is not required if you are using a
 [Framework](https://reactnative.dev/architecture/glossary#react-native-framework).
 
-
 Ensure you have [Node.js](https://nodejs.org/en/download) installed on your
 system. These will manage your JavaScript packages. Install Android Studio:
 

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -71,7 +71,8 @@ speakers. The libraries are intuitive and the documentation is phenomenal.
 
 #### How to create an Expo app
 
-To begin using Expo, first follow the setup instructions described in the Getting Started section of the
+To begin using Expo, first follow the setup instructions described in the
+Getting Started section of the
 [Introduction to Solana Mobile lesson](/content/courses/mobile/intro-to-solana-mobile.md).
 After that, you'll want to sign up for an
 [Expo Application Services (EAS) account](https://expo.dev/eas).
@@ -390,8 +391,8 @@ already have a Devnet-enabled wallet installed you can skip step 0.
 
 #### 0. Install a Devnet-enabled Solana wallet
 
-You'll need a wallet that supports Devnet to test with. In
-our [Mobile Wallet Adapter lesson](/content/courses/mobile/mwa-deep-dive.md) we
+You'll need a wallet that supports Devnet to test with. In our
+[Mobile Wallet Adapter lesson](/content/courses/mobile/mwa-deep-dive.md) we
 created one of these. Let's install it from the repo in a different directory
 from our app:
 
@@ -436,8 +437,8 @@ Solana-based apps.
 Create two new folders: `components` and `screens`.
 
 We are going to use some boilerplate code from the
-[first Mobile lesson](/content/courses/mobile/intro-to-solana-mobile.md). We will be
-copying over `components/AuthorizationProvider.tsx` and
+[first Mobile lesson](/content/courses/mobile/intro-to-solana-mobile.md). We
+will be copying over `components/AuthorizationProvider.tsx` and
 `components/ConnectionProvider.tsx`. These files provide us with a `Connection`
 object as well as some helper functions that authorize our dapp.
 

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -943,7 +943,7 @@ This should have the following fields:
   function that creates a new snapshot NFT
 
 The `DigitalAsset` type comes from `@metaplex-foundation/mpl-token-metadata`
-that have metadata, off-chain metadata, collection data, plugins (including
+which has metadata, off-chain metadata, collection data, plugins (including
 Attributes), and more.
 
 ```tsx

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -436,7 +436,7 @@ Solana-based apps.
 Create two new folders: `components` and `screens`.
 
 We are going to use some boilerplate code from the
-[first Mobile lesson](/content/courses/mobile/basic-solana-mobile). We will be
+[first Mobile lesson](/content/courses/mobile/intro-to-solana-mobile.md). We will be
 copying over `components/AuthorizationProvider.tsx` and
 `components/ConnectionProvider.tsx`. These files provide us with a `Connection`
 object as well as some helper functions that authorize our dapp.

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -442,7 +442,7 @@ copying over `components/AuthorizationProvider.tsx` and
 object as well as some helper functions that authorize our dapp.
 
 Create file `components/AuthorizationProvider.tsx` and copy the contents of
-[our existing Auth Provider from Github](https://raw.githubusercontent.com/solana-developers/mobile-apps-with-expo/main/components/AuthorizationProvider.tsx)
+[our existing Auth Provider from Github](https://raw.githubusercontent.com/solana-developers/mobile-apps-with-expo/main/components/AuthProvider.tsx)
 into the new file.
 
 Secondly, create file `components/ConnectionProvider.tsx` and copy the contents

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -71,7 +71,7 @@ speakers. The libraries are intuitive and the documentation is phenomenal.
 
 #### How to create an Expo app
 
-To get started with Expo, you first need the prerequisite setup described in the
+To begin using Expo, first follow the setup instructions described in the Getting Started section of the
 [Introduction to Solana Mobile lesson](/content/courses/mobile/intro-to-solana-mobile.md).
 After that, you'll want to sign up for an
 [Expo Application Services (EAS) account](https://expo.dev/eas).

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -391,7 +391,7 @@ already have a Devnet-enabled wallet installed you can skip step 0.
 #### 0. Install a Devnet-enabled Solana wallet
 
 You'll need a wallet that supports Devnet to test with. In
-[our Mobile Wallet Adapter lesson](/content/courses/mobile/mwa-deep-dive) we
+our [Mobile Wallet Adapter lesson](/content/courses/mobile/mwa-deep-dive.md) we
 created one of these. Let's install it from the repo in a different directory
 from our app:
 

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -72,7 +72,7 @@ speakers. The libraries are intuitive and the documentation is phenomenal.
 #### How to create an Expo app
 
 To get started with Expo, you first need the prerequisite setup described in the
-[Introduction to Solana Mobile lesson](/content/courses/mobile/intro-to-solana-mobile).
+[Introduction to Solana Mobile lesson](/content/courses/mobile/intro-to-solana-mobile.md).
 After that, you'll want to sign up for an
 [Expo Application Services (EAS) account](https://expo.dev/eas).
 

--- a/content/courses/mobile/solana-mobile-dapps-with-expo.md
+++ b/content/courses/mobile/solana-mobile-dapps-with-expo.md
@@ -266,7 +266,7 @@ diary of sorts.
 To mint the NFTs we'll be using Metaplex's Umi libraries along with
 [Pinata Cloud](https://pinata.cloud/) to store images and metadata. We are using
 Pinata in this tutorial, but
-[there are many good solutions for store images for long-term storage](https://solana.com/developers/guides/getstarted/how-to-create-a-token#create-and-upload-image-and-offchain-metadata).
+[there are many good solutions for long-term image storage](https://solana.com/developers/guides/getstarted/how-to-create-a-token#create-and-upload-image-and-offchain-metadata).
 All of our onchain work will be on Devnet.
 
 The first half of this lab is cobbling together the needed components to make


### PR DESCRIPTION
### Problem
### Summary of Changes
1. Fixed broken links
2. Suggested rewording: changed "prerequisites" to "Getting Started" because the original Prerequisites section in the [Introduction to Solana Mobile](https://github.com/solana-foundation/developer-content/blob/main/content/courses/mobile/intro-to-solana-mobile.md) lesson was deleted and renamed to "Getting Started" in a recent PR update and would make it easier for beginners to find/navigate to.
3. Adjust grammar and wording to make it a little more concise.
4. The Auth Provider link was recently changed in another PR but the link was broken, I changed it to what [looks like the correct link](https://raw.githubusercontent.com/solana-developers/mobile-apps-with-expo/main/components/AuthProvider.tsx), but not sure if this is the intended link. Let me know if this needs to be fixed.
Thank you.






Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->