### PR TITLE
fix typo in program-derived-address.md

### DIFF
--- a/docs/intro/quick-start/program-derived-address.md
+++ b/docs/intro/quick-start/program-derived-address.md
@@ -473,7 +473,7 @@ The `Update` struct defines the accounts required for the `update` instruction.
 ---
 
 Note that the `bump = message_account.bump` constraint uses the bump seed stored
-on the `mesesage_account`, rather than having Anchor recalculate it.
+on the `message_account`, rather than having Anchor recalculate it.
 
 ---
 


### PR DESCRIPTION
Just fixed a small typo.