### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -168,7 +168,7 @@ const basicContentFields: FieldDefs = {
 /**
  * Standard computed fields for all records
  *
- * note: changing these may warrant an update the the hacky custom `ComputedFieldsTypeHack` type
+ * note: changing these may warrant an update the hacky custom `ComputedFieldsTypeHack` type
  */
 const standardComputedFields: ComputedFields = {
   locale: {

--- a/docs/economics/inflation/_adjusted_staking_yield.md
+++ b/docs/economics/inflation/_adjusted_staking_yield.md
@@ -23,7 +23,7 @@ fraction of staked supply grow as shown below.
 ![Graph of example growth of staked supply](/assets/docs/economics/example_staked_supply_w_range_initial_stake.png)
 
 Due to this relative change in representation, the proportion of stake of any
-token holder will also change as a function of the _Inflation Schedule_ and the
+token holders will also change as a function of the _Inflation Schedule_ and the
 proportion of all tokens that are staked.
 
 Of initial interest, however, is the _dilution of **un-staked** tokens_, or
@@ -165,6 +165,6 @@ relative dilution of un-staked tokens grows dramatically. E.g. with $80\%$ of
 the network tokens staked, an un-staked token holder will experience ~$400\%$
 more dilution than a staked holder.
 
-Again, this represents the change in fractional change in ownership of staked
+Again, this represents the fractional change in ownership of staked
 tokens and illustrates the built-in incentive for token holder to stake their
 tokens to earn _Staked Yield_ and avoid _Un-staked Dilution_.

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -548,7 +548,7 @@ Generating a new keypair
 
 For added security, enter a BIP39 passphrase
 
-NOTE! This passphrase improves security of the recovery seed phrae NOT the
+NOTE! This passphrase improves security of the recovery seed phrase NOT the
 keypair file itself, which is stored as insecure plain text
 
 BIP39 Passphrase (empty for none):


### PR DESCRIPTION


This PR fixes several typos and grammatical issues across the documentation to improve readability and accuracy.

## Changes

### docs/economics/inflation/_adjusted_staking_yield.md
- Fixed: "token holder" -> "token holders"
- Reason: Corrected plural form for consistency with the subject

### docs/economics/inflation/_adjusted_staking_yield.md
- Fixed: "change in fractional change" -> "fractional change"
- Reason: Removed redundant wording to improve clarity

### docs/intro/installation.md
- Fixed: "seed phrae" -> "seed phrase"
- Reason: Corrected spelling of critical security terminology

### contentlayer.config.ts
- Fixed: "update the the" -> "update the"
- Reason: Removed duplicate word
