### PR TITLE
fix: exclude code dir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,20 +18,20 @@
     "paths": {
       "contentlayer/generated": ["./.contentlayer/generated"],
       "@/*": ["./src/*"],
-      "@@/*": ["./*"]
+      "@@/*": ["./*"],
     },
     "plugins": [
       {
-        "name": "next"
-      }
-    ]
+        "name": "next",
+      },
+    ],
   },
   "include": [
     ".contentlayer/generated",
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "code"],
 }


### PR DESCRIPTION
### Problem

recent code-import pr prevents building the nextjs app due to nextjs attempting to validate the types included in any of the code files stored in the `code` dir

### Summary of Changes

ignore the `code` dir via tsconfig
