### PR TITLE
[docs/rpc] fix incorrect `space` labels

### DIFF
--- a/docs/rpc/http/getAccountInfo.mdx
+++ b/docs/rpc/http/getAccountInfo.mdx
@@ -90,7 +90,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
     \(and is strictly read-only\)
   - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as
     u64
-  - `size: <u64>` - the data size of the account
+  - `space: <u64>` - the data size of the account
 
 </DocLeftSide>
 
@@ -120,19 +120,14 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 {
   "jsonrpc": "2.0",
   "result": {
-    "context": {
-      "slot": 1
-    },
+    "context": { "apiVersion": "2.0.15", "slot": 341197053 },
     "value": {
-      "data": [
-        "11116bv5nS2h3y12kD1yUKeMZvGcKLSjQgX6BeV7u1FrjeJcKfsHRTPuR3oZ1EioKtYGiYxpxMG5vpbZLsbcBYBEmZZcMKaSoGx9JZeAuWf",
-        "base58"
-      ],
+      "data": ["", "base58"],
       "executable": false,
-      "lamports": 1000000000,
+      "lamports": 88849814690250,
       "owner": "11111111111111111111111111111111",
-      "rentEpoch": 2,
-      "space": 80
+      "rentEpoch": 18446744073709551615,
+      "space": 0
     }
   },
   "id": 1

--- a/docs/rpc/http/getMultipleAccounts.mdx
+++ b/docs/rpc/http/getMultipleAccounts.mdx
@@ -93,7 +93,7 @@ The result will be a JSON object with `value` equal to an array of:
     \(and is strictly read-only\)
   - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as
     u64
-  - `space: <u64>` - the data size of the account
+  - `size: <u64>` - the data size of the account
 
 </DocLeftSide>
 
@@ -126,24 +126,22 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 {
   "jsonrpc": "2.0",
   "result": {
-    "context": {
-      "slot": 1
-    },
+    "context": { "apiVersion": "2.0.15", "slot": 341197247 },
     "value": [
       {
-        "data": ["", "base64"],
+        "data": ["", "base58"],
         "executable": false,
-        "lamports": 1000000000,
+        "lamports": 88849814690250,
         "owner": "11111111111111111111111111111111",
-        "rentEpoch": 2,
-        "space": 16
+        "rentEpoch": 18446744073709551615,
+        "space": 0
       },
       {
-        "data": ["", "base64"],
+        "data": ["", "base58"],
         "executable": false,
-        "lamports": 5000000000,
-        "owner": "11111111111111111111111111111111",
-        "rentEpoch": 2,
+        "lamports": 998763433,
+        "owner": "2WRuhE4GJFoE23DYzp2ij6ZnuQ8p9mJeU6gDgfsjR4or",
+        "rentEpoch": 18446744073709551615,
         "space": 0
       }
     ]

--- a/docs/rpc/http/getProgramAccounts.mdx
+++ b/docs/rpc/http/getProgramAccounts.mdx
@@ -119,7 +119,7 @@ The resultant response array will contain:
     \(and is strictly read-only\)
   - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as
     u64
-  - `size: <u64>` - the data size of the account
+  - `space: <u64>` - the data size of the account
 
 </DocLeftSide>
 

--- a/docs/rpc/http/getTokenAccountsByDelegate.mdx
+++ b/docs/rpc/http/getTokenAccountsByDelegate.mdx
@@ -101,7 +101,7 @@ JSON objects, which will contain:
     (and is strictly read-only\)
   - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as
     u64
-  - `size: <u64>` - the data size of the account
+  - `space: <u64>` - the data size of the account
 
 When the data is requested with the `jsonParsed` encoding a format similar to
 that of the [Token Balances Structure](/docs/rpc/json-structures#token-balances)

--- a/docs/rpc/http/getTokenAccountsByOwner.mdx
+++ b/docs/rpc/http/getTokenAccountsByOwner.mdx
@@ -101,7 +101,7 @@ JSON objects, which will contain:
     \(and is strictly read-only\)
   - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as
     u64
-  - `size: <u64>` - the data size of the account
+  - `space: <u64>` - the data size of the account
 
 When the data is requested with the `jsonParsed` encoding a format similar to
 that of the [Token Balances Structure](/docs/rpc/json-structures#token-balances)
@@ -137,13 +137,9 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 
 ```json
 {
-  "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "context": {
-      "apiVersion": "2.0.8",
-      "slot": 329669901
-    },
+    "context": { "apiVersion": "2.0.15", "slot": 341197933 },
     "value": [
       {
         "account": {
@@ -151,14 +147,14 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
             "parsed": {
               "info": {
                 "isNative": false,
-                "mint": "BejB75Gmq8btLboHx7yffWcurHVBv5xvKcnY1fBYxnvf",
+                "mint": "2cHr7QS3xfuSV8wdxo3ztuF4xbiarF6Nrgx3qpx3HzXR",
                 "owner": "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd",
                 "state": "initialized",
                 "tokenAmount": {
-                  "amount": "10000000000000",
-                  "decimals": 9,
-                  "uiAmount": 10000,
-                  "uiAmountString": "10000"
+                  "amount": "420000000000000",
+                  "decimals": 6,
+                  "uiAmount": 420000000.0,
+                  "uiAmountString": "420000000"
                 }
               },
               "type": "account"
@@ -172,7 +168,7 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
           "rentEpoch": 18446744073709551615,
           "space": 165
         },
-        "pubkey": "5HvuXcy57o41qtGBBJM7dRN9DS6G3jd9KEhHt4eYqJmB"
+        "pubkey": "BGocb4GEpbTFm8UFV2VsDSaBXHELPfAXrvd4vtt8QWrA"
       },
       {
         "account": {
@@ -180,13 +176,13 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
             "parsed": {
               "info": {
                 "isNative": false,
-                "mint": "FSX34rYUJ4zfdD7z4p3L1Fd1pGiiErusaSNTfgKqhep6",
+                "mint": "4KVSsAtsG8JByKfB2jYWgGwvVR9WcBSUfsqpTSL9c3Jr",
                 "owner": "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd",
                 "state": "initialized",
                 "tokenAmount": {
                   "amount": "10000000000000",
                   "decimals": 9,
-                  "uiAmount": 10000,
+                  "uiAmount": 10000.0,
                   "uiAmountString": "10000"
                 }
               },
@@ -201,10 +197,11 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
           "rentEpoch": 18446744073709551615,
           "space": 165
         },
-        "pubkey": "HvTGvCP4tg2wVdFtqZCTdMPHDXmkYwNAxaTBCHabqh2X"
+        "pubkey": "9PwCPoWJ75LSgZeGMubXBdufYMVd66HrcF78QzW6ZHkV"
       }
     ]
-  }
+  },
+  "id": 1
 }
 ```
 


### PR DESCRIPTION
### Problem

Several rpc docs locations mislabel the `space` value as `size`

### Summary of Changes

- corrected `space` labels
- updated some of the rpc responses too

Related: https://github.com/solana-labs/web3.js-issue-conveyer/issues/3

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->