### PR TITLE
Fixed SW QoS doc to use getClusterNodes

### DIFF
--- a/content/guides/advanced/stake-weighted-qos.md
+++ b/content/guides/advanced/stake-weighted-qos.md
@@ -140,9 +140,8 @@ On the RPC you will have to use `--rpc-send-transaction-tpu-peer` to forward
 transactions to a specific leader. The exact usage would be
 `--rpc-send-transaction-tpu-peer HOST:PORT`. The Host is the ip address of the
 leader you have the `staked-nodes-overrides` enabled on and the Port is the QUIC
-TPU port of that host. The QUIC TPU port number is the lowest value of your
-`--dynamic-port-range` plus 9. For example, if the flag is
-`--dynamic-port-range 8000-8100`, the QUIC TPU port is `8009`.
+TPU port of that host. The QUIC TPU port for a leader can be identified by
+making an RPC call to [getClusterNodes](/docs/rpc/http/getClusterNodes.mdx).
 
 The peering would looking like the following:
 


### PR DESCRIPTION
The QUIC tpu port number was incorrectly listed in the docs. This change tells the user to get the
QUIC tpu port from the getClusterNodes RPC call.

### Problem
The QUIC tpu port number was incorrectly listed in the docs


### Summary of Changes
Suggest the use of getClusterNodes RPC call


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->