### PR TITLE
Trivial fixes

### DIFF
--- a/content/courses/program-optimization/program-architecture.md
+++ b/content/courses/program-optimization/program-architecture.md
@@ -934,7 +934,7 @@ Each concept has an accompanying program and test file. For example, the
 
 **program -** `programs/architecture/src/concepts/sizes.rs`
 
-**test -** `cd tests/sizes.ts`
+**test -** `tests/sizes.ts`
 
 Now that you've read about each of these concepts, feel free to jump into the
 code to experiment a little. You can change existing values, try to break the

--- a/content/courses/program-optimization/program-architecture.md
+++ b/content/courses/program-optimization/program-architecture.md
@@ -945,7 +945,8 @@ You can fork and/or clone
 to get started. Before building and running the test suite, remember to update
 the `lib.rs` and `Anchor.toml` with your local program ID.
 
-You can run the entire test suite or add `.only` to the `describe` call in a
+You can run the entire test suite or
+[add `.only` to the `describe` call](https://mochajs.org/#exclusive-tests) in a
 specific test file to only run that file's tests. Feel free to customize it and
 make it your own.
 


### PR DESCRIPTION
### Problem

In this page: 
https://solana.com/developers/courses/program-optimization/program-architecture
I mainly made 2 small changes:
1.  Remove `cd` from  **test -** `cd tests/sizes.ts`. because here it's meant to indicate the location of the test file, not a `cd` command to execute.
2. Add hyper link to https://mochajs.org/#exclusive-tests on how to add `.only` to the `describe` call, which can be helpful for anyone who hasn't used this feature before.

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->