### PR TITLE
Update anchor-cpi.md

### DIFF
--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -380,7 +380,7 @@ pub struct InitializeMint<'info> {
         bump,
         payer = user,
         mint::decimals = 6,
-        mint::authority = user,
+        mint::authority = mint,
     )]
     pub mint: Account<'info, Mint>,
     #[account(mut)]


### PR DESCRIPTION
### Problem

The mint authority of the mint account should be PDA, otherwise the add_movie_review instruction couldn't work.

### Summary of Changes

Change constraint `mint::authority = user` to `mint::authority = mint`.

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->