### PR TITLE
Update sendTransaction.mdx

### DIFF
--- a/docs/rpc/http/sendTransaction.mdx
+++ b/docs/rpc/http/sendTransaction.mdx
@@ -19,8 +19,8 @@ cluster.
 While the rpc service will reasonably retry to submit it, the transaction could
 be rejected if transaction's `recent_blockhash` expires before it lands.
 
-Use [`getSignatureStatuses`](#getsignaturestatuses) to ensure a transaction is
-processed and confirmed.
+Use [`getSignatureStatuses`](/docs/rpc/http/getSignatureStatuses) to ensure a
+transaction is processed and confirmed.
 
 Before submitting, the following preflight checks are performed:
 


### PR DESCRIPTION
### Problem

The link to `getSignatureStatuses` in `sendTransaction` page doesn't work.

### Summary of Changes

This PR updates the link to ensure it points to the correct page.