### PR TITLE
Small typos in anchor-cpi.md leading to failing tests

### DIFF
--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -383,7 +383,7 @@ pub struct InitializeMint<'info> {
         bump,
         payer = user,
         mint::decimals = 6,
-        mint::authority = mint,
+        mint::authority = user,
     )]
     pub mint: Account<'info, Mint>,
     #[account(mut)]

--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -145,7 +145,7 @@ The `cpi` module turns `callee`'s instruction handlers into Rust functions.
 These functions take a `CpiContext` and any extra data needed for the
 instruction. They work just like the instruction handlers in your Anchor
 programs, but use `CpiContext` instead of `Context`. The `cpi` module also
-provides the account structs needed for these instruction handler.
+provides the account structs needed for these instruction handlers.
 
 For example, if `callee` has the instruction `do_something` that requires the
 accounts defined in the `DoSomething` struct, you could invoke `do_something` as
@@ -661,7 +661,7 @@ it("Initializes the reward token", async () => {
 });
 ```
 
-Notice that we didn't have to add `.accounts` because they call be inferred,
+Notice that we didn't have to add `.accounts` because they can be inferred,
 including the `mint` account (assuming you have seed inference enabled).
 
 Next, update the test for the `addMovieReview` instruction. The primary


### PR DESCRIPTION
### Problem

Found these small typos while I was going through this lesson. One of the typos in the code snippets was leading to failing tests when running `anchor test` at the end of the lab:

```
  anchor-movie-review-program
    ✔ Initializes the reward token (271ms)
    1) Movie review is added
    2) Movie review is updated
    3) Movie review is deleted


  1 passing (305ms)
  3 failing

  1) anchor-movie-review-program
       Movie review is added:
     Simulation failed. 
Message: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x4. 
Logs: 
[
  "Program log: Title: Test Movie",
  "Program log: Description: This was a very good movie.",
  "Program log: Rating: 5",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
  "Program log: Instruction: MintTo",
  "Program log: Error: owner does not match",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4253 of 145107 compute units",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x4",
  "Program 8kwE9wZmCjb4WoyUTxV8MFFrge8jUbwLtQgiEGHZwJYW consumed 59146 of 200000 compute units",
  "Program 8kwE9wZmCjb4WoyUTxV8MFFrge8jUbwLtQgiEGHZwJYW failed: custom program error: 0x4"
]. 
Catch the `SendTransactionError` and call `getLogs()` on it for full details.
  

  2) anchor-movie-review-program
       Movie review is updated:
     Error: AnchorError caused by account: movie_review. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.
      at Function.parse (node_modules/@coral-xyz/anchor/src/error.ts:168:14)
      at translateError (node_modules/@coral-xyz/anchor/src/error.ts:277:35)
      at MethodsBuilder.rpc [as _rpcFn] (node_modules/@coral-xyz/anchor/src/program/namespace/rpc.ts:35:29)
      at processTicksAndRejections (node:internal/process/task_queues:105:5)

  3) anchor-movie-review-program
       Movie review is deleted:
     Error: AnchorError caused by account: movie_review. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.
      at Function.parse (node_modules/@coral-xyz/anchor/src/error.ts:168:14)
      at translateError (node_modules/@coral-xyz/anchor/src/error.ts:277:35)
      at MethodsBuilder.rpc [as _rpcFn] (node_modules/@coral-xyz/anchor/src/program/namespace/rpc.ts:35:29)
      at processTicksAndRejections (node:internal/process/task_queues:105:5)



error Command failed with exit code 3.
```

### Summary of Changes

Changed 2 words and fixed a small bug in the code snippet. Now the tests are passing:

```
  anchor-movie-review-program
    ✔ Initializes the reward token (147ms)
    ✔ Movie review is added (482ms)
    ✔ Movie review is updated (475ms)
    ✔ Movie review is deleted (475ms)


  4 passing (2s)
```