### PR TITLE
Small typo in signer-auth.md

### DIFF
--- a/content/courses/program-security/signer-auth.md
+++ b/content/courses/program-security/signer-auth.md
@@ -198,8 +198,8 @@ performed.
 ### Using Anchor's `#[account(signer)]` Constraint
 
 While the `Signer` account type is useful, it doesn't perform other ownership or
-type checks, limiting its use in instruction handler logic. The
-[anchor's `#[account(signer)]`](https://www.anchor-lang.com/docs/account-constraints)
+type checks, limiting its use in instruction handler logic.
+[Anchor's `#[account(signer)]`](https://www.anchor-lang.com/docs/account-constraints)
 constraint addresses this by verifying that the account signed the transaction
 while allowing access to its underlying data.
 


### PR DESCRIPTION
### Problem

Typo in [Signer Auth lesson](https://solana.com/developers/courses/program-security/signer-auth)

### Summary of Changes

No changes in code, just a simple text change to fix a typo.

<!-- 
Note: The maintainers of this repo may make editorial changes as needed without creating comments.
Please ensure you have "Allow edits by maintainers" setting on this PR enabled to help speed up the review process. Thanks :)
-->