### PR TITLE
Fixing compile error in Anchor CPI lesson

### DIFF
--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -362,10 +362,10 @@ anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
 anchor-spl = "0.30.1"
 ```
 
-Since we are adding `anchor-spl` as a dependency we also need to add the `idl-build`
-for it in the features section of `Cargo.toml`. This is because all types that will be
-used in the `Accounts` structures that we are adding in this lesson require the `IdlBuild`
-trait implementation to generate an IDL.
+Since we are adding `anchor-spl` as a dependency we also need to add the
+`idl-build` for it in the features section of `Cargo.toml`. This is because all
+types that will be used in the `Accounts` structures that we are adding in this
+lesson require the `IdlBuild` trait implementation to generate an IDL.
 
 ```rust
 [features]

--- a/content/courses/onchain-development/anchor-cpi.md
+++ b/content/courses/onchain-development/anchor-cpi.md
@@ -362,6 +362,17 @@ anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
 anchor-spl = "0.30.1"
 ```
 
+Since we are adding `anchor-spl` as a dependency we also need to add the `idl-build`
+for it in the features section of `Cargo.toml`. This is because all types that will be
+used in the `Accounts` structures that we are adding in this lesson require the `IdlBuild`
+trait implementation to generate an IDL.
+
+```rust
+[features]
+# All lines remain unchanged, except for this idl-build line
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+```
+
 ### Initialize reward token
 
 Next, navigate to `lib.rs` and implement the `InitializeMint` context type and


### PR DESCRIPTION
### Problem

After implementing the code in the Lab section of the Anchor CPI lesson [here](https://solana.com/developers/courses/onchain-development/anchor-cpi), I ran into the following build errors:

```
% anchor build
   Compiling anchor-movie-review-program v0.1.0 (/Users/s/anchor-movie-review-program/programs/anchor-movie-review-program)
    Finished release [optimized] target(s) in 1.46s
   Compiling anchor-movie-review-program v0.1.0 (/Users/s/anchor-movie-review-program/programs/anchor-movie-review-program)
error[E0599]: no function or associated item named `create_type` found for struct `anchor_spl::token::Mint` in the current scope
  --> programs/anchor-movie-review-program/src/lib.rs:89:10
   |
89 | #[derive(Accounts)]
   |          ^^^^^^^^ function or associated item not found in `Mint`
   |
   = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `anchor_spl::token::Mint: Discriminator` is not satisfied
  --> programs/anchor-movie-review-program/src/lib.rs:99:30
   |
99 |     pub mint: Account<'info, Mint>,
   |                              ^^^^ the trait `Discriminator` is not implemented for `anchor_spl::token::Mint`
   |
   = help: the following other types implement trait `Discriminator`:
             InitializeTokenMint
             MovieAccountState
             __idl::IdlAccount
             anchor_lang::ProgramData
             anchor_lang::idl::IdlAccount
             instruction::AddMovieReview
             instruction::DeleteMovieReview
             instruction::UpdateMovieReview

error[E0599]: no function or associated item named `insert_types` found for struct `anchor_spl::token::Mint` in the current scope
  --> programs/anchor-movie-review-program/src/lib.rs:89:10
   |
89 | #[derive(Accounts)]
   |          ^^^^^^^^ function or associated item not found in `Mint`
   |
   = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no function or associated item named `create_type` found for struct `anchor_spl::token::Mint` in the current scope
   --> programs/anchor-movie-review-program/src/lib.rs:107:10
    |
107 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `Mint`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `anchor_spl::token::Mint: Discriminator` is not satisfied
   --> programs/anchor-movie-review-program/src/lib.rs:127:30
    |
127 |     pub mint: Account<'info, Mint>,
    |                              ^^^^ the trait `Discriminator` is not implemented for `anchor_spl::token::Mint`
    |
    = help: the following other types implement trait `Discriminator`:
              InitializeTokenMint
              MovieAccountState
              __idl::IdlAccount
              anchor_lang::ProgramData
              anchor_lang::idl::IdlAccount
              instruction::AddMovieReview
              instruction::DeleteMovieReview
              instruction::UpdateMovieReview

error[E0599]: no function or associated item named `insert_types` found for struct `anchor_spl::token::Mint` in the current scope
   --> programs/anchor-movie-review-program/src/lib.rs:107:10
    |
107 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `Mint`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no function or associated item named `create_type` found for struct `anchor_spl::token::TokenAccount` in the current scope
   --> programs/anchor-movie-review-program/src/lib.rs:107:10
    |
107 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `TokenAccount`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `anchor_spl::token::TokenAccount: Discriminator` is not satisfied
   --> programs/anchor-movie-review-program/src/lib.rs:134:39
    |
134 |     pub token_account: Account<'info, TokenAccount>,
    |                                       ^^^^^^^^^^^^ the trait `Discriminator` is not implemented for `anchor_spl::token::TokenAccount`
    |
    = help: the following other types implement trait `Discriminator`:
              InitializeTokenMint
              MovieAccountState
              __idl::IdlAccount
              anchor_lang::ProgramData
              anchor_lang::idl::IdlAccount
              instruction::AddMovieReview
              instruction::DeleteMovieReview
              instruction::UpdateMovieReview

error[E0599]: no function or associated item named `insert_types` found for struct `anchor_spl::token::TokenAccount` in the current scope
   --> programs/anchor-movie-review-program/src/lib.rs:107:10
    |
107 | #[derive(Accounts)]
    |          ^^^^^^^^ function or associated item not found in `TokenAccount`
    |
    = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `anchor-movie-review-program` (lib test) due to 9 previous errors
Error: Building IDL failed
```

### Summary of Changes

Added a paragraph to the lesson that indicates what needs to be added to the `Cargo.toml` file in order for the code to compile successfully.
<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->