### PR TITLE
Add solana4j (open sourced by LMAX) to the list of client-side java sdks

### DIFF
--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -69,11 +69,11 @@ language you're comfortable with. Solana has community-contributed SDKs to help
 developers interact with the Solana network in most popular languages :
 
 | Language   | SDK                                                                                                    |
-| ---------- | ------------------------------------------------------------------------------------------------------ |
+| ---------- |--------------------------------------------------------------------------------------------------------|
 | RUST       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                            |
 | Typescript | [@solana/web3.js](https://github.com/solana-labs/solana-web3.js)                                       |
 | Python     | [solders](https://github.com/kevinheavey/solders)                                                      |
-| Java       | [solanaj](https://github.com/skynetcap/solanaj)                                                        |
+| Java       | [solanaj](https://github.com/skynetcap/solanaj) or [solana4j](https://github.com/LMAX-Exchange/solana4j)                                        |
 | C++        | [solcpp](https://github.com/mschneider/solcpp)                                                         |
 | Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                                 |
 | Kotlin     | [solanaKT](https://github.com/metaplex-foundation/SolanaKT) or [sol4k](https://github.com/sol4k/sol4k) |

--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -68,16 +68,16 @@ If you're developing on the client-side, you can work with any programming
 language you're comfortable with. Solana has community-contributed SDKs to help
 developers interact with the Solana network in most popular languages :
 
-| Language   | SDK                                                                                                    |
-| ---------- |--------------------------------------------------------------------------------------------------------|
-| RUST       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                            |
-| Typescript | [@solana/web3.js](https://github.com/solana-labs/solana-web3.js)                                       |
-| Python     | [solders](https://github.com/kevinheavey/solders)                                                      |
-| Java       | [solanaj](https://github.com/skynetcap/solanaj) or [solana4j](https://github.com/LMAX-Exchange/solana4j)                                        |
-| C++        | [solcpp](https://github.com/mschneider/solcpp)                                                         |
-| Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                                 |
-| Kotlin     | [solanaKT](https://github.com/metaplex-foundation/SolanaKT) or [sol4k](https://github.com/sol4k/sol4k) |
-| Dart       | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)            |
+| Language   | SDK                                                                                                      |
+| ---------- | -------------------------------------------------------------------------------------------------------- |
+| RUST       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                              |
+| Typescript | [@solana/web3.js](https://github.com/solana-labs/solana-web3.js)                                         |
+| Python     | [solders](https://github.com/kevinheavey/solders)                                                        |
+| Java       | [solanaj](https://github.com/skynetcap/solanaj) or [solana4j](https://github.com/LMAX-Exchange/solana4j) |
+| C++        | [solcpp](https://github.com/mschneider/solcpp)                                                           |
+| Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                                   |
+| Kotlin     | [solanaKT](https://github.com/metaplex-foundation/SolanaKT) or [sol4k](https://github.com/sol4k/sol4k)   |
+| Dart       | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)              |
 
 You'll also need a connection with an RPC to interact with the network. You can
 either work with a [RPC infrastructure provider](https://solana.com/rpc) or


### PR DESCRIPTION
### Problem

LMAX have recently open sourced a new Java SDK. It should be on the list of supported Java SDKs within the documentation.  On a quick comparison between `solana4j` (LMAX's) and `solanaj` (skynetcap's), `solana4j` looks _at least_ as complete, if not more complete. Please note, I work for LMAX and I was responsible for open sourcing it.

### Summary of Changes

Adds a link to LMAX's solana4j library within the documentation, a recently open sourced Java SDK for Solana. 

Fixes #

N/A

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->