### PR TITLE
fix: pow operation in both rust and ts

### DIFF
--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -495,7 +495,7 @@ Next, let's update the `add_movie_review` instruction to do the following:
   the `DescriptionTooLong` error.
 - Make a CPI to the token program's `mint_to` instruction using the mint
   authority PDA as a signer. Note that we'll mint 10 tokens to the user but need
-  to adjust for the mint decimals by making it `10*10^6`.
+  to adjust for the mint decimals by making it `10 * 10u64.pow(6)`.
 
 Fortunately, we can use the `anchor_spl` crate to access helper functions and
 types like `mint_to` and `MintTo` for constructing our CPI to the Token Program.
@@ -561,7 +561,7 @@ pub fn add_movie_review(
                 &[ctx.bumps.mint]
             ]]
         ),
-        10*10^6
+        10 * 10u64.pow(6)
     )?;
 
     msg!("Minted tokens");
@@ -691,7 +691,7 @@ it("Movie review is added`", async () => {
   );
 
   const userAta = await getAccount(provider.connection, tokenAccount);
-  expect(Number(userAta.amount)).to.equal((10 * 10) ^ 6);
+  expect(Number(userAta.amount)).to.equal(10 * 10 ** 6);
 });
 ```
 


### PR DESCRIPTION
### Problem

In rust and typescript/js, `^` is a bitwise operation of `XOR`, not exponentiation as intended.  to correctly represents 10 tokens with 6 decimal places of percision, this fix has to be made, otherwise `10 * 10 ^ 6` would result in `98` in binary computation. not the expected `10 * 1_000_000`, this might be misleading. 

### Summary of Changes
To fix `10 * 10 ^6`:
in typescript the change is `10 * 10 ** 6`, 
while in rust it becomes `10 * 10u64.pow(6)`.


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->