### PR TITLE
chore(documentation): PDA's keypoints

### DIFF
--- a/docs/core/pda.md
+++ b/docs/core/pda.md
@@ -42,7 +42,7 @@ anything built at that location.
 - PDAs are addresses that fall off the Ed25519 curve and have no corresponding
   private key.
 
-- Solana programs can programmatically "sign" for PDAs that are derived using
+- Solana programs can programmatically "sign" on behalf of PDAs that are derived using
   its program ID.
 
 - Deriving a PDA does not automatically create an on-chain account.


### PR DESCRIPTION
### Problem

Sometimes we need to be quite explicit with wording in order to make ourselves 100% clear.

In that context _**for**_ leaves a bit of confusion of what we really want to express. That's why I propose to replace _**for**_ with  _**on behalf of**_ ...

### Summary of Changes

replace **_for_** with **_on behalf of ..._**  in order to express more clarity
