### PR TITLE
Add back lang-rust, limitation, faq pages under programs section

### DIFF
--- a/content/courses/state-compression/generalized-state-compression.md
+++ b/content/courses/state-compression/generalized-state-compression.md
@@ -50,10 +50,10 @@ These hashes take up far less storage space than the original data. The full
 data can be stored in a cheaper, offchain location, and only needs to be
 verified against the onchain hash when accessed.
 
-The Solana State Compression program uses a program
-known as a **concurrent Merkle tree**. A concurrent Merkle tree is a special
-kind of binary tree that deterministically hashes data, i.e. the same inputs
-will always produce the same Merkle root.
+The Solana State Compression program uses a program known as a **concurrent
+Merkle tree**. A concurrent Merkle tree is a special kind of binary tree that
+deterministically hashes data, i.e. the same inputs will always produce the same
+Merkle root.
 
 The final hash, called a _Merkle root_, is significantly smaller in size than
 all the original full data sets combined. This is why it’s called "compression".

--- a/docs/programs/anchor/index.md
+++ b/docs/programs/anchor/index.md
@@ -5,10 +5,7 @@ sidebarLabel: Anchor Framework
 sidebarSortOrder: 1
 altRoutes:
   - /docs/programs/debugging
-  - /docs/programs/faq
   - /docs/programs/lang-c
-  - /docs/programs/lang-rust
-  - /docs/programs/limitations
   - /docs/programs/overview
 ---
 

--- a/docs/programs/deploying.md
+++ b/docs/programs/deploying.md
@@ -4,7 +4,7 @@ description:
   "Deploying onchain programs can be done using the Solana CLI using the
   Upgradable BPF loader to upload the compiled byte-code to the Solana
   blockchain."
-sidebarSortOrder: 4
+sidebarSortOrder: 3
 ---
 
 Solana onchain programs (otherwise known as "smart contracts") are stored in

--- a/docs/programs/faq.md
+++ b/docs/programs/faq.md
@@ -1,0 +1,194 @@
+---
+title: "FAQ"
+sidebarSortOrder: 7
+---
+
+Post your questions on
+[StackExchange](https://solana.stackexchange.com/questions/ask).
+
+## Berkeley Packet Filter (BPF)
+
+Solana onchain programs are compiled via the
+[LLVM compiler infrastructure](https://llvm.org/) to an
+[Executable and Linkable Format (ELF)](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format)
+containing a variation of the
+[Berkeley Packet Filter (BPF)](https://en.wikipedia.org/wiki/Berkeley_Packet_Filter)
+bytecode.
+
+Because Solana uses the LLVM compiler infrastructure, a program may be written
+in any programming language that can target the LLVM's BPF backend.
+
+BPF provides an efficient
+[instruction set](https://github.com/iovisor/bpf-docs/blob/master/eBPF.md) that
+can be executed in an interpreted virtual machine or as efficient just-in-time
+compiled native instructions.
+
+## Memory map
+
+The virtual address memory map used by Solana SBF programs is fixed and laid out
+as follows
+
+- Program code starts at 0x100000000
+- Stack data starts at 0x200000000
+- Heap data starts at 0x300000000
+- Program input parameters start at 0x400000000
+
+The above virtual addresses are start addresses but programs are given access to
+a subset of the memory map. The program will panic if it attempts to read or
+write to a virtual address that it was not granted access to, and an
+`AccessViolation` error will be returned that contains the address and size of
+the attempted violation.
+
+## InvalidAccountData
+
+This program error can happen for a lot of reasons. Usually, it's caused by
+passing an account to the program that the program is not expecting, either in
+the wrong position in the instruction or an account not compatible with the
+instruction being executed.
+
+An implementation of a program might also cause this error when performing a
+cross-program instruction and forgetting to provide the account for the program
+that you are calling.
+
+## InvalidInstructionData
+
+This program error can occur while trying to deserialize the instruction, check
+that the structure passed in matches exactly the instruction. There may be some
+padding between fields. If the program implements the Rust `Pack` trait then try
+packing and unpacking the instruction type `T` to determine the exact encoding
+the program expects.
+
+## MissingRequiredSignature
+
+Some instructions require the account to be a signer; this error is returned if
+an account is expected to be signed but is not.
+
+An implementation of a program might also cause this error when performing a
+[cross-program invocation](/docs/core/cpi.md) that requires a signed program
+address, but the passed signer seeds passed to `invoke_signed` don't match the
+signer seeds used to create the program address
+[`create_program_address`](/docs/core/pda.md#createprogramaddress).
+
+## Stack
+
+SBF uses stack frames instead of a variable stack pointer. Each stack frame is
+4KB in size.
+
+If a program violates that stack frame size, the compiler will report the
+overrun as a warning.
+
+For example:
+
+```text
+Error: Function _ZN16curve25519_dalek7edwards21EdwardsBasepointTable6create17h178b3d2411f7f082E Stack offset of -30728 exceeded max offset of -4096 by 26632 bytes, please minimize large stack variables
+```
+
+The message identifies which symbol is exceeding its stack frame, but the name
+might be mangled.
+
+> To demangle a Rust symbol use [rustfilt](https://github.com/luser/rustfilt).
+
+The above warning came from a Rust program, so the demangled symbol name is:
+
+```shell
+rustfilt _ZN16curve25519_dalek7edwards21EdwardsBasepointTable6create17h178b3d2411f7f082E
+curve25519_dalek::edwards::EdwardsBasepointTable::create
+```
+
+The reason a warning is reported rather than an error is because some dependent
+crates may include functionality that violates the stack frame restrictions even
+if the program doesn't use that functionality. If the program violates the stack
+size at runtime, an `AccessViolation` error will be reported.
+
+SBF stack frames occupy a virtual address range starting at `0x200000000`.
+
+## Heap size
+
+Programs have access to a runtime heap via the Rust `alloc` APIs. To facilitate
+fast allocations, a simple 32KB bump heap is utilized. The heap does not support
+`free` or `realloc`.
+
+Internally, programs have access to the 32KB memory region starting at virtual
+address 0x300000000 and may implement a custom heap based on the program's
+specific needs.
+
+Rust programs implement the heap directly by defining a custom
+[`global_allocator`](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/entrypoint.rs#L72)
+
+## Loaders
+
+Programs are deployed with and executed by runtime loaders, currently there are
+two supported loaders
+[BPF Loader](https://github.com/solana-labs/solana/blob/7ddf10e602d2ed87a9e3737aa8c32f1db9f909d8/sdk/program/src/bpf_loader.rs#L17)
+and
+[BPF loader deprecated](https://github.com/solana-labs/solana/blob/7ddf10e602d2ed87a9e3737aa8c32f1db9f909d8/sdk/program/src/bpf_loader_deprecated.rs#L14)
+
+Loaders may support different application binary interfaces so developers must
+write their programs for and deploy them to the same loader. If a program
+written for one loader is deployed to a different one the result is usually a
+`AccessViolation` error due to mismatched deserialization of the program's input
+parameters.
+
+For all practical purposes program should always be written to target the latest
+BPF loader and the latest loader is the default for the command-line interface
+and the javascript APIs.
+
+- [Rust program entrypoints](/docs/programs/lang-rust.md#program-entrypoint)
+
+### Deployment
+
+SBF program deployment is the process of uploading a BPF shared object into a
+program account's data and marking the account executable. A client breaks the
+SBF shared object into smaller pieces and sends them as the instruction data of
+[`Write`](https://github.com/solana-labs/solana/blob/bc7133d7526a041d1aaee807b80922baa89b6f90/sdk/program/src/loader_instruction.rs#L13)
+instructions to the loader where loader writes that data into the program's
+account data. Once all the pieces are received the client sends a
+[`Finalize`](https://github.com/solana-labs/solana/blob/bc7133d7526a041d1aaee807b80922baa89b6f90/sdk/program/src/loader_instruction.rs#L30)
+instruction to the loader, the loader then validates that the SBF data is valid
+and marks the program account as _executable_. Once the program account is
+marked executable, subsequent transactions may issue instructions for that
+program to process.
+
+When an instruction is directed at an executable SBF program the loader
+configures the program's execution environment, serializes the program's input
+parameters, calls the program's entrypoint, and reports any errors encountered.
+
+For further information, see [deploying programs](/docs/programs/deploying.md).
+
+### Input Parameter Serialization
+
+SBF loaders serialize the program input parameters into a byte array that is
+then passed to the program's entrypoint, where the program is responsible for
+deserializing it on-chain. One of the changes between the deprecated loader and
+the current loader is that the input parameters are serialized in a way that
+results in various parameters falling on aligned offsets within the aligned byte
+array. This allows deserialization implementations to directly reference the
+byte array and provide aligned pointers to the program.
+
+- [Rust program parameter deserialization](/docs/programs/lang-rust.md#parameter-deserialization)
+
+The latest loader serializes the program input parameters as follows (all
+encoding is little endian):
+
+- 8 bytes unsigned number of accounts
+- For each account
+  - 1 byte indicating if this is a duplicate account, if not a duplicate then
+    the value is 0xff, otherwise the value is the index of the account it is a
+    duplicate of.
+  - If duplicate: 7 bytes of padding
+  - If not duplicate:
+    - 1 byte boolean, true if account is a signer
+    - 1 byte boolean, true if account is writable
+    - 1 byte boolean, true if account is executable
+    - 4 bytes of padding
+    - 32 bytes of the account public key
+    - 32 bytes of the account's owner public key
+    - 8 bytes unsigned number of lamports owned by the account
+    - 8 bytes unsigned number of bytes of account data
+    - x bytes of account data
+    - 10k bytes of padding, used for realloc
+    - enough padding to align the offset to 8 bytes.
+    - 8 bytes rent epoch
+- 8 bytes of unsigned number of instruction data
+- x bytes of instruction data
+- 32 bytes of the program id

--- a/docs/programs/lang-rust.md
+++ b/docs/programs/lang-rust.md
@@ -1,0 +1,387 @@
+---
+title: "Developing with Rust"
+sidebarSortOrder: 4
+---
+
+Solana supports writing onchain programs using the
+[Rust](https://www.rust-lang.org/) programming language.
+
+- [Setup your local environment](/docs/intro/installation) and use the local
+  test validator.
+
+## Project Layout
+
+Solana Rust programs follow the typical
+[Rust project layout](https://doc.rust-lang.org/cargo/guide/project-layout.html):
+
+```text
+/inc/
+/src/
+/Cargo.toml
+```
+
+Solana Rust programs may depend directly on each other in order to gain access
+to instruction helpers when making
+[cross-program invocations](/docs/core/cpi.md). When doing so it's important to
+not pull in the dependent program's entrypoint symbols because they may conflict
+with the program's own. To avoid this, programs should define an `no-entrypoint`
+feature in `Cargo.toml` and use to exclude the entrypoint.
+
+- [Define the feature](https://github.com/solana-labs/solana-program-library/blob/fca9836a2c8e18fc7e3595287484e9acd60a8f64/token/program/Cargo.toml#L12)
+- [Exclude the entrypoint](https://github.com/solana-labs/solana-program-library/blob/fca9836a2c8e18fc7e3595287484e9acd60a8f64/token/program/src/lib.rs#L12)
+
+Then when other programs include this program as a dependency, they should do so
+using the `no-entrypoint` feature.
+
+- [Include without entrypoint](https://github.com/solana-labs/solana-program-library/blob/fca9836a2c8e18fc7e3595287484e9acd60a8f64/token-swap/program/Cargo.toml#L22)
+
+## Project Dependencies
+
+At a minimum, Solana Rust programs must pull in the
+[`solana-program`](https://crates.io/crates/solana-program) crate.
+
+Solana SBF programs have some [restrictions](#restrictions) that may prevent the
+inclusion of some crates as dependencies or require special handling.
+
+For example:
+
+- Crates that require the architecture be a subset of the ones supported by the
+  official toolchain. There is no workaround for this unless that crate is
+  forked and SBF added to that those architecture checks.
+- Crates may depend on `rand` which is not supported in Solana's deterministic
+  program environment. To include a `rand` dependent crate refer to
+  [Depending on Rand](#depending-on-rand).
+- Crates may overflow the stack even if the stack overflowing code isn't
+  included in the program itself. For more information refer to
+  [Stack](/docs/programs/faq.md#stack).
+
+## How to Build
+
+First setup the environment:
+
+- Install the latest Rust stable from https://rustup.rs/
+- Install the latest [Solana command-line tools](/docs/intro/installation.md)
+
+The normal cargo build is available for building programs against your host
+machine which can be used for unit testing:
+
+```shell
+cargo build
+```
+
+To build a specific program, such as SPL Token, for the Solana SBF target which
+can be deployed to the cluster:
+
+```shell
+cd <the program directory>
+cargo build-bpf
+```
+
+## How to Test
+
+Solana programs can be unit tested via the traditional `cargo test` mechanism by
+exercising program functions directly.
+
+To help facilitate testing in an environment that more closely matches a live
+cluster, developers can use the
+[`program-test`](https://crates.io/crates/solana-program-test) crate. The
+`program-test` crate starts up a local instance of the runtime and allows tests
+to send multiple transactions while keeping state for the duration of the test.
+
+For more information the
+[test in sysvar example](https://github.com/solana-labs/solana-program-library/blob/master/examples/rust/sysvar/tests/functional.rs)
+shows how an instruction containing sysvar account is sent and processed by the
+program.
+
+## Program Entrypoint
+
+Programs export a known entrypoint symbol which the Solana runtime looks up and
+calls when invoking a program. Solana supports multiple versions of the BPF
+loader and the entrypoints may vary between them. Programs must be written for
+and deployed to the same loader. For more details see the
+[FAQ section on Loaders](/docs/programs/faq.md#loaders).
+
+Currently there are two supported loaders
+[BPF Loader](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/bpf_loader.rs#L17)
+and
+[BPF loader deprecated](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/bpf_loader_deprecated.rs#L14)
+
+They both have the same raw entrypoint definition, the following is the raw
+symbol that the runtime looks up and calls:
+
+```rust
+#[no_mangle]
+pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64;
+```
+
+This entrypoint takes a generic byte array which contains the serialized program
+parameters (program id, accounts, instruction data, etc...). To deserialize the
+parameters each loader contains its own wrapper macro that exports the raw
+entrypoint, deserializes the parameters, calls a user defined instruction
+processing function, and returns the results.
+
+You can find the entrypoint macros here:
+
+- [BPF Loader's entrypoint macro](https://github.com/solana-labs/solana/blob/9b1199cdb1b391b00d510ed7fc4866bdf6ee4eb3/sdk/program/src/entrypoint.rs#L42)
+- [BPF Loader deprecated's entrypoint macro](https://github.com/solana-labs/solana/blob/9b1199cdb1b391b00d510ed7fc4866bdf6ee4eb3/sdk/program/src/entrypoint_deprecated.rs#L38)
+
+The program defined instruction processing function that the entrypoint macros
+call must be of this form:
+
+```rust
+pub type ProcessInstruction =
+    fn(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult;
+```
+
+### Parameter Deserialization
+
+Each loader provides a helper function that deserializes the program's input
+parameters into Rust types. The entrypoint macros automatically calls the
+deserialization helper:
+
+- [BPF Loader deserialization](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/entrypoint.rs#L146)
+- [BPF Loader deprecated deserialization](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/entrypoint_deprecated.rs#L57)
+
+Some programs may want to perform deserialization themselves and they can by
+providing their own implementation of the [raw entrypoint](#program-entrypoint).
+Take note that the provided deserialization functions retain references back to
+the serialized byte array for variables that the program is allowed to modify
+(lamports, account data). The reason for this is that upon return the loader
+will read those modifications so they may be committed. If a program implements
+their own deserialization function they need to ensure that any modifications
+the program wishes to commit be written back into the input byte array.
+
+Details on how the loader serializes the program inputs can be found in the
+[Input Parameter Serialization](/docs/programs/faq.md#input-parameter-serialization)
+docs.
+
+### Data Types
+
+The loader's entrypoint macros call the program defined instruction processor
+function with the following parameters:
+
+```rust
+program_id: &Pubkey,
+accounts: &[AccountInfo],
+instruction_data: &[u8]
+```
+
+The program id is the public key of the currently executing program.
+
+The accounts is an ordered slice of the accounts referenced by the instruction
+and represented as an
+[AccountInfo](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/account_info.rs#L12)
+structures. An account's place in the array signifies its meaning, for example,
+when transferring lamports an instruction may define the first account as the
+source and the second as the destination.
+
+The members of the `AccountInfo` structure are read-only except for `lamports`
+and `data`. Both may be modified by the program in accordance with the "runtime
+enforcement policy". Both of these members are protected by the Rust `RefCell`
+construct, so they must be borrowed to read or write to them. The reason for
+this is they both point back to the original input byte array, but there may be
+multiple entries in the accounts slice that point to the same account. Using
+`RefCell` ensures that the program does not accidentally perform overlapping
+read/writes to the same underlying data via multiple `AccountInfo` structures.
+If a program implements their own deserialization function care should be taken
+to handle duplicate accounts appropriately.
+
+The instruction data is the general purpose byte array from the
+[instruction's instruction data](/docs/core/transactions.md#instruction) being
+processed.
+
+## Heap
+
+Rust programs implement the heap directly by defining a custom
+[`global_allocator`](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/entrypoint.rs#L72)
+
+Programs may implement their own `global_allocator` based on its specific needs.
+Refer to the [custom heap example](#examples) for more information.
+
+## Restrictions
+
+On-chain Rust programs support most of Rust's libstd, libcore, and liballoc, as
+well as many 3rd party crates.
+
+There are some limitations since these programs run in a resource-constrained,
+single-threaded environment, as well as being deterministic:
+
+- No access to
+  - `rand`
+  - `std::fs`
+  - `std::net`
+  - `std::future`
+  - `std::process`
+  - `std::sync`
+  - `std::task`
+  - `std::thread`
+  - `std::time`
+- Limited access to:
+  - `std::hash`
+  - `std::os`
+- Bincode is extremely computationally expensive in both cycles and call depth
+  and should be avoided
+- String formatting should be avoided since it is also computationally
+  expensive.
+- No support for `println!`, `print!`, the Solana [logging helpers](#logging)
+  should be used instead.
+- The runtime enforces a limit on the number of instructions a program can
+  execute during the processing of one instruction. See
+  [computation budget](/docs/core/fees.md#compute-budget) for more information.
+
+## Depending on Rand
+
+Programs are constrained to run deterministically, so random numbers are not
+available. Sometimes a program may depend on a crate that depends itself on
+`rand` even if the program does not use any of the random number functionality.
+If a program depends on `rand`, the compilation will fail because there is no
+`get-random` support for Solana. The error will typically look like this:
+
+```shell
+error: target is not supported, for more information see: https://docs.rs/getrandom/#unsupported-targets
+   --> /Users/jack/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.1.14/src/lib.rs:257:9
+    |
+257 | /         compile_error!("\
+258 | |             target is not supported, for more information see: \
+259 | |             https://docs.rs/getrandom/#unsupported-targets\
+260 | |         ");
+    | |___________^
+```
+
+To work around this dependency issue, add the following dependency to the
+program's `Cargo.toml`:
+
+```rust
+getrandom = { version = "0.1.14", features = ["dummy"] }
+```
+
+or if the dependency is on getrandom v0.2 add:
+
+```rust
+getrandom = { version = "0.2.2", features = ["custom"] }
+```
+
+## Logging
+
+Rust's `println!` macro is computationally expensive and not supported. Instead
+the helper macro
+[`msg!`](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/log.rs#L33)
+is provided.
+
+`msg!` has two forms:
+
+```rust
+msg!("A string");
+```
+
+or
+
+```rust
+msg!(0_64, 1_64, 2_64, 3_64, 4_64);
+```
+
+Both forms output the results to the program logs. If a program so wishes they
+can emulate `println!` by using `format!`:
+
+```rust
+msg!("Some variable: {:?}", variable);
+```
+
+## Panicking
+
+Rust's `panic!`, `assert!`, and internal panic results are printed to the
+program logs by default.
+
+```shell
+INFO  solana_runtime::message_processor] Finalized account CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ
+INFO  solana_runtime::message_processor] Call SBF program CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ
+INFO  solana_runtime::message_processor] Program log: Panicked at: 'assertion failed: `(left == right)`
+      left: `1`,
+     right: `2`', rust/panic/src/lib.rs:22:5
+INFO  solana_runtime::message_processor] SBF program consumed 5453 of 200000 units
+INFO  solana_runtime::message_processor] SBF program CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ failed: BPF program panicked
+```
+
+### Custom Panic Handler
+
+Programs can override the default panic handler by providing their own
+implementation.
+
+First define the `custom-panic` feature in the program's `Cargo.toml`
+
+```rust
+[features]
+default = ["custom-panic"]
+custom-panic = []
+```
+
+Then provide a custom implementation of the panic handler:
+
+```rust
+#[cfg(all(feature = "custom-panic", target_os = "solana"))]
+#[no_mangle]
+fn custom_panic(info: &core::panic::PanicInfo<'_>) {
+    solana_program::msg!("program custom panic enabled");
+    solana_program::msg!("{}", info);
+}
+```
+
+In the above snippit, the default implementation is shown, but developers may
+replace that with something that better suits their needs.
+
+One of the side effects of supporting full panic messages by default is that
+programs incur the cost of pulling in more of Rust's `libstd` implementation
+into program's shared object. Typical programs will already be pulling in a fair
+amount of `libstd` and may not notice much of an increase in the shared object
+size. But programs that explicitly attempt to be very small by avoiding `libstd`
+may take a significant impact (~25kb). To eliminate that impact, programs can
+provide their own custom panic handler with an empty implementation.
+
+```rust
+#[cfg(all(feature = "custom-panic", target_os = "solana"))]
+#[no_mangle]
+fn custom_panic(info: &core::panic::PanicInfo<'_>) {
+    // Do nothing to save space
+}
+```
+
+## Compute Budget
+
+Use the system call `sol_remaining_compute_units()` to return a `u64` indicating
+the number of compute units remaining for this transaction.
+
+Use the system call
+[`sol_log_compute_units()`](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/log.rs#L141)
+to log a message containing the remaining number of compute units the program
+may consume before execution is halted
+
+See the [Compute Budget](/docs/core/fees.md#compute-budget) documentation for
+more information.
+
+## ELF Dump
+
+The SBF shared object internals can be dumped to a text file to gain more
+insight into a program's composition and what it may be doing at runtime. The
+dump will contain both the ELF information as well as a list of all the symbols
+and the instructions that implement them. Some of the BPF loader's error log
+messages will reference specific instruction numbers where the error occurred.
+These references can be looked up in the ELF dump to identify the offending
+instruction and its context.
+
+To create a dump file:
+
+```shell
+cd <program directory>
+cargo build-bpf --dump
+```
+
+## Examples
+
+The
+[Solana Program Library GitHub](https://github.com/solana-labs/solana-program-library/tree/master/examples/rust)
+repo contains a collection of Rust examples.
+
+The
+[Solana Developers Program Examples GitHub](https://github.com/solana-developers/program-examples)
+repo also contains a collection of beginner to intermediate Rust program
+examples.

--- a/docs/programs/limitations.md
+++ b/docs/programs/limitations.md
@@ -1,0 +1,112 @@
+---
+title: "Limitations"
+sidebarSortOrder: 6
+---
+
+Developing programs on the Solana blockchain have some inherent limitation
+associated with them. Below is a list of common limitation that you may run
+into.
+
+## Rust libraries
+
+Since Rust based onchain programs must run be deterministic while running in a
+resource-constrained, single-threaded environment, they have some limitations on
+various libraries.
+
+On-chain Rust programs support most of Rust's libstd, libcore, and liballoc, as
+well as many 3rd party crates.
+
+There are some limitations since these programs run in a resource-constrained,
+single-threaded environment, as well as being deterministic:
+
+- No access to
+  - `rand`
+  - `std::fs`
+  - `std::net`
+  - `std::future`
+  - `std::process`
+  - `std::sync`
+  - `std::task`
+  - `std::thread`
+  - `std::time`
+- Limited access to:
+  - `std::hash`
+  - `std::os`
+- Bincode is extremely computationally expensive in both cycles and call depth
+  and should be avoided
+- String formatting should be avoided since it is also computationally
+  expensive.
+- No support for `println!`, `print!`, use the
+  [`msg!`](https://github.com/solana-labs/solana/blob/d9b0fc0e3eec67dfe4a97d9298b15969b2804fab/sdk/program/src/log.rs#L33)
+  macro instead.
+- The runtime enforces a limit on the number of instructions a program can
+  execute during the processing of one instruction. See
+  [computation budget](/docs/core/fees.md#compute-budget) for more information.
+
+## Compute budget
+
+To prevent abuse of the blockchain's computational resources, each transaction
+is allocated a [compute budget](/docs/terminology.md#compute-budget). Exceeding
+this compute budget will result in the transaction failing.
+
+See the [computational constraints](/docs/core/fees.md#compute-budget)
+documentation for more specific details.
+
+## Call stack depth - `CallDepthExceeded` error
+
+Solana programs are constrained to run quickly, and to facilitate this, the
+program's call stack is limited to a max depth of **64 frames**.
+
+When a program exceeds the allowed call stack depth limit, it will receive the
+`CallDepthExceeded` error.
+
+## CPI call depth - `CallDepth` error
+
+Cross-program invocations allow programs to invoke other programs directly, but
+the depth is constrained currently to `4`.
+
+When a program exceeds the allowed
+[cross-program invocation call depth](/docs/core/cpi.md), it will receive a
+`CallDepth` error
+
+## Float Rust types support
+
+Programs support a limited subset of Rust's float operations. If a program
+attempts to use a float operation that is not supported, the runtime will report
+an unresolved symbol error.
+
+Float operations are performed via software libraries, specifically LLVM's float
+built-ins. Due to the software emulated, they consume more compute units than
+integer operations. In general, fixed point operations are recommended where
+possible.
+
+The
+[Solana Program Library math](https://github.com/solana-labs/solana-program-library/tree/master/libraries/math)
+tests will report the performance of some math operations. To run the test, sync
+the repo and run:
+
+```shell
+cargo test-sbf -- --nocapture --test-threads=1
+```
+
+Recent results show the float operations take more instructions compared to
+integers equivalents. Fixed point implementations may vary but will also be less
+than the float equivalents:
+
+```text
+          u64   f32
+Multiply    8   176
+Divide      9   219
+```
+
+## Static writable data
+
+Program shared objects do not support writable shared data. Programs are shared
+between multiple parallel executions using the same shared read-only code and
+data. This means that developers should not include any static writable or
+global variables in programs. In the future a copy-on-write mechanism could be
+added to support writable data.
+
+## Signed division
+
+The SBF instruction set does not support signed division.


### PR DESCRIPTION
 Add back the following pages, with minor updates to remove references to removed C page:
  - /docs/programs/faq
  - /docs/programs/lang-rust
  - /docs/programs/limitations