### PR TITLE
docs: update anza docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For specific validator clients, consult their respective documentation:
 
 | Validator Client         | Repo                                                               | Website                                                |
 | ------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------ |
-| Anza's Agave             | [Repo](https://github.com/anza-xyz/agave/blob/master/docs)         | [Website](https://docs.solanalabs.com/)                |
+| Anza's Agave             | [Repo](https://github.com/anza-xyz/agave/blob/master/docs)         | [Website](https://docs.anza.xyz/)                      |
 | Jump Crypto's Firedancer | [Repo](https://github.com/firedancer-io/firedancer/tree/main/book) | [Website](https://firedancer-io.github.io/firedancer/) |
 
 ### Developer Guides

--- a/content/cookbook/transactions/send-sol.md
+++ b/content/cookbook/transactions/send-sol.md
@@ -175,4 +175,4 @@ import {
 
 </Tabs>
 
-[1]: https://docs.solanalabs.com/runtime/programs#system-program
+[1]: https://docs.anza.xyz/runtime/programs#system-program

--- a/content/courses/native-onchain-development/program-security.md
+++ b/content/courses/native-onchain-development/program-security.md
@@ -372,9 +372,8 @@ let account_len: usize = 1000;
 ```
 
 The [realloc](https://docs.rs/solana-sdk/latest/solana_sdk/account_info/struct.AccountInfo.html#method.realloc) method
-was just recently enabled by Solana Labs which allows you to dynamically change
-the size of your accounts. We will not be using this method for this lab, but
-it's something to be aware of.
+allows you to dynamically change the size of your accounts. We will not be using
+this method for this lab, but it's something to be aware of.
 
 Finally, we've also implemented some additional functionality for our
 `MovieAccountState` struct in `state.rs` using the `impl` keyword.

--- a/content/courses/offline-transactions/durable-nonces.md
+++ b/content/courses/offline-transactions/durable-nonces.md
@@ -171,7 +171,7 @@ the nonce. This ensures that every transaction which is signed using the nonce
 as the recent blockhash will be unique.
 
 It is important to note that durable nonces require
-[unique mechanisms within Solana](https://docs.solanalabs.com/implemented-proposals/durable-tx-nonces)
+[unique mechanisms within Solana](https://docs.anza.xyz/implemented-proposals/durable-tx-nonces)
 to function, thus they have some special rules that don't apply normally. We'll
 see this as we deep dive into the technicals.
 

--- a/content/guides/advanced/introduction-to-durable-nonces.md
+++ b/content/guides/advanced/introduction-to-durable-nonces.md
@@ -619,5 +619,5 @@ change will happen on-chain, and the winner can be decided.
 ## References
 
 - [Neodyme Blog: Nonce Upon a Time, or a Total Loss of Funds](https://neodyme.io/blog/nonce-upon-a-time/)
-- [Solana Durable Nonces CLI](https://docs.solanalabs.com/cli/examples/durable-nonce)
-- [Solana Durable Transaction Nonces Proposal](https://docs.solanalabs.com/implemented-proposals/durable-tx-nonces)
+- [Solana Durable Nonces CLI](https://docs.anza.xyz/cli/examples/durable-nonce)
+- [Solana Durable Transaction Nonces Proposal](https://docs.anza.xyz/implemented-proposals/durable-tx-nonces)

--- a/content/guides/getstarted/local-rust-hello-world.md
+++ b/content/guides/getstarted/local-rust-hello-world.md
@@ -57,9 +57,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ## Run your localhost validator
 
 The Solana CLI comes with the
-[test validator](https://docs.solanalabs.com/cli/examples/test-validator) built
-in. This command line tool will allow you to run a full blockchain cluster on
-your machine.
+[test validator](https://docs.anza.xyz/cli/examples/test-validator) built in.
+This command line tool will allow you to run a full blockchain cluster on your
+machine.
 
 ```shell
 solana-test-validator
@@ -201,8 +201,8 @@ solana program deploy ./target/deploy/hello_world.so
 ```
 
 Once your Solana program has been deployed (and the transaction
-[finalized](https://docs.solanalabs.com/consensus/commitments)), the above
-command will output your program's public address (aka its "program id").
+[finalized](https://docs.anza.xyz/consensus/commitments)), the above command
+will output your program's public address (aka its "program id").
 
 ```shell
 # example output

--- a/content/guides/getstarted/rust-to-solana.md
+++ b/content/guides/getstarted/rust-to-solana.md
@@ -115,7 +115,7 @@ provides a local Solana runtime instance which can be used in conjunction with
 outside tests sending transactions.
 
 Finally, a full test cluster can be started with the
-[solana-test-validator](https://docs.solanalabs.com/cli/examples/test-validator),
+[solana-test-validator](https://docs.anza.xyz/cli/examples/test-validator),
 installed along with the Solana CLI. This creates a fully featured test cluster
 on a local machine, which can then deploy programs and run tests.
 

--- a/docs/advanced/confirmation.md
+++ b/docs/advanced/confirmation.md
@@ -230,7 +230,7 @@ to a different commitment level.
 The `confirmed` commitment level should almost always be used for RPC requests
 because it's usually only a few slots behind the `processed` commitment and has
 a very low chance of belonging to a dropped
-[fork](https://docs.solanalabs.com/consensus/fork-generation).
+[fork](https://docs.anza.xyz/consensus/fork-generation).
 
 But feel free to consider the other options:
 
@@ -396,7 +396,7 @@ Here's how these durable transactions are processed by the Solana runtime:
    processed again
 
 For more details about how these durable transactions work, you can read the
-[original proposal](https://docs.solanalabs.com/implemented-proposals/durable-tx-nonces)
+[original proposal](https://docs.anza.xyz/implemented-proposals/durable-tx-nonces)
 and
 [check out an example](/content/guides/advanced/introduction-to-durable-nonces.md)
 in the Solana docs.

--- a/docs/advanced/lookup-tables.md
+++ b/docs/advanced/lookup-tables.md
@@ -187,7 +187,6 @@ console.log(
 
 ## More Resources
 
-- Read the
-  [proposal](https://docs.solanalabs.com/proposals/versioned-transactions) for
-  Address Lookup Tables and Versioned transactions
+- Read the [proposal](https://docs.anza.xyz/proposals/versioned-transactions)
+  for Address Lookup Tables and Versioned transactions
 - [Example Rust program using Address Lookup Tables](https://github.com/TeamRaccoons/address-lookup-table-multi-swap)

--- a/docs/advanced/versions.md
+++ b/docs/advanced/versions.md
@@ -187,5 +187,5 @@ console.log(`https://explorer.solana.com/tx/${txId}?cluster=devnet`);
   [example of a v0 transaction](https://explorer.solana.com/tx/h9WQsqSUYhFvrbJWKFPaXximJpLf6Z568NW1j6PBn3f7GPzQXe9PYMYbmWSUFHwgnUmycDNbEX9cr6WjUWkUFKx/?cluster=devnet)
   on Solana Explorer
 - read the
-  [accepted proposal](https://docs.solanalabs.com/proposals/versioned-transactions)
+  [accepted proposal](https://docs.anza.xyz/proposals/versioned-transactions)
   for Versioned Transaction and Address Lookup Tables

--- a/docs/core/accounts.md
+++ b/docs/core/accounts.md
@@ -87,7 +87,7 @@ balance, anyone can increase the balance.
 Solana contains a small handful of native programs that are part of the
 validator implementation and provide various core functionalities for the
 network. You can find the full list of native programs
-[here](https://docs.solanalabs.com/runtime/programs).
+[here](https://docs.anza.xyz/runtime/programs).
 
 When developing custom programs on Solana, you will commonly interact with two
 native programs, the System Program and the BPF Loader.
@@ -128,7 +128,7 @@ executing custom programs.
 Sysvar accounts are special accounts located at predefined addresses that
 provide access to cluster state data. These accounts are dynamically updated
 with data about the network cluster. You can find the full list of Sysvar
-Accounts [here](https://docs.solanalabs.com/runtime/sysvars).
+Accounts [here](https://docs.anza.xyz/runtime/sysvars).
 
 ## Custom Programs
 

--- a/docs/core/fees.md
+++ b/docs/core/fees.md
@@ -72,8 +72,8 @@ The same is true on Solana. Specifically:
   (destroyed), with the remaining going to the current
   [leader](/docs/terminology.md#leader) processing the transaction.
 - A scheduled global inflation rate provides a source for
-  [rewards](https://docs.solanalabs.com/implemented-proposals/staking-rewards)
-  distributed to [Solana Validators](https://docs.solanalabs.com/operations).
+  [rewards](https://docs.anza.xyz/implemented-proposals/staking-rewards)
+  distributed to [Solana Validators](https://docs.anza.xyz/operations).
 
 ### Fee collection
 
@@ -413,7 +413,7 @@ The Solana rent rate is set on a network wide basis, primarily based on a
 runtime set
 "[lamports _per_ byte _per_ year](https://github.com/anza-xyz/agave/blob/b7bbe36918f23d98e2e73502e3c4cba78d395ba9/sdk/program/src/rent.rs#L27-L34)".
 Currently, the rent rate is a static amount and stored in the
-[Rent sysvar](https://docs.solanalabs.com/runtime/sysvars#rent).
+[Rent sysvar](https://docs.anza.xyz/runtime/sysvars#rent).
 
 This rent rate is used to calculate the exact amount of rent required to be
 withheld inside an account for the space allocated to the account (i.e. the
@@ -451,7 +451,7 @@ recommended to use the
 RPC endpoint to calculate the specific balance for a given account size.
 
 The required rent deposit amount can also be estimated via the
-[`solana rent` CLI subcommand](https://docs.solanalabs.com/cli/usage#solana-rent):
+[`solana rent` CLI subcommand](https://docs.anza.xyz/cli/usage#solana-rent):
 
 ```shell
 solana rent 15000
@@ -492,5 +492,5 @@ an "account not found" type of message, you may still be able to view
 transaction history associated with that account.
 
 You can read the validator
-[implemented proposal](https://docs.solanalabs.com/implemented-proposals/persistent-account-storage#garbage-collection)
+[implemented proposal](https://docs.anza.xyz/implemented-proposals/persistent-account-storage#garbage-collection)
 for garbage collection to learn more.

--- a/docs/core/tokens.md
+++ b/docs/core/tokens.md
@@ -244,8 +244,8 @@ what this account relationship looks like.
 
 ## Token Examples
 
-The [`spl-token` CLI](https://docs.solanalabs.com/cli) can be used to experiment
-with SPL tokens. In the examples below, we'll use the
+The [`spl-token` CLI](https://docs.anza.xyz/cli) can be used to experiment with
+SPL tokens. In the examples below, we'll use the
 [Solana Playground](https://beta.solpg.io/) terminal to run the CLI commands
 directly in the browser without having to install the CLI locally.
 

--- a/docs/economics/staking/index.md
+++ b/docs/economics/staking/index.md
@@ -8,7 +8,7 @@ terms with regards to balance of SOL. This document makes no suggestion as to
 the monetary value of SOL at any time._
 
 By staking your SOL tokens, you help secure the network and
-[earn rewards](https://docs.solanalabs.com/implemented-proposals/staking-rewards)
+[earn rewards](https://docs.anza.xyz/implemented-proposals/staking-rewards)
 while doing so.
 
 You can stake by delegating your tokens to validators who process transactions
@@ -41,7 +41,7 @@ participants.
 
 There is no in protocol implementation of slashing currently. For more
 information on slashing see the
-[slashing roadmap](https://docs.solanalabs.com/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
+[slashing roadmap](https://docs.anza.xyz/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
 
 ## How do I stake my SOL tokens?
 
@@ -58,7 +58,7 @@ your favorite wallet's maintainers regarding status
 - Solana command line tools can perform all stake operations in conjunction with
   a CLI-generated keypair file wallet, a paper wallet, or with a connected
   Ledger Nano.
-  [Staking commands using the Solana Command Line Tools](https://docs.solanalabs.com/cli/examples/delegate-stake).
+  [Staking commands using the Solana Command Line Tools](https://docs.anza.xyz/cli/examples/delegate-stake).
 
 #### Create a Stake Account
 

--- a/docs/economics/staking/stake-accounts.md
+++ b/docs/economics/staking/stake-accounts.md
@@ -24,7 +24,7 @@ necessarily have any control over the account. In fact, a keypair or private key
 may not even exist for a stake account's address.
 
 The only time a stake account's address has a keypair file is when
-[creating a stake account using the command line tools](https://docs.solanalabs.com/cli/examples/delegate-stake#create-a-stake-account).
+[creating a stake account using the command line tools](https://docs.anza.xyz/cli/examples/delegate-stake#create-a-stake-account).
 A new keypair file is created first only to ensure that the stake account's
 address is new and unique.
 
@@ -117,7 +117,7 @@ deactivated in a single epoch, to prevent large sudden changes in stake across
 the network as a whole. Since warmup and cooldown are dependent on the behavior
 of other network participants, their exact duration is difficult to predict.
 Details on the warmup and cooldown timing can be found
-[here](https://docs.solanalabs.com/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal).
+[here](https://docs.anza.xyz/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal).
 
 #### Lockups
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,8 @@ from other blockchains.
 Get to know the underlying architecture of how the proof-of-stake blockchain
 works.
 
-- [Validators](https://docs.solanalabs.com/validator/anatomy) - the individual
-  nodes that are the backbone of the network
+- [Validators](https://docs.anza.xyz/validator/anatomy) - the individual nodes
+  that are the backbone of the network
 - [Clusters](/docs/core/clusters) - a collection of validators that work
   together for consensus
 
@@ -58,11 +58,11 @@ works.
 
 Explore what it takes to operate a Solana validator and help secure the network.
 
-- [System Requirements](https://docs.solanalabs.com/operations/requirements) -
+- [System Requirements](https://docs.anza.xyz/operations/requirements) -
   Recommended hardware requirements and expected SOL needed to operate a
   validator
-- [Quick Start](https://docs.solanalabs.com/operations/setup-a-validator) -
-  Setup a validator and get connected to a cluster for the first time
+- [Quick Start](https://docs.anza.xyz/operations/setup-a-validator) - Setup a
+  validator and get connected to a cluster for the first time
 
 ## Why Solana?
 

--- a/docs/intro/dev.md
+++ b/docs/intro/dev.md
@@ -83,7 +83,7 @@ developers interact with the Solana network in most popular languages :
 
 You'll also need a connection with an RPC to interact with the network. You can
 either work with a [RPC infrastructure provider](https://solana.com/rpc) or
-[run your own RPC node](https://docs.solanalabs.com/operations/setup-an-rpc-node).
+[run your own RPC node](https://docs.anza.xyz/operations/setup-an-rpc-node).
 
 To quickly get started with a front-end for your application, you can generate a
 customizable Solana scaffold by typing the following into your CLI:

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -613,9 +613,9 @@ Alternatively, you can get devnet SOL using the
 ### Run Local Validator
 
 The Solana CLI comes with the
-[test validator](https://docs.solanalabs.com/cli/examples/test-validator)
-built-in. Running a local validator will allow you to deploy and test your
-programs locally.
+[test validator](https://docs.anza.xyz/cli/examples/test-validator) built-in.
+Running a local validator will allow you to deploy and test your programs
+locally.
 
 In a separate terminal, run the following command to start a local validator:
 

--- a/docs/intro/wallets.md
+++ b/docs/intro/wallets.md
@@ -64,6 +64,6 @@ that might be right for you on the [Solana Wallets](https://solana.com/wallets)
 page.
 
 For advanced users or developers, the
-[command-line wallets](https://docs.solanalabs.com/cli/wallets) may be more
+[command-line wallets](https://docs.anza.xyz/cli/wallets) may be more
 appropriate, as new features on the Solana blockchain will always be supported
 on the command line first before being integrated into third-party solutions.

--- a/docs/more/exchange.md
+++ b/docs/more/exchange.md
@@ -20,7 +20,7 @@ This setup enables you:
 
 Solana nodes demand relatively high computing power to handle our fast blocks
 and high TPS. For specific requirements, please see
-[hardware recommendations](https://docs.solanalabs.com/operations/requirements).
+[hardware recommendations](https://docs.anza.xyz/operations/requirements).
 
 To run an api node:
 
@@ -46,7 +46,7 @@ to the port you want to expose.
 
 The `--entrypoint` and `--expected-genesis-hash` parameters are all specific to
 the cluster you are joining.
-[Current parameters for Mainnet Beta](https://docs.solanalabs.com/clusters/available#example-solana-validator-command-line-2)
+[Current parameters for Mainnet Beta](https://docs.anza.xyz/clusters/available#example-solana-validator-command-line-2)
 
 The `--limit-ledger-size` parameter allows you to specify how many ledger
 [shreds](/docs/terminology.md#shred) your node retains on disk. If you do not
@@ -60,7 +60,7 @@ selecting a custom limit value is
 
 Specifying one or more `--known-validator` parameters can protect you from
 booting from a malicious snapshot.
-[More on the value of booting with known validators](https://docs.solanalabs.com/operations/guides/validator-start#known-validators)
+[More on the value of booting with known validators](https://docs.anza.xyz/operations/guides/validator-start#known-validators)
 
 Optional parameters to consider:
 
@@ -86,7 +86,7 @@ solana-watchtower --validator-identity <YOUR VALIDATOR IDENTITY>
 ```
 
 > You can find more information about the
-> [best practices for Solana Watchtower](https://docs.solanalabs.com/operations/best-practices/monitoring#solana-watchtower)
+> [best practices for Solana Watchtower](https://docs.anza.xyz/operations/best-practices/monitoring#solana-watchtower)
 > here in the docs.
 
 #### New Software Release Announcements
@@ -159,7 +159,7 @@ validators and only on the _Gossip_, _Repair_ and _ServeR_ ports.
 Solana accounts do not require any on-chain initialization; once they contain
 some SOL, they exist. To set up a deposit account for your exchange, simply
 generate a Solana keypair using any of our
-[wallet tools](https://docs.solanalabs.com/cli/wallets).
+[wallet tools](https://docs.anza.xyz/cli/wallets).
 
 We recommend using a unique deposit account for each of your users.
 
@@ -187,7 +187,7 @@ curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -
 
 You may wish to keep the keys for one or more collection accounts offline for
 greater security. If so, you will need to move SOL to hot accounts using our
-[offline methods](https://docs.solanalabs.com/cli/examples/offline-signing).
+[offline methods](https://docs.anza.xyz/cli/examples/offline-signing).
 
 ## Listening for Deposits
 

--- a/docs/programs/testing.md
+++ b/docs/programs/testing.md
@@ -13,7 +13,7 @@ using `solana-bankrun`.
 
 There are two ways to test programs on Solana:
 
-1. [solana-test-validator](https://docs.solanalabs.com/cli/examples/test-validator):
+1. [solana-test-validator](https://docs.anza.xyz/cli/examples/test-validator):
    That spins up a local emulator of the Solana Blockchain on your local machine
    which receives the transactions to be processed by the validator.
 2. The various

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -126,7 +126,7 @@ A gossip network connecting all [nodes](#node) of a [cluster](#cluster).
 Some number of [epochs](#epoch) after [stake](#stake) has been deactivated while
 it progressively becomes available for withdrawal. During this period, the stake
 is considered to be "deactivating". More info about:
-[warmup and cooldown](https://docs.solanalabs.com/implemented-proposals/staking-rewards#stake-warmup-cooldown-withdrawal)
+[warmup and cooldown](https://docs.anza.xyz/implemented-proposals/staking-rewards#stake-warmup-cooldown-withdrawal)
 
 ## credit
 
@@ -324,7 +324,7 @@ See [Proof of History](#proof-of-history-poh).
 ## point
 
 A weighted [credit](#credit) in a rewards regime. In the [validator](#validator)
-[rewards regime](https://docs.solanalabs.com/consensus/stake-delegation-and-rewards),
+[rewards regime](https://docs.anza.xyz/consensus/stake-delegation-and-rewards),
 the number of points owed to a [stake](#stake) during redemption is the product
 of the [vote credits](#vote-credit) earned and the number of lamports staked.
 
@@ -472,11 +472,10 @@ SWQoS allows
 
 ## sysvar
 
-A system [account](#account).
-[Sysvars](https://docs.solanalabs.com/runtime/sysvars) provide cluster state
-information such as current tick height, rewards [points](#point) values, etc.
-Programs can access Sysvars via a Sysvar account (pubkey) or by querying via a
-syscall.
+A system [account](#account). [Sysvars](https://docs.anza.xyz/runtime/sysvars)
+provide cluster state information such as current tick height, rewards
+[points](#point) values, etc. Programs can access Sysvars via a Sysvar account
+(pubkey) or by querying via a syscall.
 
 ## thin client
 
@@ -520,7 +519,7 @@ capabilities of transferring, freezing, and minting tokens.
 
 ## tpu
 
-[Transaction processing unit](https://docs.solanalabs.com/validator/tpu).
+[Transaction processing unit](https://docs.anza.xyz/validator/tpu).
 
 ## transaction
 
@@ -545,7 +544,7 @@ A set of [transactions](#transaction) that may be executed in parallel.
 
 ## tvu
 
-[Transaction validation unit](https://docs.solanalabs.com/validator/tvu).
+[Transaction validation unit](https://docs.anza.xyz/validator/tvu).
 
 ## validator
 
@@ -580,4 +579,4 @@ A collection of [keypairs](#keypair) that allows users to manage their funds.
 Some number of [epochs](#epoch) after [stake](#stake) has been delegated while
 it progressively becomes effective. During this period, the stake is considered
 to be "activating". More info about:
-[warmup and cooldown](https://docs.solanalabs.com/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal)
+[warmup and cooldown](https://docs.anza.xyz/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal)

--- a/next.config.js
+++ b/next.config.js
@@ -46,7 +46,7 @@ module.exports = withContentlayer({
       ...redirectFormatter("https://solana.com/", redirectsJson["common-docs"]),
       // validator client docs
       ...redirectFormatter(
-        "https://docs.solanalabs.com/",
+        "https://docs.anza.xyz/",
         redirectsJson["solana-client"],
       ),
     ];

--- a/next.config.js
+++ b/next.config.js
@@ -47,7 +47,7 @@ module.exports = withContentlayer({
       // validator client docs
       ...redirectFormatter(
         "https://docs.anza.xyz/",
-        redirectsJson["solana-client"],
+        redirectsJson["agave-client"],
       ),
     ];
   },

--- a/redirects.json
+++ b/redirects.json
@@ -193,7 +193,7 @@
     { "destination": "/docs/intro/wallets", "source": "/wallet-guide/:path" },
     { "destination": "/docs/intro", "source": "/introduction" }
   ],
-  "solana-client": [
+  "agave-client": [
     {
       "source": "/apps/sysvars",
       "destination": "/developing/runtime-facilities/sysvars"
@@ -276,6 +276,10 @@
 
     { "source": "/clusters", "destination": "/clusters" },
     { "source": "/cluster/overview", "destination": "/clusters" },
+    {
+      "source": "/cluster/economics",
+      "destination": "/implemented-proposals/ed_overview"
+    },
     { "source": "/cluster/bench-tps", "destination": "/clusters/benchmark" },
     {
       "source": "/cluster/performance-metrics",

--- a/src/components/HomeComponent.tsx
+++ b/src/components/HomeComponent.tsx
@@ -47,14 +47,14 @@ export const HomeViewComponent = () => {
           </p>
         </Link>
         <Link
-          href="https://docs.solanalabs.com/"
+          href="https://docs.anza.xyz/"
           className="card hover:border-gray-500"
         >
-          <h2>Solana Validator Client</h2>
+          <h2>Agave Validator Client</h2>
           <p>
             Read and explore the documentation for the Validator Client
-            originally developed by Solana Labs, including the Solana CLI
-            tool-suite and validator architecture.
+            originally developed by Anza, including the Solana CLI tool-suite
+            and validator architecture.
           </p>
         </Link>
         <Link
@@ -84,8 +84,8 @@ export const HomeViewComponent = () => {
             </Link>
           </li>
           <li className="">
-            <Link href="https://docs.solanalabs.com" className="">
-              docs.solanalabs.com
+            <Link href="https://docs.anza.xyz" className="">
+              docs.anza.xyz
             </Link>
           </li>
         </ul>
@@ -109,10 +109,10 @@ export const HomeViewComponent = () => {
         </p>
 
         <p className="!text-white">
-          The documentation for the original Solana Validator Client developed
-          by Solana Labs can now be found on{" "}
-          <Link href="https://docs.solanalabs.com" className="">
-            docs.solanalabs.com
+          The documentation for the original Agave Validator Client, developed
+          by Anza can now be found on{" "}
+          <Link href="https://docs.anza.xyz" className="">
+            docs.anza.xyz
           </Link>
           , which contains all the information specific to that validator
           client&apos;s implementation and inner workings. Including{" "}
@@ -120,13 +120,11 @@ export const HomeViewComponent = () => {
             installing the Solana CLI tool-suite
           </Link>
           , this{" "}
-          <Link href={"https://docs.solanalabs.com/architecture"}>
+          <Link href={"https://docs.anza.xyz/architecture"}>
             validator&apos;s architecture
           </Link>
           , and{" "}
-          <Link
-            href={"https://docs.solanalabs.com/operations/setup-a-validator"}
-          >
+          <Link href={"https://docs.anza.xyz/operations/setup-a-validator"}>
             how to operate a validator
           </Link>
           .


### PR DESCRIPTION
### Problem

The old Solana Labs docs site has been shutdown. The Agave validator client docs are now on the Anza docs domains

### Summary of Changes

- updated references to the SolanaLabs docs site in favor of Anza's
- minor updates to bits of copy
- added a missing redirect that was found: `/cluster/economics`