### PR TITLE
fix: read token_account from bumps

### DIFF
--- a/content/courses/program-security/owner-checks.md
+++ b/content/courses/program-security/owner-checks.md
@@ -511,10 +511,7 @@ pub mod owner_check {
     pub fn secure_withdraw(ctx: Context<SecureWithdraw>) -> Result<()> {
         let amount = ctx.accounts.token_account.amount;
 
-        let seeds = &[
-            b"token".as_ref(),
-            &[*ctx.bumps.get("token_account").unwrap()],
-        ];
+        let seeds = &[b"token".as_ref(), &[ctx.bumps.token_account]];
         let signer = [&seeds[..]];
 
         let cpi_ctx = CpiContext::new_with_signer(


### PR DESCRIPTION
### Problem
in this page: https://solana.com/developers/courses/program-security/owner-checks
current rust code in the tutorial, using syntax `*ctx.bumps.get("token_account").unwrap()` to read `token_account` from `bumps`, that now no longer works on `anchor-lang = "0.30.1"`.  In fact, this has already been updated in the sample code repository, https://github.com/yanCode/owner-checks/blob/7bda9fb5051976b37ec7cd68aa9cf9595ad087b8/programs/owner-check/src/lib.rs#L49

I personally think while the code repository  got updated, the doc has'nt been update accordingly.


### Summary of Changes

Update the code as:

```rust
 let seeds = &[b"token".as_ref(), &[ctx.bumps.token_account]];

```
