### PR TITLE
fix: Command comment error

### DIFF
--- a/content/guides/getstarted/how-to-cpi.md
+++ b/content/guides/getstarted/how-to-cpi.md
@@ -257,5 +257,5 @@ When building an instruction in Rust, use the following syntax to specify the
 AccountMeta::new(account1_pubkey, true),           // writable, signer
 AccountMeta::new(account2_pubkey, false),          // writable, not signer
 AccountMeta::new_readonly(account3_pubkey, false), // not writable, not signer
-AccountMeta::new_readonly(account4_pubkey, true),  // writable, signer
+AccountMeta::new_readonly(account4_pubkey, true),  // not writable, signer
 ```


### PR DESCRIPTION
Update how-to-cpi.md

```
AccountMeta::new_readonly(account4_pubkey, true),  // writable, signer
```
to
```
AccountMeta::new_readonly(account4_pubkey, true),  // not writable, signer
```


