### PR TITLE
Update `@solana/web3.js` documentation URLs to point at new `v1.x` folder

### DIFF
--- a/content/cookbook/development/subscribing-events.md
+++ b/content/cookbook/development/subscribing-events.md
@@ -9,7 +9,7 @@ Instead of pinging a typical HTTP endpoint at an interval to get frequent
 updates, you can instead receive those updates only when they happen.
 
 Solana's web3
-[`Connection`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html)
+[`Connection`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html)
 under the hood generates a websocket endpoint and registers a websocket client
 when you create a new `Connection` instance (see source code
 [here](https://github.com/solana-labs/solana-web3.js/blob/45923ca00e4cc1ed079d8e55ecbee83e5b4dc174/src/connection.ts#L2100)).
@@ -18,9 +18,9 @@ The `Connection` class exposes pub/sub methods - they all start with `on`, like
 event emitters. When you call these listener methods, it registers a new
 subscription to the websocket client of that `Connection` instance. The example
 pub/sub method we use below is
-[`onAccountChange`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#onAccountChange).
+[`onAccountChange`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#onAccountChange).
 The callback will provide the updated state data through arguments (see
-[`AccountChangeCallback`](https://solana-labs.github.io/solana-web3.js/modules.html#AccountChangeCallback)
+[`AccountChangeCallback`](https://solana-labs.github.io/solana-web3.js/v1.x/types/AccountChangeCallback.html)
 as an example).
 
 ```typescript filename="subscribe-to-events.ts"

--- a/content/courses/native-onchain-development/deserialize-custom-data-frontend.md
+++ b/content/courses/native-onchain-development/deserialize-custom-data-frontend.md
@@ -52,7 +52,7 @@ can be signed for by the program address used to create them.
 PDAs and the data inside them can be consistently found based on the program
 address, bump, and seeds. To find a PDA, the program ID and seeds of the
 developer's choice (like a string of text) are passed through the
-[`findProgramAddress()`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html#findProgramAddress)
+[`findProgramAddress()`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/PublicKey.html#findProgramAddress)
 function.
 
 Let's have a look at some examples...

--- a/content/guides/advanced/introduction-to-durable-nonces.md
+++ b/content/guides/advanced/introduction-to-durable-nonces.md
@@ -477,7 +477,7 @@ as we discussed before. This is done to avoid using the same nonce again.
 
 Voila, we've gone through a very real-life use case of Durable Nonces. Now let's
 see how to use them in transactions using JavaScript and the
-[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/) package.
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) package.
 
 ## Durable Nonces with Solana Web3.js
 

--- a/content/guides/dapps/cash-app.md
+++ b/content/guides/dapps/cash-app.md
@@ -1494,7 +1494,7 @@ const withdrawInstruction = await program.methods
 **Additional documentation:**
 
 - [Transactions and Instructions](https://solana.com/docs/core/transactions)
-- [Connection Class](https://solana-labs.github.io/solana-web3.js/classes/Connection.html)
+- [Connection Class](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html)
 - Library for
   [wallets](https://github.com/solana-mobile/mobile-wallet-adapter/tree/main/android/walletlib)
   to provide the Mobile Wallet Adapter transaction signing services to dapps

--- a/content/guides/getstarted/intro-to-native-rust.md
+++ b/content/guides/getstarted/intro-to-native-rust.md
@@ -326,7 +326,7 @@ pub struct NewAccount {
 
 Interacting with Solana programs written in native Rust involves directly
 building the
-[`TransactionInstruction`](https://solana-labs.github.io/solana-web3.js/classes/TransactionInstruction.html).
+[`TransactionInstruction`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/TransactionInstruction.html).
 
 Similarly, fetching and deserializing account data requires creating a schema
 compatible with the on-chain program's data structures.

--- a/content/guides/getstarted/solana-token-airdrop-and-faucets.md
+++ b/content/guides/getstarted/solana-token-airdrop-and-faucets.md
@@ -43,7 +43,7 @@ connection.requestAirdrop();
 ```
 
 See more:
-[`requestAirdrop()`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#requestAirdrop)
+[`requestAirdrop()`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#requestAirdrop)
 documentation inside web3.js.
 
 ## 2. Web Faucet

--- a/content/guides/javascript/compressed-nfts.md
+++ b/content/guides/javascript/compressed-nfts.md
@@ -808,7 +808,7 @@ helper function.
 
 Since each of these hash values resemble and are formatted similar to
 PublicKeys, we can use the
-[`PublicKey`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html)
+[`PublicKey`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/PublicKey.html)
 class in web3.js to convert them into an accepted byte array format.
 
 #### Send the transaction

--- a/content/guides/javascript/get-program-accounts.md
+++ b/content/guides/javascript/get-program-accounts.md
@@ -34,7 +34,7 @@ The `getProgramAccounts` RPC method has the following syntax:
     [State commitment](/docs/rpc/index.mdx#configuring-state-commitment)
   - (optional) `encoding`: `string` - Encoding for account data, either:
     `base58`, `base64`, or `jsonParsed`. Note, web3js users should instead use
-    [`getParsedProgramAccounts`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getParsedProgramAccounts)
+    [`getParsedProgramAccounts`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getParsedProgramAccounts)
   - (optional) `dataSlice`: `object` - Limit the returned account data based on:
     - `offset`: `number` - Number of bytes into account data to begin returning
     - `length`: `number` - Number of bytes of account data to return
@@ -307,5 +307,5 @@ interested in.
 ## Other Resources
 
 - [RPC API Documentation](https://solana.com/docs/rpc/http/getprogramaccounts)
-- [web3.js documentation](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getProgramAccounts)
-- [getParsedProgramAccounts documentation](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getParsedProgramAccounts)
+- [web3.js documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getProgramAccounts)
+- [getParsedProgramAccounts documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getParsedProgramAccounts)

--- a/docs/advanced/actions.md
+++ b/docs/advanced/actions.md
@@ -816,9 +816,9 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
 ```
 
 - `transaction` - The value must be a base64-encoded
-  [serialized transaction](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#serialize).
+  [serialized transaction](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#serialize).
   The client must base64-decode the transaction and
-  [deserialize it](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#from).
+  [deserialize it](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#from).
 
 - `message` - The value must be a UTF-8 string that describes the nature of the
   transaction included in the response. The client should display this value to
@@ -839,16 +839,16 @@ export interface ActionPostResponse<T extends ActionType = ActionType> {
 #### POST Response - Transaction
 
 If the transaction
-[`signatures`](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#signatures)
+[`signatures`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#signatures)
 are empty or the transaction has NOT been partially signed:
 
 - The client must ignore the
-  [`feePayer`](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#feePayer)
+  [`feePayer`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#feePayer)
   in the transaction and set the `feePayer` to the `account` in the request.
 - The client must ignore the
-  [`recentBlockhash`](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#recentBlockhash)
+  [`recentBlockhash`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#recentBlockhash)
   in the transaction and set the `recentBlockhash` to the
-  [latest blockhash](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getLatestBlockhash).
+  [latest blockhash](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getLatestBlockhash).
 - The client must serialize and deserialize the transaction before signing it.
   This ensures consistent ordering of the account keys, as a workaround for
   [this issue](https://github.com/solana-labs/solana/issues/21722).
@@ -856,9 +856,9 @@ are empty or the transaction has NOT been partially signed:
 If the transaction has been partially signed:
 
 - The client must NOT alter the
-  [`feePayer`](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#feePayer)
+  [`feePayer`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#feePayer)
   or
-  [`recentBlockhash`](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#recentBlockhash)
+  [`recentBlockhash`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html#recentBlockhash)
   as this would invalidate any existing signatures.
 - The client must verify existing signatures, and if any are invalid, the client
   must reject the transaction as **malformed**.
@@ -1189,7 +1189,7 @@ string with each separated by a semi-colon.
 No other data should be included with Identifier Message's Memo instruction.
 
 The `identity` and the `reference` should be included as read-only, non-signer
-[keys](https://solana-labs.github.io/solana-web3.js/classes/TransactionInstruction.html#keys)
+[keys](https://solana-labs.github.io/solana-web3.js/v1.x/classes/TransactionInstruction.html#keys)
 in the transaction on an instruction that is NOT the Identifier Message Memo
 instruction.
 

--- a/docs/advanced/lookup-tables.md
+++ b/docs/advanced/lookup-tables.md
@@ -39,7 +39,7 @@ Creating a new lookup table with the `@solana/web3.js` library is similar to the
 older `legacy` transactions, but with some differences.
 
 Using the `@solana/web3.js` library, you can use the
-[`createLookupTable`](https://solana-labs.github.io/solana-web3.js/classes/AddressLookupTableProgram.html#createLookupTable)
+[`createLookupTable`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/AddressLookupTableProgram.html#createLookupTable)
 function to construct the instruction needed to create a new lookup table, as
 well as determine its address:
 
@@ -75,7 +75,7 @@ console.log("lookup table address:", lookupTableAddress.toBase58());
 
 Adding addresses to a lookup table is known as "_extending_". Using the
 `@solana/web3.js` library, you can create a new _extend_ instruction using the
-[`extendLookupTable`](https://solana-labs.github.io/solana-web3.js/classes/AddressLookupTableProgram.html#extendLookupTable)
+[`extendLookupTable`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/AddressLookupTableProgram.html#extendLookupTable)
 method:
 
 ```js
@@ -109,7 +109,7 @@ Enabling up to 64 addresses in those future transactions.
 
 Similar to requesting another account (or PDA) from the cluster, you can fetch a
 complete Address Lookup Table with the
-[`getAddressLookupTable`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getAddressLookupTable)
+[`getAddressLookupTable`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getAddressLookupTable)
 method:
 
 ```js

--- a/docs/advanced/state-compression.md
+++ b/docs/advanced/state-compression.md
@@ -279,7 +279,7 @@ package, developers can use the
 function to calculate the required space for a given tree size parameters.
 
 Then using the
-[`getMinimumBalanceForRentExemption`](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getMinimumBalanceForRentExemption)
+[`getMinimumBalanceForRentExemption`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getMinimumBalanceForRentExemption)
 function to get the final cost (in lamports) to allocate the required space for
 the tree on-chain.
 

--- a/docs/advanced/versions.md
+++ b/docs/advanced/versions.md
@@ -45,13 +45,14 @@ transaction is returned when `legacy` is selected)
 ## How to set max supported version
 
 You can set the `maxSupportedTransactionVersion` using both the
-[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) library and
-JSON formatted requests directly to an RPC endpoint.
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) library
+and JSON formatted requests directly to an RPC endpoint.
 
 ### Using web3.js
 
-Using the [`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/)
-library, you can retrieve the most recent block or get a specific transaction:
+Using the
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) library,
+you can retrieve the most recent block or get a specific transaction:
 
 ```js
 // connect to the `devnet` cluster and get the current `slot`

--- a/docs/advanced/versions.md
+++ b/docs/advanced/versions.md
@@ -45,12 +45,12 @@ transaction is returned when `legacy` is selected)
 ## How to set max supported version
 
 You can set the `maxSupportedTransactionVersion` using both the
-[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/) library and
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) library and
 JSON formatted requests directly to an RPC endpoint.
 
 ### Using web3.js
 
-Using the [`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/)
+Using the [`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/)
 library, you can retrieve the most recent block or get a specific transaction:
 
 ```js

--- a/docs/clients/javascript-reference.md
+++ b/docs/clients/javascript-reference.md
@@ -11,13 +11,13 @@ The `@solana/web3.js` library is a package that has coverage over the
 [Solana JSON RPC API](/docs/rpc).
 
 You can find the full documentation for the `@solana/web3.js` library
-[here](https://solana-labs.github.io/solana-web3.js/).
+[here](https://solana-labs.github.io/solana-web3.js/v1.x/).
 
 ## General
 
 ### Connection
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Connection.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html)
 
 Connection is used to interact with the [Solana JSON RPC](/docs/rpc). You can
 use Connection to confirm transactions, get account info, and more.
@@ -62,12 +62,12 @@ console.log(slotLeader);
 ```
 
 The above example shows only a few of the methods on Connection. Please see the
-[source generated docs](https://solana-labs.github.io/solana-web3.js/classes/Connection.html)
+[source generated docs](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html)
 for the full list.
 
 ### Transaction
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Transaction.html)
 
 A transaction is used to interact with programs on the Solana blockchain. These
 transactions are constructed with TransactionInstructions, containing all the
@@ -142,7 +142,7 @@ await web3.sendAndConfirmRawTransaction(connection, rawTransaction);
 
 ### Keypair
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Keypair.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Keypair.html)
 
 The keypair is used to create an account with a public key and secret key within
 Solana. You can either generate, generate from a seed, or create from a secret
@@ -214,7 +214,7 @@ entropy. Do not share your seed. Treat the seed like you would a private key.
 
 ### PublicKey
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/PublicKey.html)
 
 PublicKey is used throughout `@solana/web3.js` in transactions, keypairs, and
 programs. You require publickey when listing each account in a transaction and
@@ -260,7 +260,7 @@ console.log(`Valid Program Address: ${validProgramAddress}`);
 
 ### SystemProgram
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/SystemProgram.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/SystemProgram.html)
 
 The SystemProgram grants the ability to create accounts, allocate account data,
 assign an account to programs, work with nonce accounts, and transfer lamports.
@@ -358,7 +358,7 @@ await web3.sendAndConfirmTransaction(connection, assignTransaction, [
 
 ### Secp256k1Program
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Secp256k1Program.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Secp256k1Program.html)
 
 The Secp256k1Program is used to verify Secp256k1 signatures, which are used by
 both Bitcoin and Ethereum.
@@ -421,7 +421,7 @@ await web3.sendAndConfirmTransaction(connection, transaction, [fromPublicKey]);
 
 ### Message
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Message.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Message.html)
 
 Message is used as another way to construct transactions. You can construct a
 message using the accounts, header, instructions, and recentBlockhash that are a
@@ -487,7 +487,7 @@ await web3.sendAndConfirmTransaction(connection, transaction, [fromPublicKey]);
 
 ### Struct
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Struct.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Struct.html)
 
 The struct class is used to create Rust compatible structs in javascript. This
 class is only compatible with Borsh encoded Rust structs.
@@ -517,7 +517,7 @@ export class Fee extends Struct {
 
 ### Enum
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Enum.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Enum.html)
 
 The Enum class is used to represent a Rust compatible Enum in javascript. The
 enum will just be a string representation if logged but can be properly
@@ -547,7 +547,7 @@ export class AccountType extends Enum {}
 
 ### NonceAccount
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/NonceAccount.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/NonceAccount.html)
 
 Normally a transaction is rejected if a transaction's `recentBlockhash` field is
 too old. To provide for certain custodial services, Nonce Accounts are used.
@@ -637,7 +637,7 @@ offline with the nonce in place of the `recentBlockhash`.
 
 ### VoteAccount
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/VoteAccount.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/VoteAccount.html)
 
 Vote account is an object that grants the capability of decoding vote accounts
 from the native vote account program on the network.
@@ -711,7 +711,7 @@ VoteAccount {
 
 ### StakeProgram
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/StakeProgram.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/StakeProgram.html)
 
 The StakeProgram facilitates staking SOL and delegating them to any validators
 on the network. You can use StakeProgram to create a stake account, stake some
@@ -811,7 +811,7 @@ await web3.sendAndConfirmTransaction(connection, withdrawTransaction, [
 
 ### Authorized
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Authorized.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Authorized.html)
 
 Authorized is an object used when creating an authorized account for staking
 within Solana. You can designate a `staker` and `withdrawer` separately,
@@ -822,7 +822,7 @@ You can find more usage of the `Authorized` object under
 
 ### Lockup
 
-[Source Documentation](https://solana-labs.github.io/solana-web3.js/classes/Lockup.html)
+[Source Documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Lockup.html)
 
 Lockup is used in conjunction with the
 [StakeProgram](/docs/clients/javascript.md#StakeProgram) to create an account.

--- a/docs/clients/javascript.md
+++ b/docs/clients/javascript.md
@@ -14,7 +14,7 @@ The Solana-Web3.js library aims to provide complete coverage of Solana. The
 library was built on top of the [Solana JSON RPC API](/docs/rpc).
 
 You can find the full documentation for the `@solana/web3.js` library
-[here](https://solana-labs.github.io/solana-web3.js/).
+[here](https://solana-labs.github.io/solana-web3.js/v1.x/).
 
 ## Common Terminology
 

--- a/docs/core/fees.md
+++ b/docs/core/fees.md
@@ -338,7 +338,7 @@ let instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
 #### Javascript
 
 The `@solana/web3.js` library includes functions within the
-[`ComputeBudgetProgram`](https://solana-labs.github.io/solana-web3.js/classes/ComputeBudgetProgram.html)
+[`ComputeBudgetProgram`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/ComputeBudgetProgram.html)
 class to craft instructions for setting the _compute unit limit_ and _compute
 unit price_:
 


### PR DESCRIPTION
### Problem

GitHub Pages doesn't offer 301 redirects. These URLs changed.

### Summary of Changes

Regex'd this: `solana-labs.github.io/solana-web3.js/([^\)]+)`
Replaced with: `solana-labs.github.io/solana-web3.js/v1.x/$1`