### PR TITLE
fix typo in intro-to-custom-onchain-programs.md

### DIFF
--- a/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
+++ b/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
@@ -145,12 +145,8 @@ also have. Let's add the string versions of both of those as constants at the
 top of the file:
 
 ```typescript
-const PING_PROGRAM_ADDRESS = new web3.PublicKey(
-  "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa",
-);
-const PING_PROGRAM_DATA_ADDRESS = new web3.PublicKey(
-  "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod",
-);
+const PING_PROGRAM_ADDRESS = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
+const PING_PROGRAM_DATA_ADDRESS = "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
 ```
 
 Now let's create a new transaction, then initialize a `PublicKey` for the

--- a/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
+++ b/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
@@ -145,10 +145,9 @@ also have. Let's add the string versions of both of those as constants at the
 top of the file:
 
 ```typescript
-const PING_PROGRAM_ADDRESS 
-  = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
-const PING_PROGRAM_DATA_ADDRESS 
-  = "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
+const PING_PROGRAM_ADDRESS = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
+const PING_PROGRAM_DATA_ADDRESS =
+  "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
 ```
 
 Now let's create a new transaction, then initialize a `PublicKey` for the

--- a/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
+++ b/content/courses/intro-to-solana/intro-to-custom-onchain-programs.md
@@ -145,8 +145,10 @@ also have. Let's add the string versions of both of those as constants at the
 top of the file:
 
 ```typescript
-const PING_PROGRAM_ADDRESS = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
-const PING_PROGRAM_DATA_ADDRESS = "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
+const PING_PROGRAM_ADDRESS 
+  = "ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa";
+const PING_PROGRAM_DATA_ADDRESS 
+  = "Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod";
 ```
 
 Now let's create a new transaction, then initialize a `PublicKey` for the


### PR DESCRIPTION
### Problem
I found a typo in the code example. The address constants should be strings, as the keys are declared using them below.


### Summary of Changes
Change the address constants to string type.


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->