### PR TITLE
fix: mint authority

### DIFF
--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -552,7 +552,7 @@ pub fn add_movie_review(
         CpiContext::new_with_signer(
             ctx.accounts.token_program.to_account_info(),
             MintTo {
-                authority: ctx.accounts.mint.to_account_info(),
+                authority: ctx.accounts.initializer.to_account_info(),
                 to: ctx.accounts.token_account.to_account_info(),
                 mint: ctx.accounts.mint.to_account_info()
             },


### PR DESCRIPTION
### Problem

in this page https://solana.com/developers/courses/onchain-development/anchor-cpi
if you run `anchor test` in the final example, you can see errors:
```
 "Program log: Instruction: MintTo",
  "Program log: Error: owner does not match",
```

### Summary of Changes

the reason is in this line:
https://github.com/solana-foundation/developer-content/blob/5dc01dd84e01f5dfcb7b0cb7947c3a533e73bba7/content/courses/onchain-development/anchor-cpi.md?plain=1#L555

it passed an incorrect mint authority, because in `InitializeMint`, the `authority` passed with `user`, which is the signer. but when it call `MintTo` in `CpiContext::new_with_signer`,  `authority` is incorrectly passed as `mint`. which is not the authority of itself, instead  the signer, `ctx.accounts.initializer.to_account_info()`, should be passed in.

Fixes #

Also I see in this PR: https://github.com/solana-foundation/developer-content/pull/571/files.  it uses the mint as its own authority. well, i am afriad I can't think this is very good based on two reasons:
1. Security: If the mint were its own authority, anyone who could predict the PDA (which is techincally possible! ) could potentially mint tokens.

2. Security: If the mint were its own authority, anyone who could predict the PDA could potentially mint tokens.


<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->