### PR TITLE
Fix: resolve type error in program initialization example

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor-frontend.md
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.md
@@ -414,10 +414,10 @@ const wallet = useAnchorWallet();
 const provider = new AnchorProvider(connection, wallet, {});
 setProvider(provider);
 
-const program = new Program(idl as Idl) as Program<CounterProgram>;
+const program = new Program(idl as CounterProgram); 
 
 // we can also explicitly mention the provider
-const program = new Program(idl as Idl, provider) as Program<CounterProgram>;
+const program = new Program(idl as CounterProgram, provider);
 ```
 
 ### Anchor `MethodsBuilder`


### PR DESCRIPTION
### Problem
In one of the [examples](https://github.com/solana-foundation/developer-content/blob/c050fd3b48e53b8a896e852b7555ecdd2a4cb53a/content/courses/onchain-development/intro-to-anchor-frontend.md?plain=1#L417C1-L420C78) , there was a type error: 
![image](https://github.com/user-attachments/assets/4ef06314-b743-43c0-821c-95609af5bed8)
caused by conversion of `Program<Idl>` to `Program<CounterProgram>`


### Summary of Changes
Change to direct conversion when passing `idl` to `Program`



<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->