### PR TITLE
minor updates to web3js v2 examples

### DIFF
--- a/content/cookbook/transactions/send-sol.md
+++ b/content/cookbook/transactions/send-sol.md
@@ -66,7 +66,7 @@ async function transferSol() {
   console.log("Requesting airdrop");
   await airdrop({
     commitment: "confirmed",
-    lamports: lamports(1000_000n),
+    lamports: lamports(1_000_000_000n),
     recipientAddress: keypairSigner.address,
   });
   console.log("Airdrop confirmed");
@@ -85,7 +85,7 @@ async function transferSol() {
           getTransferSolInstruction({
             source: keypairSigner,
             destination: address("web3Qm5PuFapMJqe6PWRWfRBarkeqE2ZC8Eew3zwHH2"),
-            amount: lamports(1_000n),
+            amount: lamports(1_000_000n),
           }),
         ],
         m,

--- a/content/cookbook/wallets/connect-wallet-react.md
+++ b/content/cookbook/wallets/connect-wallet-react.md
@@ -11,6 +11,11 @@ makes it easy to manage wallet connections client-side. For a full length guide,
 check out
 [Add Solana Wallet Adapter to a NextJS application](/content/guides/wallets/add-solana-wallet-adapter-to-nextjs.md).
 
+> For web3.js v2, please reference the
+> [react example](https://github.com/solana-labs/solana-web3.js/tree/master/examples/react-app)
+> from the
+> [Anza Web3js v2 Blog](https://www.anza.xyz/blog/solana-web3-js-2-release).
+
 ## How to Connect to a Wallet with React
 
 > Currently, `create-solana-dapp` only works with Solana Web3.js v1.

--- a/content/cookbook/wallets/restore-keypair.md
+++ b/content/cookbook/wallets/restore-keypair.md
@@ -12,36 +12,34 @@ secret to test out your dApp.
 <Tabs groupId="language" items={['web3.js v2', 'web3.js v1']}>
 
 <Tab value="web3.js v2">
-  
-```typescript
 
+```typescript
 import { createKeyPairFromBytes } from "@solana/web3.js";
 
-const keypairBytes = new Uint8Array([ 174, 47, 154, 16, 202, 193, 206, 113,
-199, 190, 53, 133, 169, 175, 31, 56, 222, 53, 138, 189, 224, 216, 117, 173,
-10, 149, 53, 45, 73, 251, 237, 246, 15, 185, 186, 82, 177, 240, 148, 69,
-241, 227, 167, 80, 141, 89, 240, 121, 121, 35, 172, 247, 68, 251, 226, 218,
-48, 63, 176, 109, 168, 89, 238, 135 ]);
+const keypairBytes = new Uint8Array([
+  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
+  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
+  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
+  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135,
+]);
 
 const keypair = await createKeyPairFromBytes(keypairBytes);
-
 ```
+
 </Tab>
-
 <Tab value="web3.js v1">
-  
-```typescript
 
+```typescript
 import { Keypair } from "@solana/web3.js";
 
-const keypairBytes = Uint8Array.from([ 174, 47, 154, 16,
-202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56, 222, 53, 138, 189,
-224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15, 185, 186, 82,
-177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121, 35, 172, 247,
-68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135 ]),
+const keypairBytes = Uint8Array.from([
+  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
+  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
+  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
+  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135,
+]);
 
-const keypair = Keypair.fromSecretKey( keypairBytes );
-
+const keypair = Keypair.fromSecretKey(keypairBytes);
 ```
 
 </Tab>
@@ -52,29 +50,27 @@ const keypair = Keypair.fromSecretKey( keypairBytes );
 <Tabs groupId="language" items={['web3.js v2', 'web3.js v1']}>
 
 <Tab value="web3.js v2">
-  
-```typescript
 
+```typescript
 import { createKeyPairFromBytes, getBase58Codec } from "@solana/web3.js";
 
-const keypairBase58 = "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG";
-const keypairBytes = getBase58Codec().decode(keypairBase58); 
+const keypairBase58 =
+  "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG";
+const keypairBytes = getBase58Codec().decode(keypairBase58);
 const keypair = await createKeyPairFromBytes(keypairBytes);
-
 ```
+
 </Tab>
-
 <Tab value="web3.js v1">
-  
-```typescript
 
+```typescript
 import { Keypair } from "@solana/web3.js";
 import * as bs58 from "bs58";
 
-const keypairBase58 = "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG";
+const keypairBase58 =
+  "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG";
 const keypairBytes = bs58.decode(keypairBase58);
 const keypair = Keypair.fromSecretKey(keypairBytes);
-
 ```
 
 </Tab>


### PR DESCRIPTION
- fix prettier error
- add link to web3js react example
- use `createKeyPairSignerFromBytes` instead of `createKeyPairFromBytes`
- increase lamports in SOL transfer above minimum rent