### PR TITLE
fix: correct slight mixup of transfer fee and default acc state ext

### DIFF
--- a/content/courses/token-extensions/default-account-state.md
+++ b/content/courses/token-extensions/default-account-state.md
@@ -66,10 +66,10 @@ is `Initialized`.
 
 ### Adding default account state
 
-Initializing a mint with transfer fee involves three instructions:
+Initializing a mint with the default account state extension involves three instructions:
 
 - `SystemProgram.createAccount`
-- `createInitializeTransferFeeConfigInstruction`
+- `createInitializeDefaultAccountStateInstruction`
 - `createInitializeMintInstruction`
 
 The first instruction `SystemProgram.createAccount` allocates space on the


### PR DESCRIPTION
### Problem
remove transfer fee mention mentioned in default account state extension


### Summary of Changes
update to correct extension being thought. 

 