### PR TITLE
fix: docs #create-token-acc

### DIFF
--- a/docs/core/tokens.md
+++ b/docs/core/tokens.md
@@ -386,7 +386,7 @@ Signature: 44vqKdfzspT592REDPY4goaRJH3uJ3Ce13G4BCuUHg35dVUbHuGTHvqn4ZjYF9BGe9Qrj
 
 Under the hood, creating an Associated Token Account requires a single
 instruction that invokes the
-[Associated Token Program](https://github.com/solana-labs/solana-program-library/tree/b1c44c171bc95e6ee74af12365cb9cbab68be76c/associated-token-account/program/src).
+[Token Program](https://github.com/solana-labs/solana-program-library/tree/b1c44c171bc95e6ee74af12365cb9cbab68be76c/token/program).
 Here is a Javascript example on
 [Solana Playground](https://beta.solpg.io/660ce868cffcf4b13384d011).
 


### PR DESCRIPTION
### Problem
Wrong statement:
<img width="931" alt="Screenshot 2024-12-20 at 1 51 42 AM" src="https://github.com/user-attachments/assets/d8ecfea6-5268-4245-871c-9ea1ddf4c621" />


### Summary of Changes
Just replaced "Associated Token Program" with appropriate one "Token Program" and also updated link that it's pointing to (href in <a href="...">) 


Fixes #
<img width="886" alt="Screenshot 2024-12-20 at 2 11 18 AM" src="https://github.com/user-attachments/assets/1a7b04c7-fe87-46dc-8dde-fa541292b058" />

