### PR TITLE
removing comma which makes JSON example as invalid

### DIFF
--- a/docs/rpc/http/simulateTransaction.mdx
+++ b/docs/rpc/http/simulateTransaction.mdx
@@ -157,7 +157,7 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
     "params": [
       "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDArczbMia1tLmq7zz4DinMNN0pJ1JtLdqIJPUw3YrGCzYAMHBsgN27lcgB6H2WQvFgyZuJYHa46puOQo9yQ8CVQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCp20C7Wj2aiuk5TReAXo+VTVg8QTHjs0UjNMMKCvpzZ+ABAgEBARU=",
       {
-        "encoding":"base64",
+        "encoding":"base64"
       }
     ]
   }


### PR DESCRIPTION
### Problem
When I was trying the simulate transaction RPC method, I realized that the example had a typo error. 


### Summary of Changes
I removed the typo error.


Fixes #

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->