### PR TITLE
Add links to C# and gdscript sdks

### DIFF
--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -78,6 +78,8 @@ developers interact with the Solana network in most popular languages :
 | Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                                   |
 | Kotlin     | [solanaKT](https://github.com/metaplex-foundation/SolanaKT) or [sol4k](https://github.com/sol4k/sol4k)   |
 | Dart       | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)              |
+| C#         | [solnet](https://github.com/bmresearch/Solnet)                                                           |
+| GdScript   | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                 |
 
 You'll also need a connection with an RPC to interact with the network. You can
 either work with a [RPC infrastructure provider](https://solana.com/rpc) or


### PR DESCRIPTION
### Problem
C# and gd script sdks were missing from the list of client SDKs


### Summary of Changes
Added links to these SDKs
