### PR TITLE
Update Close Account to reflect best practices.

### DIFF
--- a/content/cookbook/accounts/close-account.md
+++ b/content/cookbook/accounts/close-account.md
@@ -37,8 +37,8 @@ fn process_instruction(
         .unwrap();
     **source_account_info.lamports.borrow_mut() = 0;
 
-    let mut source_data = source_account_info.data.borrow_mut();
-    source_data.fill(0);
+    source_account_info.assign(&system_program::ID);
+    source_account_info.realloc(0, false).map_err(Into::into)
 
     Ok(())
 }


### PR DESCRIPTION
### Problem
Close Accounts example reflects a potential exploit by not reassigning account ownership (thank you to Sec3 for flagging this). This is shown by the Anchor Sealevel attack example https://github.com/coral-xyz/sealevel-attacks/blob/master/programs/9-closing-accounts/insecure-still/src/lib.rs

### Summary of Changes
Reassign and realloc the account so ownership of an unclosed account cannot be faked.

Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->